### PR TITLE
feat(api): :sparkles: add endpoint to delete application

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "conventionalCommits.scopes": ["applications"]
+  "conventionalCommits.scopes": ["applications", "api"]
 }

--- a/backend/prisma/migrations/20250402081911_add_delete_on_cascade_for_application/migration.sql
+++ b/backend/prisma/migrations/20250402081911_add_delete_on_cascade_for_application/migration.sql
@@ -1,0 +1,53 @@
+-- DropForeignKey
+ALTER TABLE "ExternalRessource" DROP CONSTRAINT "ExternalRessource_applicationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Hosting" DROP CONSTRAINT "Hosting_applicationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "actors" DROP CONSTRAINT "actors_applicationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "anomalyNotification" DROP CONSTRAINT "anomalyNotification_applicationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "compliances" DROP CONSTRAINT "compliances_applicationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "events" DROP CONSTRAINT "events_applicationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "labels" DROP CONSTRAINT "labels_applicationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "relations" DROP CONSTRAINT "relations_applicationSource_fkey";
+
+-- DropForeignKey
+ALTER TABLE "relations" DROP CONSTRAINT "relations_applicationTarget_fkey";
+
+-- AddForeignKey
+ALTER TABLE "anomalyNotification" ADD CONSTRAINT "anomalyNotification_applicationId_fkey" FOREIGN KEY ("applicationId") REFERENCES "applications"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "relations" ADD CONSTRAINT "relations_applicationSource_fkey" FOREIGN KEY ("applicationSource") REFERENCES "applications"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "relations" ADD CONSTRAINT "relations_applicationTarget_fkey" FOREIGN KEY ("applicationTarget") REFERENCES "applications"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "compliances" ADD CONSTRAINT "compliances_applicationId_fkey" FOREIGN KEY ("applicationId") REFERENCES "applications"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "events" ADD CONSTRAINT "events_applicationId_fkey" FOREIGN KEY ("applicationId") REFERENCES "applications"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ExternalRessource" ADD CONSTRAINT "ExternalRessource_applicationId_fkey" FOREIGN KEY ("applicationId") REFERENCES "applications"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Hosting" ADD CONSTRAINT "Hosting_applicationId_fkey" FOREIGN KEY ("applicationId") REFERENCES "applications"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "labels" ADD CONSTRAINT "labels_applicationId_fkey" FOREIGN KEY ("applicationId") REFERENCES "applications"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "actors" ADD CONSTRAINT "actors_applicationId_fkey" FOREIGN KEY ("applicationId") REFERENCES "applications"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema/anomaly.prisma
+++ b/backend/prisma/schema/anomaly.prisma
@@ -9,7 +9,7 @@ model AnomalyNotification {
   updatedAt     DateTime                  @updatedAt
 
   history     AnomalyNotificationHistory[]
-  application Application?                 @relation("ApplicationAnomalyNotification", fields: [applicationId], references: [id])
+  application Application? @relation("ApplicationAnomalyNotification", fields: [applicationId], references: [id], onDelete: Cascade)
 
   @@map("anomalyNotification")
 }

--- a/backend/prisma/schema/applications.prisma
+++ b/backend/prisma/schema/applications.prisma
@@ -38,8 +38,8 @@ model Relation {
   type              RelationType
   applicationSource String
   applicationTarget String
-  sourceApplication Application     @relation("SourceHasTarget", fields: [applicationSource], references: [id])
-  targetApplication Application     @relation("TargetHasSource", fields: [applicationTarget], references: [id])
+  sourceApplication Application @relation("SourceHasTarget", fields: [applicationSource], references: [id], onDelete: Cascade)
+  targetApplication Application @relation("TargetHasSource", fields: [applicationTarget], references: [id], onDelete: Cascade)
 
   @@unique([applicationSource, applicationTarget, type])
   @@map("relations")

--- a/backend/prisma/schema/compliance.prisma
+++ b/backend/prisma/schema/compliance.prisma
@@ -11,7 +11,7 @@ model Compliance {
   metadataId      String?         
   metadata        Metadata?       @relation("ComplianceMetadata", fields: [metadataId], references: [id])
   applicationId   String?         
-  application     Application?    @relation("ApplicationCompliances", fields: [applicationId], references: [id])
+  application   Application? @relation("ApplicationCompliances", fields: [applicationId], references: [id], onDelete: Cascade)
 
   @@map("compliances")
 }

--- a/backend/prisma/schema/events.prisma
+++ b/backend/prisma/schema/events.prisma
@@ -7,7 +7,7 @@ model Event {
   metadataId    String
   metadata      Metadata    @relation("EventMetadata", fields: [metadataId], references: [id])
   applicationId String
-  application   Application @relation("ApplicationEvents", fields: [applicationId], references: [id])
+  application   Application @relation("ApplicationEvents", fields: [applicationId], references: [id], onDelete: Cascade)
 
   @@map("events")
 }

--- a/backend/prisma/schema/externals.prisma
+++ b/backend/prisma/schema/externals.prisma
@@ -4,7 +4,7 @@ model ExternalRessource {
   description   String?
   type          ExternalRessourceType
   applicationId String
-  application   Application           @relation("ApplicationExternalsRessource", fields: [applicationId], references: [id])
+  application   Application @relation("ApplicationExternalsRessource", fields: [applicationId], references: [id], onDelete: Cascade)
 }
 
 enum ExternalRessourceType {

--- a/backend/prisma/schema/hosting.prisma
+++ b/backend/prisma/schema/hosting.prisma
@@ -7,7 +7,7 @@ model Hosting {
   nature          Nature?
   platform        String?
   applicationId   String
-  application     Application @relation(fields: [applicationId], references: [id])
+  application   Application @relation(fields: [applicationId], references: [id], onDelete: Cascade)
 }
 
 enum Nature {

--- a/backend/prisma/schema/labels.prisma
+++ b/backend/prisma/schema/labels.prisma
@@ -6,7 +6,7 @@ model Label {
   metadataId          String
   metadata            Metadata    @relation("LabelMetadata", fields: [metadataId], references: [id])
   applicationId       String
-  application         Application @relation("ApplicationLabels", fields: [applicationId], references: [id])
+  application         Application @relation("ApplicationLabels", fields: [applicationId], references: [id], onDelete: Cascade)
 
   @@map("labels")
 }

--- a/backend/prisma/schema/users.prisma
+++ b/backend/prisma/schema/users.prisma
@@ -22,7 +22,7 @@ model Actor {
   organizationId String?
   organization   Organization? @relation(fields: [organizationId], references: [id])
   applicationId  String?
-  application    Application?  @relation("ApplicationActors", fields: [applicationId], references: [id])
+  application Application? @relation("ApplicationActors", fields: [applicationId], references: [id], onDelete: Cascade)
 
   @@index([applicationId])
   @@map("actors")

--- a/backend/src/product/application.controller.ts
+++ b/backend/src/product/application.controller.ts
@@ -10,6 +10,7 @@ import {
   BadRequestException,
   Response,
   Logger,
+  Delete,
 } from '@nestjs/common';
 import { ApplicationService } from './application.service';
 
@@ -242,5 +243,26 @@ Aucun paramètre n'est requis pour accéder à cette liste.
       where: { id: id },
       data: applicationToUpdate,
     });
+  }
+  /**
+   * Supprime une application par son ID.
+   *
+   * @param id L'identifiant de l'application à supprimer.
+   *
+   * @throws NotFoundException Si l'application n'est pas trouvée.
+   */
+  @Delete(':id')
+  @ApiOperation({
+    summary: 'Supprimer une application',
+    description: 'Supprime une application par son ID.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Application supprimée avec succès.',
+  })
+  @ApiResponse({ status: 404, description: 'Application non trouvée.' })
+  async remove(@Param('id') id: string) {
+    await this.applicationService.deleteApplication(id);
+    return { message: 'Application supprimée avec succès.' };
   }
 }

--- a/backend/src/product/application.service.ts
+++ b/backend/src/product/application.service.ts
@@ -135,6 +135,12 @@ export class ApplicationService {
     const application =
       await this.applicationRepository.findById(applicationId);
 
+    if (!application) {
+      throw new NotFoundException(
+        `Application non trouvée pour l'ID: ${applicationId}`,
+      );
+    }
+
     console.log(
       "📌 Application récupérée depuis l'API :",
       JSON.stringify(application, null, 2),
@@ -152,6 +158,15 @@ export class ApplicationService {
   public async getApplications() {
     const applications = await this.applicationRepository.findAll();
     return applications;
+  }
+
+  public async deleteApplication(id: string): Promise<void> {
+    const existing = await this.applicationRepository.findById(id);
+    if (!existing) {
+      throw new NotFoundException(`Application non trouvée pour l'ID: ${id}`);
+    }
+
+    await this.applicationRepository.delete(id);
   }
 
   private async createApplicationMetadata(ownerId: string) {

--- a/backend/src/product/infrastructure/repository/application.repository.interface.ts
+++ b/backend/src/product/infrastructure/repository/application.repository.interface.ts
@@ -8,4 +8,5 @@ export interface IApplicationRepository {
     ownerId: string,
     actorsToCreate,
   ): Promise<Application>;
+  delete(id: string): Promise<void>;
 }

--- a/backend/src/product/infrastructure/repository/application.repository.ts
+++ b/backend/src/product/infrastructure/repository/application.repository.ts
@@ -97,4 +97,10 @@ export class ApplicationRepository implements IApplicationRepository {
     });
     return results.map((r) => r.application);
   }
+
+  public async delete(id: string): Promise<void> {
+    await this.prisma.application.delete({
+      where: { id },
+    });
+  }
 }


### PR DESCRIPTION
# description

1. **Ajout de paramètres de configuration VS Code** :
   - Un nouveau fichier `.vscode/settings.json` est ajouté, contenant une configuration pour les commits conventionnels avec une portée "api".

2. **Modification des contraintes de clé étrangère dans la base de données** :
   - Un script de migration SQL est ajouté (`migration.sql`) pour supprimer et réajouter des contraintes de clé étrangère sur plusieurs tables afin de définir des actions "ON DELETE CASCADE" et "ON UPDATE CASCADE". Cela signifie que la suppression d'une application entraînera automatiquement la suppression des enregistrements associés dans ces tables.

3. **Mise à jour des schémas Prisma** :
   - Les fichiers Prisma sont mis à jour pour inclure les nouvelles contraintes "ON DELETE CASCADE" dans les relations entre les modèles. Cela concerne les fichiers `anomaly.prisma`, `applications.prisma`, `compliance.prisma`, `events.prisma`, `externals.prisma`, `hosting.prisma`, `labels.prisma`, et `users.prisma`.

4. **Ajout d'une route pour supprimer une application par son ID dans le contrôleur** :
   - Une nouvelle méthode `remove` est ajoutée dans le contrôleur `application.controller.ts` pour permettre la suppression d'une application par son ID via une requête DELETE. Cette méthode vérifie si l'application existe avant de la supprimer et renvoie un message de succès ou une erreur si l'application n'est pas trouvée.

5. **Ajout de la logique de suppression d'application dans le service** :
   - Une nouvelle méthode `deleteApplication` est ajoutée dans le service `application.service.ts` pour gérer la suppression d'une application. Elle vérifie l'existence de l'application avant de la supprimer.

6. **Mise à jour du dépôt d'applications pour inclure la méthode de suppression** :
   - Le fichier `application.repository.interface.ts` est mis à jour pour inclure la méthode `delete`. Le fichier `application.repository.ts` implémente cette méthode en utilisant Prisma pour supprimer l'application de la base de données.

7. **Ajout de tests end-to-end pour la suppression d'application** :
   - Un nouveau test est ajouté dans `applications.e2e-spec.ts` pour vérifier la fonctionnalité de suppression d'une application. Le test crée une application temporaire, la supprime, puis vérifie que l'application a été correctement supprimée.

En résumé, ce code permet de gérer la suppression des applications de manière sécurisée en cascade, en supprimant également tous les enregistrements associés dans d'autres tables, et ajoute des tests pour vérifier cette fonctionnalité.