### PR TITLE
Bugfix: createdAt changes when updating application with PUT

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,7 +96,7 @@ model Role {
 
 model AppApplication {
   createdby                                                       String                     @db.VarChar(200)
-  createdat                                                       DateTime                   @updatedAt
+  createdat                                                       DateTime                   @default(now())
   updatedby                                                       String                     @db.VarChar(200)
   updatedat                                                       DateTime                   @updatedAt
   comments                                                        String?

--- a/src/applications/applications.service.ts
+++ b/src/applications/applications.service.ts
@@ -1,4 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { excludes } from './../utilities/index';
+import { Organisation } from './../organisations/entities/organisation.entity';
+import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { Prisma } from '@prisma/client';
 import { CreateApplicationDto } from './dto/create-application.dto';
@@ -10,6 +12,7 @@ import { InstancesService } from '../instances/instances.service';
 import { CompliancesService } from '../compliances/compliances.service';
 import { EnvironmentVariablesService } from '../environment-variables/environment-variables.service';
 import map from 'lodash/map';
+import _ from 'lodash';
 
 @Injectable()
 export class ApplicationsService {
@@ -21,12 +24,11 @@ export class ApplicationsService {
     private readonly env: EnvironmentVariablesService,
   ) {}
 
-  async getAllBy(
+  public async getAllBy(
     filters: Partial<{
       searchQuery?: string;
       currentPage: number;
       maxPerPage: number;
-      // orderBy: Prisma.AppApplicationOrderByWithRelationAndSearchRelevanceInput;
       id: string;
       parentId: string;
       nom: string;
@@ -39,84 +41,15 @@ export class ApplicationsService {
     const pageNumber = Math.max(filters.currentPage ?? 1, 1);
     const skip = (pageNumber - 1) * maxPerPage;
 
-    const where: Prisma.AppApplicationWhereInput = {
-      OR: [
-        filters.id ? { id: filters.id } : undefined,
-        filters.parentId ? { parentid: filters.parentId } : undefined,
-        filters.nom
-          ? {
-              OR: [
-                { longname: { contains: filters.nom, mode: 'insensitive' } },
-                {
-                  orgOrganisationunit: {
-                    label: { contains: filters.nom, mode: 'insensitive' },
-                  },
-                },
-              ],
-            }
-          : undefined,
-        filters.searchQuery
-          ? {
-              OR: [
-                {
-                  longname: {
-                    contains: filters.searchQuery,
-                    mode: 'insensitive',
-                  },
-                },
-                {
-                  description: {
-                    contains: filters.searchQuery,
-                    mode: 'insensitive',
-                  },
-                },
-                {
-                  orgOrganisationunit: {
-                    label: {
-                      contains: filters.searchQuery,
-                      mode: 'insensitive',
-                    },
-                  },
-                },
-              ],
-            }
-          : undefined,
-        filters.statut ? { status: filters.statut } : undefined,
-        filters.sensibilite ? { sensitivity: filters.sensibilite } : undefined,
-      ].filter(Boolean) as Prisma.AppApplicationWhereInput[], // Remove undefined values
-    };
-
-    if (filters.parentOnly) {
-      where.parentid = { not: null };
-    }
-
-    if (where.OR?.length === 0) delete where.OR;
+    const where: Prisma.AppApplicationWhereInput =
+      this.buildWhereClause(filters);
 
     const [count, applications] = await this.prisma.$transaction([
       this.prisma.appApplication.count({ where }),
       this.prisma.appApplication.findMany({
-        include: {
-          refSensitivity: true,
-          fctUrbanzoneapplication: true,
-          appCompliance: true,
-          appApplicationid: true,
-          prjApplicationrole: {
-            include: {
-              orgRoletype: true,
-            },
-          },
-          appInstance: {
-            include: {
-              appInstancestatus: true,
-            },
-          },
-          appStatus: true,
-          orgOrganisationunit: true,
-          appApplication: true,
-        },
+        include: this.getApplicationIncludes(),
         skip,
         take: maxPerPage,
-        // orderBy: filters.orderBy,
         where,
       }),
     ]);
@@ -132,145 +65,111 @@ export class ApplicationsService {
     };
   }
 
-  async getOneById(appId: string): Promise<Application | null> {
+  public async getOneById(appId: string): Promise<Application | null> {
     return await this.prisma.appApplication.findFirst({
-      include: {
-        fctUrbanzoneapplication: true,
-        refSensitivity: true,
-        appCompliance: true,
-        appApplicationid: true,
-        prjApplicationrole: {
-          include: {
-            orgRoletype: true,
-          },
-        },
-        appInstance: {
-          include: {
-            appInstancestatus: true,
-          },
-        },
-        appStatus: true,
-        orgOrganisationunit: true,
-        appApplication: true,
-      },
-      where: {
-        applicationid: appId,
-      },
+      include: this.getApplicationIncludes(),
+      where: { applicationid: appId },
     });
   }
 
-  async getOneByNameAndOrgnisation(
+  public async getOneByNameAndOrgnisation(
     appName: string,
     organisationCode?: string,
     organisationId?: string,
   ): Promise<Application | null> {
     return this.prisma.appApplication.findFirst({
-      include: {
-        appCompliance: true,
-        appApplicationid: true,
-        prjApplicationrole: {
-          include: {
-            orgRoletype: true,
-          },
-        },
-        appInstance: {
-          include: {
-            appInstancestatus: true,
-          },
-        },
-      },
+      include: this.getApplicationIncludes(),
       where: {
-        longname: {
-          equals: appName,
-          mode: 'insensitive',
-        },
+        longname: { equals: appName, mode: 'insensitive' },
         OR: [
           { organisationunitid: organisationId },
-          {
-            orgOrganisationunit: {
-              organisationcode: organisationCode,
-            },
-          },
+          { orgOrganisationunit: { organisationcode: organisationCode } },
         ],
       },
     });
   }
 
-  async updateOrCreate(
+  public async createApplication(
     username: string,
-    inputData: CreateApplicationDto | UpdateApplicationDto,
-    isCreating: boolean,
-    application?: Application | string | null,
+    inputData: CreateApplicationDto,
   ): Promise<Application | string> {
-    //Updating
-    if (typeof application === 'string') {
-      application = await this.getOneById(application);
+    const validation = await this.validateApplicationData(inputData);
+    if (typeof validation === 'string') return validation;
+
+    return this.saveApplicationData(username, inputData, validation, null);
+  }
+
+  public async updateApplication(
+    username: string,
+    applicationId: string,
+    inputData: UpdateApplicationDto,
+  ): Promise<Application | string> {
+    const application = await this.getOneById(applicationId);
+    if (!application)
+      return `Application with ID ${applicationId} does not exist`;
+
+    const validation = await this.validateApplicationData(
+      inputData,
+      application,
+    );
+    if (typeof validation === 'string') return validation;
+
+    return this.saveApplicationData(
+      username,
+      inputData,
+      validation,
+      application,
+    );
+  }
+
+  private async validateApplicationData(
+    inputData: CreateApplicationDto | UpdateApplicationDto,
+    application?: Application,
+  ) {
+
+    const sanitizedUpdateDto = _.omit(UpdateApplicationDto, 'createdAt');
+
+    if (inputData.parent && inputData.parent === application?.applicationid) {
+      return `Une application ne peut pas être son propre parent.`;
     }
 
-    let parent = null;
-
     if (inputData.parent) {
-      parent = await this.prisma.appApplication.findFirst({
-        where: {
-          applicationid: inputData.parent,
-        },
-      });
-
+      const parent = await this.findFirstParent(inputData.parent);
       if (!parent) {
         return `L'application parent avec l'ID: ${inputData.parent} n'existe pas`;
       }
     }
 
-    const appType = await this.prisma.appType.findFirst({
-      where: {
-        applicationtypecode: {
-          startsWith: inputData.typeApplication ?? parent?.apptype ?? 'SVBUS',
-          mode: 'insensitive',
-        },
-      },
-    });
+    const appType = await this.findFirstAppType(inputData.typeApplication);
+    if (!appType) return `AppType ${inputData.typeApplication} n'existe pas`;
 
-    if (!appType) {
-      return `AppType ${inputData.typeApplication} n'existe pas`;
-    }
-
-    const orginisation = await this.prisma.orgOrganisationunit.findFirst({
-      where: {
-        OR: [
-          { organisationunitid: inputData.organisationid },
-          {
-            organisationcode: {
-              startsWith: inputData.organisation,
-              mode: 'insensitive',
-            },
-          },
-        ],
-      },
-    });
-
-    if (!orginisation) {
+    const organisation = await this.findFirstOrganisation(
+      inputData.organisationid,
+      inputData.organisation,
+    );
+    if (!organisation)
       return `Le code de l'organisation ${inputData.organisation} n'existe pas`;
-    }
 
     const sensitivity = await this.prisma.refSensitivity.findFirst({
-      where: {
-        sensitivitycode: inputData.sensibilite,
-      },
+      where: { sensitivitycode: inputData.sensibilite },
     });
-
-    if (!sensitivity) {
-      return `Sensibilite ${inputData.sensibilite} n'existe pas`;
-    }
+    if (!sensitivity)
+      return `Sensibilité ${inputData.sensibilite} n'existe pas`;
 
     const status = await this.prisma.appStatus.findFirst({
-      where: {
-        applicationstatuscode: inputData.statut,
-      },
+      where: { applicationstatuscode: inputData.statut },
     });
+    if (!status) return `Le statut ${inputData.statut} n'existe pas`;
 
-    if (!status) {
-      return `Le statut ${inputData.statut} n'existe pas`;
-    }
+    return { appType, organisation, sanitizedUpdateDto, sensitivity, status };
+  }
+
+  private async saveApplicationData(
+    username: string,
+    inputData: CreateApplicationDto | UpdateApplicationDto,
+    validationData: any,
+    application: Application | null,
+  ) {
 
     const input = {
       updatedby: username,
@@ -278,53 +177,77 @@ export class ApplicationsService {
       description: inputData.description ?? application?.description,
       appApplication: {
         connect: inputData.parent
-          ? {
-              applicationid: inputData.parent ?? application?.parentid,
-            }
+          ? { applicationid: inputData.parent ?? application?.parentid }
           : undefined,
       },
       appType: {
         connect: {
-          applicationtypecode:
-            appType.applicationtypecode ?? application?.apptype,
+          applicationtypecode: validationData.appType.applicationtypecode,
         },
       },
       orgOrganisationunit: {
         connect: {
           organisationunitid:
-            orginisation.organisationunitid ?? application?.organisationunitid,
+            validationData.organisation.organisationunitid ??
+            application?.organisationunitid,
         },
       },
       refSensitivity: {
         connect: {
-          sensitivitycode:
-            sensitivity.sensitivitycode ?? application?.sensitivity,
+          sensitivitycode: validationData.sensitivity.sensitivitycode,
         },
       },
       appStatus: {
         connect: {
-          applicationstatuscode:
-            status.applicationstatuscode ?? application?.status,
+          applicationstatuscode: validationData.status.applicationstatuscode,
         },
       },
     };
 
+
     application = await this.prisma.appApplication.upsert({
       where: {
         applicationid:
-          //Prisma limitation , we have to provide a unique key
           application?.applicationid ?? '00000000-0000-0000-0000-000000000000',
       },
       create: {
         ...input,
-        ...{
-          createdby: username,
-        },
+        createdby: username,
       },
       update: input,
     });
 
-    for (const role of inputData.acteurRoles ?? []) {
+    // Gestion des entités liées (roles, instances, conformités, etc.)
+    await this.handleRelatedEntities(username, application, inputData);
+
+    const app = await this.getOneById(application.applicationid);
+    if (inputData.sensibilite) {
+      await this.propagateSensitivity(
+        app!.applicationid,
+        inputData.sensibilite,
+      );
+    }
+
+    return app as Application;
+  }
+
+  private async handleRelatedEntities(
+    username: string,
+    application: Application,
+    inputData: CreateApplicationDto | UpdateApplicationDto,
+  ) {
+    await this.handleRoles(username, application, inputData.acteurRoles);
+    await this.handleInstances(username, application, inputData.instances);
+    await this.handleCompliances(username, application, inputData.conformite);
+    await this.handleCodes(username, application, inputData.codeApplication);
+  }
+
+  private async handleRoles(
+    username: string,
+    application: Application,
+    roles?: any[],
+  ) {
+    for (const role of roles ?? []) {
       const res = await this.rolesService.updateOrCreateApplicationRoleByAppId(
         username,
         application.applicationid,
@@ -334,43 +257,51 @@ export class ApplicationsService {
         },
         role.organisation?.organisationcode,
       );
-      //excpetion thrown
-      if (typeof res === 'string') return res;
+      if (typeof res === 'string') throw new Error(res);
     }
+  }
 
-    for (const instance of inputData.instances ?? []) {
-      const instanceRes = await this.instancesService.create(
+  private async handleInstances(
+    username: string,
+    application: Application,
+    instances?: any[],
+  ) {
+    for (const instance of instances ?? []) {
+      const res = await this.instancesService.create(
         username,
         application.applicationid,
         application.organisationunitid,
         instance,
       );
-      //excpetion thrown
-      if (typeof instanceRes === 'string') return instanceRes;
+      if (typeof res === 'string') throw new Error(res);
     }
+  }
 
-    for (const compliance of inputData.conformite ?? []) {
+  private async handleCompliances(
+    username: string,
+    application: Application,
+    conformites?: any[],
+  ) {
+    for (const compliance of conformites ?? []) {
       await this.compliancesService.updateOrCreateCompliancesServiceByAppId(
         username,
         application.applicationid,
         compliance,
       );
     }
+  }
 
-    //TODO: Refactor
-    if (inputData.codeApplication) {
-      for (const typeCode of inputData.codeApplication) {
-        //FIXME: is it should be this way?
-
+  private async handleCodes(
+    username: string,
+    application: Application,
+    codeApplications?: any[],
+  ) {
+    if (codeApplications) {
+      for (const typeCode of codeApplications) {
         await this.prisma.$transaction([
           this.prisma.appIdtype.upsert({
-            where: {
-              applicationidtypecode: typeCode.typeCode,
-            },
-            create: {
-              applicationidtypecode: typeCode.typeCode,
-              label: '',
-            },
+            where: { applicationidtypecode: typeCode.typeCode },
+            create: { applicationidtypecode: typeCode.typeCode, label: '' },
             update: {},
           }),
           this.prisma.appApplicationid.upsert({
@@ -405,76 +336,153 @@ export class ApplicationsService {
       await this.prisma.appApplicationid.deleteMany({
         where: {
           NOT: {
-            applicationidtypecode: {
-              in: map(inputData.codeApplication, 'typeCode'),
-            },
-            shortcode: {
-              in: map(inputData.codeApplication, 'codeCourt'),
-            },
+            applicationidtypecode: { in: map(codeApplications, 'typeCode') },
+            shortcode: { in: map(codeApplications, 'codeCourt') },
           },
-          AND: {
-            applicationid: application.applicationid,
-          },
+          AND: { applicationid: application.applicationid },
         },
       });
     }
-
-    const app = await this.prisma.appApplication.findUnique({
-      include: {
-        orgOrganisationunit: true,
-        appApplicationid: true,
-        appCompliance: true,
-        prjApplicationrole: {
-          include: {
-            orgRoletype: true,
-          },
-        },
-        appInstance: {
-          include: {
-            appInstancestatus: true,
-          },
-        },
-      },
-      where: {
-        applicationid: application.applicationid,
-      },
-    });
-
-    if (inputData.sensibilite) {
-      await this.propagateSensitivity(
-        app!.applicationid,
-        inputData.sensibilite,
-      );
-    }
-    return app as Application;
   }
 
   private async propagateSensitivity(appId: string, sensitivity: string) {
     const sensitivityLevel = +sensitivity[1];
+    const children = await this.prisma.appApplication.findMany({
+      where: { parentid: appId },
+    });
 
-    const childern =
-      (await this.prisma.appApplication.findMany({
-        where: {
-          parentid: appId,
-        },
-      })) ?? [];
-
-    for (const child of childern) {
+    for (const child of children) {
       const childSensitivityLevel = +child.sensitivity[1];
-
       if (sensitivityLevel > childSensitivityLevel) {
         await this.prisma.appApplication.update({
-          where: {
-            applicationid: child.applicationid,
-          },
-          data: {
-            sensitivity: sensitivity,
-          },
+          where: { applicationid: child.applicationid },
+          data: { sensitivity: sensitivity },
         });
-
-        //recursively update children
         await this.propagateSensitivity(child.applicationid, sensitivity);
       }
     }
+  }
+
+  private async findFirstParent(parentId: string | undefined) {
+    if (!parentId) {
+      return null; // Retourne null si parentId est undefined ou null
+    }
+
+    return await this.prisma.appApplication.findFirst({
+      where: {
+        applicationid: parentId,
+      },
+    });
+  }
+  private async findFirstAppType(typeApplication = 'SVBUS'): Promise<{
+    applicationtypecode: string;
+    label: string;
+  } | null> {
+    return await this.prisma.appType.findFirst({
+      where: {
+        applicationtypecode: {
+          startsWith: typeApplication,
+          mode: 'insensitive',
+        },
+      },
+    });
+  }
+
+  private async findFirstOrganisation(
+    organisationId: string | undefined,
+    organisation: string | undefined,
+  ): Promise<Organisation | null> {
+    return await this.prisma.orgOrganisationunit.findFirst({
+      where: {
+        OR: [
+          { organisationunitid: organisationId },
+          {
+            organisationcode: {
+              startsWith: organisation,
+              mode: 'insensitive',
+            },
+          },
+        ],
+      },
+    });
+  }
+
+  private buildWhereClause(filters: any): Prisma.AppApplicationWhereInput {
+    const orConditions: Prisma.AppApplicationWhereInput[] = [];
+
+    if (filters.id) {
+      orConditions.push({ applicationid: filters.id });
+    }
+
+    if (filters.parentId) {
+      orConditions.push({ parentid: filters.parentId });
+    }
+
+    if (filters.nom) {
+      orConditions.push({
+        OR: [
+          { longname: { contains: filters.nom, mode: 'insensitive' } },
+          {
+            orgOrganisationunit: {
+              label: { contains: filters.nom, mode: 'insensitive' },
+            },
+          },
+        ],
+      });
+    }
+
+    if (filters.searchQuery) {
+      orConditions.push({
+        OR: [
+          { longname: { contains: filters.searchQuery, mode: 'insensitive' } },
+          {
+            description: { contains: filters.searchQuery, mode: 'insensitive' },
+          },
+          {
+            orgOrganisationunit: {
+              label: { contains: filters.searchQuery, mode: 'insensitive' },
+            },
+          },
+        ],
+      });
+    }
+
+    if (filters.statut) {
+      orConditions.push({ status: filters.statut });
+    }
+
+    if (filters.sensibilite) {
+      orConditions.push({ sensitivity: filters.sensibilite });
+    }
+
+    const where: Prisma.AppApplicationWhereInput = {};
+
+    if (orConditions.length > 0) {
+      where.OR = orConditions;
+    }
+
+    if (filters.parentOnly) {
+      where.parentid = { not: null };
+    }
+
+    return where;
+  }
+
+  private getApplicationIncludes() {
+    return {
+      refSensitivity: true,
+      fctUrbanzoneapplication: true,
+      appCompliance: true,
+      appApplicationid: true,
+      prjApplicationrole: {
+        include: { orgRoletype: true },
+      },
+      appInstance: {
+        include: { appInstancestatus: true },
+      },
+      appStatus: true,
+      orgOrganisationunit: true,
+      appApplication: true,
+    };
   }
 }


### PR DESCRIPTION
# Optimiser le code et corriger les bugs 
## 1. **Exclure `createdAt` lors des mises à jour**
   - [x] Assurer que `createdAt` ne se met pas à jour lors d'un update d'une application
   - [x] Nettoyer `updateApplicationDto` dans le contrôleur en utilisant `_.omit` pour exclure `createdAt`.
   - [ ] Corriger le schema prisma de application pour createdAt

## 2. **Vérifier et Valider les Données d'Entrée**
   - [x] Vérifier que l'application ne peut pas être son propre parent dans `validateApplicationData`.
   - [x] Vérifier que `parent` est optionnel et ne pas retourner d'erreur si `parent` est `undefined` ou `null`.
   - [x] S'assurer que toutes les autres validations (`appType`, `organisation`, `sensitivity`, `status`) sont effectuées correctement.
