### PR TITLE
feat: [RGAA] Lot A — combobox / autocomplete accessible

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -5,7 +5,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "baseUrl": "./",
-    "ignoreDeprecations": "6.0",
     "module": "commonjs",
     "strict": true,
     "strictBindCallApply": false,

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -5,6 +5,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "baseUrl": "./",
+    "ignoreDeprecations": "6.0",
     "module": "commonjs",
     "strict": true,
     "strictBindCallApply": false,

--- a/frontend/src/components/AccessibleAutocomplete.vue
+++ b/frontend/src/components/AccessibleAutocomplete.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { watchDebounced } from "@vueuse/core";
 import { onClickOutside } from "@vueuse/core";
-import { computed, onMounted, ref } from "vue";
+import { computed, ref } from "vue";
 
 interface Props<T> {
   id?: string;
@@ -9,7 +9,10 @@ interface Props<T> {
   displayLabel: (item: T | null) => string;
   placeholder?: string;
   displayNoResult?: boolean;
-  isSearch?: boolean;
+  /** Étiquette visible du champ (rendue en `title` — RGAA 11.1). */
+  title?: string;
+  /** Nom accessible de la liste de suggestions (`aria-label` du listbox — RGAA 7.1). */
+  listLabel?: string;
   onChange?: (item: T | null) => void;
 }
 
@@ -22,6 +25,7 @@ const highlightedIndex = ref(-1);
 const loading = ref(false);
 const showList = ref(false);
 const inputEl = ref<HTMLInputElement | null>(null);
+const containerEl = ref<HTMLElement | null>(null);
 
 async function doSearch(query: string) {
   if (!query) {
@@ -83,10 +87,6 @@ function clear() {
 }
 defineExpose({ clear });
 
-onMounted(() => {
-  if (props.isSearch) inputEl.value?.setAttribute("role", "searchbox");
-});
-
 const hasResults = computed(() => results.value.length > 0);
 
 const ariaActiveDescendant = computed(() => {
@@ -105,26 +105,29 @@ const liveRegionText = computed(() => {
   if (results.value.length === 0) {
     return props.displayNoResult ? "Aucun résultat" : "";
   }
-  return `${results.value.length} résultat${results.value.length > 1 ? "s" : ""} disponible${results.value.length > 1 ? "s" : ""}`;
+  const n = results.value.length;
+  return `${n} suggestion${n > 1 ? "s" : ""} disponible${n > 1 ? "s" : ""}, utilisez les flèches haut et bas pour naviguer, Entrée pour sélectionner.`;
 });
 
-onClickOutside(inputEl, () => {
+onClickOutside(containerEl, () => {
   showList.value = false;
 });
 </script>
 
 <template>
-  <div class="autocomplete" @keydown="onKeydown">
+  <div ref="containerEl" class="autocomplete" @keydown="onKeydown">
     <input
       :id="id"
       ref="inputEl"
       type="text"
       class="fr-input"
       :placeholder="placeholder"
+      :title="title"
       v-model="inputValue"
       @input="onInput"
       autocomplete="off"
       role="combobox"
+      aria-autocomplete="list"
       :aria-controls="id ? id + '-list' : 'autocomplete-list'"
       :aria-activedescendant="ariaActiveDescendant"
       :aria-expanded="showList"
@@ -139,20 +142,23 @@ onClickOutside(inputEl, () => {
       :id="id ? id + '-list' : 'autocomplete-list'"
       class="autocomplete-list"
       role="listbox"
+      :aria-label="listLabel ?? 'Suggestions'"
     >
-      <li
-        v-for="(item, index) in results"
-        :key="index"
-        class="autocomplete-item"
-        :id="`autocomplete-item-${index}`"
-        :class="{ highlighted: index === highlightedIndex }"
-        @mousedown.prevent="select(item)"
-        role="option"
-        :aria-selected="index === highlightedIndex ? 'true' : 'false'"
-      >
-        <slot name="suggestion" :item="item">
-          {{ props.displayLabel(item) }}
-        </slot>
+      <li v-for="(item, index) in results" :key="index" role="presentation">
+        <button
+          type="button"
+          class="autocomplete-item"
+          :id="`autocomplete-item-${index}`"
+          :class="{ highlighted: index === highlightedIndex }"
+          tabindex="-1"
+          role="option"
+          :aria-selected="index === highlightedIndex ? 'true' : 'false'"
+          @click="select(item)"
+        >
+          <slot name="suggestion" :item="item">
+            {{ props.displayLabel(item) }}
+          </slot>
+        </button>
       </li>
 
       <li v-if="!hasResults && displayNoResult" class="no-result" role="option" aria-disabled="true">Aucun résultat</li>
@@ -182,7 +188,15 @@ onClickOutside(inputEl, () => {
   overflow-y: auto;
 }
 .autocomplete-item {
+  display: block;
+  width: 100%;
   padding: 0.5rem 0.75rem;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: 0;
+  border-radius: 0;
   cursor: pointer;
 }
 .autocomplete-item.highlighted,

--- a/frontend/src/components/AccessibleAutocomplete.vue
+++ b/frontend/src/components/AccessibleAutocomplete.vue
@@ -28,6 +28,7 @@ const inputEl = ref<HTMLInputElement | null>(null);
 const containerEl = ref<HTMLElement | null>(null);
 
 async function doSearch(query: string) {
+  highlightedIndex.value = -1;
   if (!query) {
     results.value = [];
     return;
@@ -65,15 +66,19 @@ function select(item: any) {
 
 function onKeydown(e: KeyboardEvent) {
   if (!showList.value) return;
+  const count = results.value.length;
+  const current = Number.isInteger(highlightedIndex.value) ? highlightedIndex.value : -1;
   if (e.key === "ArrowDown") {
     e.preventDefault();
-    highlightedIndex.value = (highlightedIndex.value + 1) % results.value.length;
+    if (!count) return;
+    highlightedIndex.value = (current + 1) % count;
   } else if (e.key === "ArrowUp") {
     e.preventDefault();
-    highlightedIndex.value = (highlightedIndex.value - 1 + results.value.length) % results.value.length;
-  } else if (e.key === "Enter" && highlightedIndex.value >= 0) {
+    if (!count) return;
+    highlightedIndex.value = (current - 1 + count) % count;
+  } else if (e.key === "Enter" && current >= 0 && current < count) {
     e.preventDefault();
-    select(results.value[highlightedIndex.value]);
+    select(results.value[current]);
   } else if (e.key === "Escape") {
     showList.value = false;
   }

--- a/frontend/src/components/common/TagSearchSelect.vue
+++ b/frontend/src/components/common/TagSearchSelect.vue
@@ -48,19 +48,27 @@ function removeTag(index: number) {
 <template>
   <ul class="fr-tags-group" data-testid="info-tags">
     <li v-for="(tag, index) in props.tags" :key="index" class="tag-item">
-      <DsfrTag :label="tag" selectable :value="tag" :selected="false" @click.stop.prevent="removeTag(index)" class="fr-tag--dismiss" />
+      <DsfrTag
+        :label="tag"
+        tag-name="button"
+        class="fr-tag--dismiss"
+        :title="`Supprimer le tag : ${tag}`"
+        @click.stop.prevent="removeTag(index)"
+      />
     </li>
   </ul>
+  <label for="tag-search" class="fr-label">Tags</label>
   <AccessibleAutocomplete
     id="tag-search"
     data-testid="search-tags"
+    title="Tags"
+    list-label="Tags proposés"
     :search="getTagsOptions"
     display-menu="overlay"
     placeholder="Rechercher un tag"
     :min-length="2"
     :onChange="addTag"
     :displayNoResult="true"
-    :isSearch="true"
     :displayLabel="(item) => item.name"
   />
 </template>

--- a/frontend/src/components/search/SearchHeader.vue
+++ b/frontend/src/components/search/SearchHeader.vue
@@ -97,11 +97,12 @@ function onConfirm(selection: ApplicationOption | null) {
       v-if="!isMobile"
       ref="searchRef"
       id="app-search"
+      title="Rechercher une application"
+      list-label="Applications proposées"
       :search="fetchSuggestions"
       :display-label="displayLabel"
       :on-change="onConfirm"
       :display-no-result="true"
-      :is-search="true"
       placeholder="Rechercher une application…"
       :input-ref="inputRef"
     >


### PR DESCRIPTION
## Lot A — Combobox / Autocomplete accessible

Sous-issue de #1767 (audit RGAA 4.1.2, v1.75.0). Méthode & outils de test : #1785.
Closes #1771.

Corrige le pattern ARIA du combobox/autocomplete, la navigation clavier des options et les messages de statut.

### Tickets couverts (6)
| Ticket | Sujet | Critères |
|---|---|---|
| RGAA-010 | Barre de recherche header | 11.1, 7.1 |
| RGAA-018 | Combobox (datalist) | 7.1, 7.5 |
| RGAA-019 | Combobox « ≥ 3 caractères » | 7.3, 7.1, 7.5 |
| RGAA-020 | Combobox « tags » | 11.1, 7.1 |
| RGAA-021 | Boutons de tags | 7.1 |
| RGAA-029 | Pagination · select « lignes par page » | 11.1, 11.2, 7.1 |

### Changements
- **`AccessibleAutocomplete.vue`** : suppression de la surcharge `role="searchbox"` (on garde `role="combobox"`) ; ajout de `aria-autocomplete="list"` ; props `title` (étiquette visible — 11.1) et `listLabel` (nom accessible du `listbox` — 7.1) ; options rendues en `<button role="option">` activables au pointeur (7.3) ; `onClickOutside` recentré sur le conteneur ; message `aria-live` enrichi (7.5).
- **`SearchHeader.vue`** : `title` + `list-label`, retrait de `is-search`.
- **`TagSearchSelect.vue`** : `<label for="tag-search">` + `title`/`list-label` ; chips de tags en `tag-name="button"` **sans `aria-pressed`** + `title="Supprimer le tag : …"`.
- **`tsconfig.json` (backend)** : retrait de l'option `ignoreDeprecations` invalide pour TS 5.9.

> RGAA-029 : aucun changement requis — `PaginationFooter.vue` a déjà `<label for="rows-per-page">` et `DsfrPagination` (vue-dsfr 8.15) rend nativement `<nav aria-label="Pagination">` avec libellés FR.

### Fix additionnel (commit séparé)
`fix: prevent keyboard navigation lock in AccessibleAutocomplete` — la navigation flèches calculait l'index avec `% results.length`, donnant `NaN` quand la liste se vide transitoirement (course de la recherche debouncée) ; l'index restait bloqué et la navigation clavier devenait inopérante (RGAA 7.3). Index réinitialisé à chaque recherche + garde sur liste vide.

### Validation
- Pré-validation automatique (chrome-devtools + Lighthouse/axe) sur stack locale, connecté : rôles/états ARIA, listbox nommé, `aria-live`, navigation clavier (↑/↓ + `aria-activedescendant`, focus maintenu), sélection clavier (Entrée) et pointeur, chip de tag sans `aria-pressed`. Lighthouse accessibilité 97/100 (les 2 échecs sont hors périmètre : panneau Vue DevTools + bouton « signaler » d'un autre composant).
- `pnpm type-check` ✅.

### Reste à valider manuellement (#1785)
Passe lecteur d'écran **NVDA 2025.3.2 + Firefox ESR** (Windows) : vocalisation effective et pertinence des intitulés. Le socle technique exploité par NVDA est en place et vérifié.
