### PR TITLE
feat: reorder hosting fields and ensure filter updates handle null va…

### DIFF
--- a/frontend/src/components/search/HostingFilter.vue
+++ b/frontend/src/components/search/HostingFilter.vue
@@ -16,9 +16,9 @@ type HostingField = "site" | "platform" | "provider" | "building" | "room";
 type FilterKey = "hostingSite" | "hostingPlatform" | "hostingProvider" | "hostingBuilding" | "hostingRoom";
 
 const hostingFields: { field: HostingField; filterKey: FilterKey; label: string; testId: string }[] = [
-  { field: "site", filterKey: "hostingSite", label: "Tous les sites", testId: "hosting-site-select" },
-  { field: "platform", filterKey: "hostingPlatform", label: "Toutes les plateformes", testId: "hosting-platform-select" },
   { field: "provider", filterKey: "hostingProvider", label: "Tous les fournisseurs", testId: "hosting-provider-select" },
+  { field: "platform", filterKey: "hostingPlatform", label: "Toutes les plateformes", testId: "hosting-platform-select" },
+  { field: "site", filterKey: "hostingSite", label: "Tous les sites", testId: "hosting-site-select" },
   { field: "building", filterKey: "hostingBuilding", label: "Tous les bâtiments", testId: "hosting-building-select" },
   { field: "room", filterKey: "hostingRoom", label: "Toutes les pièces", testId: "hosting-room-select" },
 ];
@@ -95,7 +95,7 @@ const labels: Record<HostingField, string> = {
       :options="optionsMap[field].value"
       :disabled="isLoading"
       :data-testid="testId"
-      @update:model-value="updateFilter(filterKey, $event)"
+      @update:model-value="updateFilter(filterKey, String($event ?? ''))"
     />
   </div>
 </template>


### PR DESCRIPTION
 Modification de l'ordonnancement des filtres d'hébergement dans le panneau de recherche (IHM) pour une meilleure utilisation.

  L'ordre des filtres passe de :
  Site → Plate-forme → Fournisseur → Bâtiment → Pièce

  au nouvel ordre attendu :
  Fournisseur → Plate-forme → Site → Bâtiment → Pièce

  Modifications

  - Réordonnancement du tableau hostingFields dans frontend/src/components/search/HostingFilter.vue. L'affichage des DsfrSelect
  étant généré par un v-for sur ce tableau, l'ordre à l'écran suit directement le nouvel ordre.

  Points de vigilance

  - Aucun changement de logique : seules les positions d'affichage sont modifiées.
  - Les clés d'URL des filtres (hostingSite, hostingPlatform, etc.) et le backend restent inchangés.
  - Les tests existants ciblent les filtres par data-testid (et non par leur position) : ils ne sont pas impactés.

  Capture

  Définition du fini

  - [x] La fonctionnalité est terminée
  - [ ] Les tests liés à cette fonctionnalité ont été ajoutés
  - [ ] La documentation liée à cette fonctionnalité a été ajoutée