### PR TITLE
feat: :memo: Add params in swagger for searchapplications

### DIFF
--- a/client/src/views/GlobalSearch.vue
+++ b/client/src/views/GlobalSearch.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
-import ExportApplications from "@/components/ExportApplications.vue";
 import SearchApplications from "@/components/SearchApplications.vue";
 </script>
 
 <template>
   <div>
     <h2>Rechercher une Application</h2>
-    <ExportApplications />
     <SearchApplications />
   </div>
 </template>

--- a/server/src/application/application.controller.ts
+++ b/server/src/application/application.controller.ts
@@ -17,7 +17,12 @@ import {
 import { ApplicationService } from './application.service';
 import { CreateApplicationDto } from './dto/create-application.dto';
 import { UpdateApplicationDto } from './dto/update-application.dto';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiExcludeEndpoint,
+} from '@nestjs/swagger';
 import { SearchApplicationDto } from './dto/search-application.dto';
 import { GetApplicationDto } from './dto/get-application.dto';
 import { ExportService } from './export.service';
@@ -60,14 +65,21 @@ export class ApplicationController {
   }
 
   @Get('search')
-  async searchApplications(@Query() query: SearchApplicationDto) {
-    return await this.applicationService.searchApplications(query);
+  @ApiOperation({ summary: 'Rechercher des applications' })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Liste des applications correspondant aux critères de recherche.',
+  })
+  async searchApplications(@Query() searchParams: SearchApplicationDto) {
+    return await this.applicationService.searchApplications(searchParams);
   }
 
   @Get('export')
   @ApiOperation({ summary: 'Exporter les applications' })
   @ApiResponse({ status: 200, description: 'Export réalisé avec succès.' })
   @ApiResponse({ status: 400, description: "Erreur lors de l'exportation." })
+  @ApiExcludeEndpoint()
   async exportApplications(
     @Query() query: SearchApplicationDto,
     @Response() res,

--- a/server/src/application/application.service.ts
+++ b/server/src/application/application.service.ts
@@ -89,7 +89,7 @@ export class ApplicationService {
   }
 
   public async searchApplications(searchParams: SearchApplicationDto) {
-    const { label } = searchParams;
+    const { label, page = 1, limit = 12 } = searchParams;
 
     const whereClause: Prisma.ApplicationWhereInput = {
       ...(label
@@ -109,11 +109,14 @@ export class ApplicationService {
         },
       };
 
+    const skip = (page - 1) * limit;
+
     try {
       const applications = await this.prisma.application.findMany({
         where: whereClause,
         orderBy: orderByClause,
-        take: 12,
+        take: limit,
+        skip: skip,
         include: {
           lifecycle: true,
           actors: true,

--- a/server/src/application/dto/search-application.dto.ts
+++ b/server/src/application/dto/search-application.dto.ts
@@ -1,7 +1,35 @@
-import { IsOptional, IsString } from 'class-validator';
+// src/application/dto/search-application.dto.ts
+
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNumber, IsOptional, IsString, Min } from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class SearchApplicationDto {
+  @ApiPropertyOptional({
+    description: "Filtrer par label de l'application",
+    example: 'Mon Application',
+  })
   @IsOptional()
   @IsString()
   label?: string;
+
+  @ApiPropertyOptional({
+    description: 'Numéro de la page pour la pagination',
+    example: 1,
+  })
+  @IsOptional()
+  @Type(() => Number) // Transformation en nombre
+  @IsNumber({}, { message: 'Le champ page doit être un nombre valide.' })
+  @Min(1, { message: 'Le champ page doit être au moins 1.' })
+  page?: number;
+
+  @ApiPropertyOptional({
+    description: "Nombre d'éléments par page",
+    example: 12,
+  })
+  @IsOptional()
+  @Type(() => Number) // Transformation en nombre
+  @IsNumber({}, { message: 'Le champ limit doit être un nombre valide.' })
+  @Min(1, { message: 'Le champ limit doit être au moins 1.' })
+  limit?: number;
 }


### PR DESCRIPTION
- **Rendu le champ label optionnel** dans le SearchApplicationDto pour permettre des valeurs vides.
- **Modifié la méthode searchApplications** du service pour utiliser dynamiquement le paramètre limit au lieu d’une valeur fixe.
- **Amélioré la documentation Swagger** en utilisant @ApiPropertyOptional pour les champs optionnels et en ajoutant des descriptions détaillées.
- **Ajouté la gestion des réponses d’erreur** dans le contrôleur pour mieux documenter les cas d’échec.