### PR TITLE
fix(front): :pencil2: fix wording in dictionnary event

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "conventionalCommits.scopes": ["applications", "ci", "api"]
+  "conventionalCommits.scopes": ["applications", "ci", "api", "front"]
 }

--- a/frontend/src/composables/use-dictionary.ts
+++ b/frontend/src/composables/use-dictionary.ts
@@ -58,8 +58,8 @@ export const linkTypesDict = {
 export const eventTypesArray = [
   { value: "under_construction", text: "En construction" },
   { value: "in_production", text: "En production" },
-  { value: "decommissioned", text: "Déclassé" },
-  { value: "decommissioning", text: "Déclassement" },
+  { value: "decommissioned", text: "Décommissionée" },
+  { value: "decommissioning", text: "En décommissionnement" },
   { value: "highlight", text: "Événement" },
 ];
 


### PR DESCRIPTION
Cette pull request (PR) apporte les modifications suivantes :

1. **Fichier `.vscode/settings.json`** :
   - Ajout de l'élément `"front"` à la liste des portées (`scopes`) pour les commits conventionnels.
   ```diff
   -  "conventionalCommits.scopes": ["applications", "ci", "api"]
   +  "conventionalCommits.scopes": ["applications", "ci", "api", "front"]
   ```

2. **Fichier `frontend/src/composables/use-dictionary.ts`** :
   - Correction de la traduction de "Déclassé" à "Décommissionée" pour la valeur `"decommissioned"`.
   - Correction de la traduction de "Déclassement" à "En décommissionnement" pour la valeur `"decommissioning"`.
   ```diff
   -  { value: "decommissioned", text: "Déclassé" },
   -  { value: "decommissioning", text: "Déclassement" },
   +  { value: "decommissioned", text: "Décommissionée" },
   +  { value: "decommissioning", text: "En décommissionnement" },
   ```

Ces modifications visent à améliorer la précision des traductions dans l'application et à étendre les portées possibles des commits conventionnels.