### PR TITLE
fix: 🐛 add RGPD compliance filter

### DIFF
--- a/backend/src/applications/dto/search-application.dto.ts
+++ b/backend/src/applications/dto/search-application.dto.ts
@@ -192,10 +192,12 @@ export class ApplicationSearchDto extends PaginationDto {
   @ApiPropertyOptional({
     description: "Filtrer par conformité",
     type: [String],
-    enum: ["dima", "pdma", "homologation", "rgaa", "dsfr"],
+    enum: ["dima", "pdma", "homologation", "rgaa", "dsfr", "rgpd"],
   })
   @IsOptional()
-  @IsEnum(["dima", "pdma", "homologation", "rgaa", "dsfr"], { each: true })
+  @IsEnum(["dima", "pdma", "homologation", "rgaa", "dsfr", "rgpd"], {
+    each: true,
+  })
   @Transform(({ value }) => ApplicationSearchDto.toArray(value))
   compliance__in?: string[];
 

--- a/backend/src/applications/prisma-query-builder.service.ts
+++ b/backend/src/applications/prisma-query-builder.service.ts
@@ -390,6 +390,16 @@ export class PrismaQueryBuilder {
             },
           });
           break;
+        case "rgpd":
+          where.AND.push({
+            compliance: {
+              OR: [
+                { rgpd_has_aipd: { not: null } },
+                { rgpd_dpo_name: { not: null } },
+              ],
+            },
+          });
+          break;
       }
     });
 

--- a/backend/tests/applications.e2e-spec.ts
+++ b/backend/tests/applications.e2e-spec.ts
@@ -92,6 +92,44 @@ describe("Applications", () => {
     expect(resultIds).not.toContain(appWithoutHomologation.id);
   });
 
+  it("/GET applications?compliance__in=rgpd should include apps with RGPD data", async () => {
+    const prisma = getPrismaClient();
+    const appWithRgpd = await ApplicationFaker.create(user);
+    const appWithoutRgpd = await ApplicationFaker.create(user);
+
+    const appWithRgpdCompliance = await ComplianceFaker.create({
+      application: appWithRgpd,
+    });
+    await prisma.compliance.update({
+      where: { id: appWithRgpdCompliance.id },
+      data: { rgpd_has_aipd: true, rgpd_dpo_name: "DPO Test" },
+    });
+
+    const appWithoutRgpdCompliance = await ComplianceFaker.create({
+      application: appWithoutRgpd,
+    });
+    await prisma.compliance.update({
+      where: { id: appWithoutRgpdCompliance.id },
+      data: { rgpd_has_aipd: null, rgpd_dpo_name: null },
+    });
+
+    const response = await request(app().getHttpServer())
+      .get("/applications")
+      .query({
+        compliance__in: "rgpd",
+        page: 0,
+        pageSize: 0,
+      })
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .expect(200);
+
+    const resultIds = response.body.results.map(
+      (application: { id: string }) => application.id,
+    );
+    expect(resultIds).toContain(appWithRgpd.id);
+    expect(resultIds).not.toContain(appWithoutRgpd.id);
+  });
+
   it("/POST applications, with missing permissions", async () => {
     await request(app().getHttpServer())
       .post("/applications")

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -593,6 +593,7 @@ paths:
                 - homologation
                 - rgaa
                 - dsfr
+                - rgpd
         - name: link
           required: false
           in: query
@@ -993,6 +994,7 @@ paths:
                 - homologation
                 - rgaa
                 - dsfr
+                - rgpd
         - name: link
           required: false
           in: query
@@ -3695,6 +3697,7 @@ paths:
                 - homologation
                 - rgaa
                 - dsfr
+                - rgpd
         - name: link
           required: false
           in: query

--- a/frontend/src/components/search/ComplianceFilter.vue
+++ b/frontend/src/components/search/ComplianceFilter.vue
@@ -3,7 +3,7 @@ import { useApplicationSearch } from "@/composables/use-application-search";
 import type { ComplianceType } from "@/composables/use-dictionary";
 
 const { filters, setFilter } = useApplicationSearch();
-const complianceOptions: ComplianceType[] = ["dima", "pdma", "homologation", "rgaa", "dsfr"];
+const complianceOptions: ComplianceType[] = ["dima", "pdma", "homologation", "rgaa", "dsfr", "rgpd"];
 
 function toggleCompliance(value: ComplianceType, checked: boolean) {
   const selected = new Set<ComplianceType>(filters.value.compliance__in || []);

--- a/frontend/tests/complianceFilters.spec.ts
+++ b/frontend/tests/complianceFilters.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 import { gotoSearchPage } from "./utils";
 
-const complianceTypes = ["dima", "pdma", "homologation", "rgaa", "dsfr"] as const;
+const complianceTypes = ["dima", "pdma", "homologation", "rgaa", "dsfr", "rgpd"] as const;
 
 type ComplianceType = (typeof complianceTypes)[number];
 


### PR DESCRIPTION
## Résumé
- ajoute l'option RGPD dans le filtre de conformité frontend (recherche d'applications)
- ajoute le support backend de `compliance__in=rgpd` (validation DTO + logique de filtrage Prisma)
- étend les tests (Playwright frontend + e2e backend) pour couvrir RGPD

## Validation
- frontend: `pnpm test:e2e -- complianceFilters.spec.ts` ✅ (18/18)
- frontend: `pnpm type-check` ⚠️ échec sur erreurs TypeScript préexistantes non liées
- backend (docker compose): `dc exec backend pnpm test -- applications.e2e-spec.ts` ✅ (10/10)

## Référence
- Refs #1696
