### PR TITLE
feat: :sparkles: add nonActorPermissions configuration

### DIFF
--- a/backend/src/common/guards/application.guard.ts
+++ b/backend/src/common/guards/application.guard.ts
@@ -2,16 +2,20 @@ import {
   Injectable,
   CanActivate,
   ExecutionContext,
+  Inject,
 } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { APP_ACTION_KEY } from "../decorators/application.decorator";
 import { PrismaService } from "src/prisma/prisma.service";
 import { APP_PERMISSIONS, APP_PERMS_MAP, AppPermissionsRecord } from "../utils/types";
 import { AdminLevel, Requestor } from "src/user/entities/user.entity";
+import { appConfig } from "src/config/configs";
+import { ConfigType } from "@nestjs/config";
 
 @Injectable()
 export class ApplicationGuard implements CanActivate {
   constructor(
+    @Inject(appConfig.KEY) private readonly appConf: ConfigType<typeof appConfig>,
     private readonly reflector: Reflector,
     private readonly prisma: PrismaService,
   ) { }
@@ -67,7 +71,7 @@ export class ApplicationGuard implements CanActivate {
     if (user.adminLevel >= AdminLevel.WRITE) {
       return new Set<APP_PERMISSIONS>(Object.keys(AppPermissionsRecord) as APP_PERMISSIONS[]);
     }
-    const appPermsSet = new Set<APP_PERMISSIONS>();
+    const appPermsSet = new Set<APP_PERMISSIONS>(this.appConf.nonActorPermissions);
     if (user.adminLevel >= AdminLevel.READ) {
       Object.keys(AppPermissionsRecord)
         .filter(key => key.startsWith("read"))

--- a/backend/src/config/configs/app.config.ts
+++ b/backend/src/config/configs/app.config.ts
@@ -1,4 +1,6 @@
 import { registerAs } from "@nestjs/config";
+import { AppPermissionsRecord } from "src/common/utils/types";
+import type { APP_PERMISSIONS } from "src/common/utils/types";
 
 export interface AppConfig {
   env: string
@@ -7,6 +9,7 @@ export interface AppConfig {
   onlyWriteSwagger: boolean
   writeYaml: boolean
   version: string
+  nonActorPermissions: APP_PERMISSIONS[]
 }
 export default registerAs("app", (): AppConfig => {
   const env = process.env.NODE_ENV ?? "development";
@@ -15,6 +18,9 @@ export default registerAs("app", (): AppConfig => {
   const onlyWriteSwagger = process.env.ONLY_WRITE_SWAGGER === "true";
   const writeYaml = process.env.WRITE_SWAGGER_YAML !== "false";
   const version = process.env.VERSION ?? "development";
+  const nonActorPermissions = (process.env.NON_ACTOR_PERMISSIONS ?? "")
+    .split(",")
+    .filter(perm => (perm in AppPermissionsRecord)) as APP_PERMISSIONS[];
 
   return {
     env,
@@ -23,5 +29,6 @@ export default registerAs("app", (): AppConfig => {
     onlyWriteSwagger,
     writeYaml,
     version,
+    nonActorPermissions,
   };
 });

--- a/backend/src/product/application.service.ts
+++ b/backend/src/product/application.service.ts
@@ -1,5 +1,5 @@
 import { PrismaService } from "src/prisma/prisma.service";
-import { Injectable, Logger, NotFoundException } from "@nestjs/common";
+import { Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { Prisma, Application } from "@prisma/client";
 import {
   CreateApplicationDto,
@@ -13,6 +13,8 @@ import { calculateIQ } from "src/common/utils/quality.utils";
 import { ApplicationRights } from "./application/dto/application-rights.dto";
 import { AdminLevel, Requestor } from "src/user/entities/user.entity";
 import { ApplicationSearchResultDto } from "./application/dto/get-application.dto.js";
+import { appConfig } from "src/config/configs";
+import { ConfigType } from "@nestjs/config";
 
 export function objectEntries<Obj extends Record<string, unknown>>(
   obj: Obj,
@@ -27,6 +29,7 @@ export class ApplicationService {
     private readonly applicationRepository: ApplicationRepository,
     private readonly labelsService: LabelsService,
     private readonly metadataService: MetadataService,
+    @Inject(appConfig.KEY) private readonly appConf: ConfigType<typeof appConfig>,
   ) { }
 
   public async createApplication(
@@ -197,13 +200,13 @@ export class ApplicationService {
     searchParams: ApplicationSearchDto,
     requestor?: Requestor,
   ): Promise<ApplicationSearchResultDto> {
-    if (requestor.adminLevel >= AdminLevel.READ) {
-      // If the user has read or write permissions, proceed with the search
-      return this.applicationRepository.findApplications(searchParams);
+    if (searchParams.isActor && requestor) {
+      return this.applicationRepository.findApplications(searchParams, { actorEmail: requestor.email });
     }
-    return this.applicationRepository.findApplications(searchParams, {
-      actorEmail: requestor.email,
-    });
+    if (!this.appConf.nonActorPermissions.includes("readBase") && requestor?.adminLevel < AdminLevel.READ) {
+      return this.applicationRepository.findApplications(searchParams, { actorEmail: requestor.email });
+    }
+    return this.applicationRepository.findApplications(searchParams);
   }
 
   public async exportApplications(): Promise<any[]> {

--- a/backend/src/product/application/dto/search-application.dto.ts
+++ b/backend/src/product/application/dto/search-application.dto.ts
@@ -186,4 +186,13 @@ export class ApplicationSearchDto extends PaginationDto {
     return Array.isArray(value) ? value : [value] as string[];
   })
   columns?: string;
+
+  @ApiPropertyOptional({
+    description: "Ne retourne que les applications dont l'utilisateur est acteur, defaut: false",
+    required: false,
+    type: String,
+  })
+  @IsOptional()
+  @Type(() => Boolean)
+  isActor?: boolean = false;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - AUTH_VERIFY_JWT=true
       - DISABLE_PINO_LOGGER=true
       - KEYCLOAK_CLIENT_ID=referentiel-applications
+      # - NON_ACTOR_PERMISSIONS=readBase
     depends_on:
       - postgres
     ports:

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -654,6 +654,14 @@ paths:
           schema:
             example: id,label,shortName,description
             type: string
+        - name: isActor
+          required: false
+          in: query
+          description: "Ne retourne que les applications dont l'utilisateur est acteur,
+            defaut: false"
+          schema:
+            default: false
+            type: string
       responses:
         "200":
           description: Liste des applications correspondant aux critères de recherche avec
@@ -926,6 +934,14 @@ paths:
           description: Colonnes à inclure dans l'export
           schema:
             example: id,label,shortName,description
+            type: string
+        - name: isActor
+          required: false
+          in: query
+          description: "Ne retourne que les applications dont l'utilisateur est acteur,
+            defaut: false"
+          schema:
+            default: false
             type: string
       responses:
         "200":


### PR DESCRIPTION
Première version pour attribuer des droits de base à n'importe quel utilisateur si il n’est pas acteur d’une application 