### PR TITLE
test(qa): automatise la non-régression #1825 (conformités, périmètres/groupes d'acteurs, MAIA)

### DIFF
--- a/.github/ISSUE_TEMPLATE/qa-conformites.md
+++ b/.github/ISSUE_TEMPLATE/qa-conformites.md
@@ -1,8 +1,8 @@
 ---
-name: "🧪 QA — Catalogue & recherche"
-about: "Campagne de non-régression du catalogue & de la recherche pour une version"
-title: "[QA][vX.Y.Z] Catalogue & recherche"
-labels: ["qa", "non-regression", "qa:catalogue"]
+name: "🧪 QA — Conformités (éco-conception & homologation)"
+about: "Campagne de non-régression des conformités (éco-index, homologation) pour une version"
+title: "[QA][vX.Y.Z] Conformités (éco-conception & homologation)"
+labels: ["qa", "non-regression", "qa:conformites"]
 ---
 
 ## Campagne
@@ -13,7 +13,7 @@ labels: ["qa", "non-regression", "qa:catalogue"]
 - **Testeur** :
 - **Date** :
 
-> Protocole de référence : [`qa/protocoles/catalogue.md`](../blob/main/qa/protocoles/catalogue.md).
+> Protocole de référence : [`qa/protocoles/conformites.md`](../blob/main/qa/protocoles/conformites.md).
 > Cocher chaque étape validée et **glisser une capture** dans la zone `📎`. Tout échec → ouvrir un
 > 🐛 (template _Rapport de bug_) et lier l'issue ici, laisser la case décochée.
 
@@ -21,7 +21,7 @@ labels: ["qa", "non-regression", "qa:catalogue"]
 
 | Total | ✅ Passés | ❌ Échecs | ⏭️ Non testés |
 | ----- | --------- | --------- | ------------- |
-| 17    |           |           |               |
+| 4     |           |           |               |
 
 ## Protocole
 

--- a/.github/ISSUE_TEMPLATE/qa-maia.md
+++ b/.github/ISSUE_TEMPLATE/qa-maia.md
@@ -1,0 +1,37 @@
+---
+name: "🧪 QA — Intégration MAIA"
+about: "Campagne de non-régression de l'intégration MAIA (organisations & acteurs) pour une version"
+title: "[QA][vX.Y.Z] Intégration MAIA"
+labels: ["qa", "non-regression", "qa:maia"]
+---
+
+## Campagne
+
+- **Version testée** : `vX.Y.Z`
+- **Environnement** : (prod / recette / local)
+- **Navigateur** :
+- **Testeur** :
+- **Date** :
+
+> Protocole de référence : [`qa/protocoles/maia.md`](../blob/main/qa/protocoles/maia.md).
+> Pré-requis : `MOCK_MAIA_SERVICE=true` côté backend. Cocher chaque étape validée et **glisser une
+> capture** dans la zone `📎`. Tout échec → ouvrir un 🐛 (template _Rapport de bug_) et lier l'issue ici.
+
+## Récapitulatif
+
+| Total | ✅ Passés | ❌ Échecs | ⏭️ Non testés |
+| ----- | --------- | --------- | ------------- |
+| 4     |           |           |               |
+
+## Protocole
+
+<!-- qa-steps -->
+
+## Bugs liés
+
+-
+
+## Verdict
+
+- [ ] `qa:pass` — aucune régression bloquante
+- [ ] `qa:fail` — régression(s) constatée(s) (voir bugs liés)

--- a/.github/ISSUE_TEMPLATE/qa-scope-acteurs.md
+++ b/.github/ISSUE_TEMPLATE/qa-scope-acteurs.md
@@ -1,0 +1,37 @@
+---
+name: "🧪 QA — Périmètres admin & groupes d'acteurs"
+about: "Campagne de non-régression des périmètres admin et des groupes d'acteurs pour une version"
+title: "[QA][vX.Y.Z] Périmètres admin & groupes d'acteurs"
+labels: ["qa", "non-regression", "qa:scope-acteurs"]
+---
+
+## Campagne
+
+- **Version testée** : `vX.Y.Z`
+- **Environnement** : (prod / recette / local)
+- **Navigateur** :
+- **Testeur** :
+- **Date** :
+
+> Protocole de référence : [`qa/protocoles/scope-acteurs.md`](../blob/main/qa/protocoles/scope-acteurs.md).
+> Pré-requis : fixtures du seed QA (`pnpm db:seed:qa`). Cocher chaque étape validée et **glisser une
+> capture** dans la zone `📎`. Tout échec → ouvrir un 🐛 (template _Rapport de bug_) et lier l'issue ici.
+
+## Récapitulatif
+
+| Total | ✅ Passés | ❌ Échecs | ⏭️ Non testés |
+| ----- | --------- | --------- | ------------- |
+| 6     |           |           |               |
+
+## Protocole
+
+<!-- qa-steps -->
+
+## Bugs liés
+
+-
+
+## Verdict
+
+- [ ] `qa:pass` — aucune régression bloquante
+- [ ] `qa:fail` — régression(s) constatée(s) (voir bugs liés)

--- a/.github/workflows/qa-campaign.yml
+++ b/.github/workflows/qa-campaign.yml
@@ -72,7 +72,11 @@ jobs:
       - name: Seed (avec retries)
         run: |
           for i in {1..10}; do
-            if IMAGE_TAG=qa-backend:ci docker compose -f docker-compose.yml -f docker-compose.ci.yml exec -T backend pnpm db:seed; then exit 0; fi
+            if IMAGE_TAG=qa-backend:ci docker compose -f docker-compose.yml -f docker-compose.ci.yml exec -T backend pnpm db:seed; then
+              # Fixtures QA déterministes (périmètres & groupes d'acteurs) — requises par scope-acteurs.spec.ts
+              IMAGE_TAG=qa-backend:ci docker compose -f docker-compose.yml -f docker-compose.ci.yml exec -T backend pnpm db:seed:qa
+              exit $?
+            fi
             echo "Seed tentative $i échouée, retry dans 5s..."; sleep 5
           done
           echo "Seed échoué"; exit 1

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "db:seed": "prisma db seed",
+    "db:seed:qa": "ts-node -r tsconfig-paths/register prisma/seed-qa.ts",
     "migrate:hosting": "ts-node src/scripts/migrate-hostings.ts"
   },
   "prisma": {

--- a/backend/prisma/seed-qa.ts
+++ b/backend/prisma/seed-qa.ts
@@ -1,0 +1,262 @@
+import { PrismaClient, Roles, priorityRestart } from "@prisma/client";
+
+/**
+ * Seed QA — fixtures déterministes et idempotentes pour la non-régression e2e (#1825, Lot 2 :
+ * scope admin par périmètre & groupes d'acteurs). À lancer APRÈS le seed principal :
+ *   pnpm db:seed && pnpm db:seed:qa
+ *
+ * Les utilisateurs sont mappés par email aux comptes Keycloak de test (scope-admin, member-toto-tutu,
+ * member-toto) : à la première connexion, `findOrCreateByEmail` retrouve l'utilisateur seedé et
+ * conserve son organisation / périmètre / rôle.
+ */
+const prisma = new PrismaClient();
+
+// Organisations hiérarchiques (ids fixes pour des upserts stables).
+const ORG = {
+  toto: {
+    id: "a0000000-0000-4000-8000-000000000001",
+    path: "TOTO",
+    parentId: null as string | null,
+  },
+  totoTutu: {
+    id: "a0000000-0000-4000-8000-000000000002",
+    path: "TOTO/TUTU",
+    parentId: "a0000000-0000-4000-8000-000000000001",
+  },
+  abcd: {
+    id: "a0000000-0000-4000-8000-000000000003",
+    path: "ABCD",
+    parentId: null as string | null,
+  },
+};
+
+// Type d'acteur dédié aux tests, isolé de MOA/MOE (matrice : lecture + écriture appli).
+const QA_ACTOR_TYPE_ID = "a0000000-0000-4000-8000-0000000000a1";
+
+// Applications fixtures (labels uniques et recherchables, ids fixes).
+const APP = {
+  scopeToto: {
+    id: "a0000000-0000-4000-8000-0000000000b1",
+    label: "QA-SCOPE-TOTO",
+  },
+  scopeAbcd: {
+    id: "a0000000-0000-4000-8000-0000000000b2",
+    label: "QA-SCOPE-ABCD",
+  },
+  groupParent: {
+    id: "a0000000-0000-4000-8000-0000000000b3",
+    label: "QA-GROUP-PARENT",
+  },
+  groupChild: {
+    id: "a0000000-0000-4000-8000-0000000000b4",
+    label: "QA-GROUP-CHILD",
+  },
+};
+
+async function ensureOrganization(org: {
+  id: string;
+  path: string;
+  parentId: string | null;
+}) {
+  return prisma.organization.upsert({
+    where: { id: org.id },
+    create: {
+      id: org.id,
+      path: org.path,
+      parentId: org.parentId,
+      sigle: org.path.slice(0, 4).toUpperCase(),
+    },
+    update: { path: org.path, parentId: org.parentId },
+  });
+}
+
+async function ensureUser(
+  email: string,
+  role: Roles,
+  organizationId: string | null,
+  scopeOrganizationId: string | null,
+) {
+  return prisma.user.upsert({
+    where: { email },
+    create: { email, role, organizationId, scopeOrganizationId },
+    update: { role, organizationId, scopeOrganizationId },
+  });
+}
+
+async function ensureApplication(
+  app: { id: string; label: string },
+  createdById: string,
+) {
+  const existing = await prisma.application.findUnique({
+    where: { id: app.id },
+  });
+  if (existing) return existing;
+  const created = await prisma.application.create({
+    data: {
+      id: app.id,
+      label: app.label,
+      shortName: app.label,
+      description: `Fixture QA ${app.label}`,
+      priorityRestart: Object.values(priorityRestart)[0],
+      quality: 50,
+      metadatas: { create: [{ createdById }] },
+    },
+  });
+  const status = await prisma.applicationStatus.create({
+    data: { applicationId: created.id, status: "under_construction" },
+  });
+  return prisma.application.update({
+    where: { id: created.id },
+    data: { currentStatusId: status.id },
+  });
+}
+
+async function ensureActor(
+  id: string,
+  applicationId: string,
+  organizationId: string,
+  isGroup: boolean,
+  email: string | null,
+) {
+  return prisma.actor.upsert({
+    where: { id },
+    create: {
+      id,
+      applicationId,
+      organizationId,
+      isGroup,
+      email,
+      actorTypeId: QA_ACTOR_TYPE_ID,
+      firstname: "QA",
+      lastname: "Actor",
+    },
+    update: {
+      applicationId,
+      organizationId,
+      isGroup,
+      email,
+      actorTypeId: QA_ACTOR_TYPE_ID,
+    },
+  });
+}
+
+async function seedQa() {
+  console.log("🏢 QA — organisations hiérarchiques (TOTO, TOTO/TUTU, ABCD)…");
+  await ensureOrganization(ORG.toto);
+  await ensureOrganization(ORG.totoTutu);
+  await ensureOrganization(ORG.abcd);
+
+  console.log("👤 QA — utilisateurs scopés (mappés aux comptes Keycloak)…");
+  const scopeAdmin = await ensureUser(
+    "scope-admin@example.com",
+    Roles.ADMIN,
+    ORG.toto.id,
+    ORG.toto.id,
+  );
+  await ensureUser(
+    "member-toto-tutu@example.com",
+    Roles.VISITOR,
+    ORG.totoTutu.id,
+    null,
+  );
+  await ensureUser("member-toto@example.com", Roles.VISITOR, ORG.toto.id, null);
+  // Cible d'édition (jamais connectée → pas de compte Keycloak) : org TOTO/TUTU, dans le périmètre TOTO.
+  await ensureUser(
+    "qa-target@example.com",
+    Roles.READER,
+    ORG.totoTutu.id,
+    null,
+  );
+  // Cible HORS périmètre (organisation ABCD) : un admin scopé TOTO/ ne doit pas pouvoir l'éditer.
+  await ensureUser("qa-outside@example.com", Roles.READER, ORG.abcd.id, null);
+
+  console.log("🎭 QA — type d'acteur dédié + matrice (AppRead/AppWrite)…");
+  await prisma.actorType.upsert({
+    where: { id: QA_ACTOR_TYPE_ID },
+    create: {
+      id: QA_ACTOR_TYPE_ID,
+      code: "QA_GROUP",
+      label: "QA Groupe (test)",
+      description: "Type d'acteur dédié aux tests de non-régression",
+    },
+    update: { label: "QA Groupe (test)" },
+  });
+  await prisma.appPermissions.upsert({
+    where: { actorTypeId: QA_ACTOR_TYPE_ID },
+    create: {
+      actorTypeId: QA_ACTOR_TYPE_ID,
+      AppRead: true,
+      AppWrite: true,
+      ActorRead: true,
+      ActorWrite: false,
+      ComplianceRead: true,
+      ComplianceWrite: false,
+      HostingRead: true,
+      HostingWrite: false,
+      MetadataRead: true,
+      RelationRead: true,
+      RelationWrite: false,
+      LinkRead: true,
+      LinkWrite: false,
+    },
+    update: { AppRead: true, AppWrite: true },
+  });
+
+  console.log("📱 QA — applications fixtures + acteurs…");
+  // #12 : app avec un acteur d'organisation TOTO/* → un admin scopé TOTO/ y est admin.
+  // Acteur SANS email : le scope ne dépend que de l'organisation, et le batch MAIA (MAI-04) ne
+  // synchronise que les acteurs avec email → la fixture n'est pas écrasée par les tests MAIA.
+  const appScopeToto = await ensureApplication(APP.scopeToto, scopeAdmin.id);
+  await ensureActor(
+    "a0000000-0000-4000-8000-0000000000c1",
+    appScopeToto.id,
+    ORG.totoTutu.id,
+    false,
+    null,
+  );
+
+  // #13 : app avec un acteur d'organisation ABCD/* uniquement → l'admin scopé TOTO/ n'y est pas admin.
+  const appScopeAbcd = await ensureApplication(APP.scopeAbcd, scopeAdmin.id);
+  await ensureActor(
+    "a0000000-0000-4000-8000-0000000000c2",
+    appScopeAbcd.id,
+    ORG.abcd.id,
+    false,
+    null,
+  );
+
+  // #16 : groupe d'acteur TOTO/ → un membre de TOTO/TUTU est acteur.
+  const appGroupParent = await ensureApplication(
+    APP.groupParent,
+    scopeAdmin.id,
+  );
+  await ensureActor(
+    "a0000000-0000-4000-8000-0000000000c3",
+    appGroupParent.id,
+    ORG.toto.id,
+    true,
+    null,
+  );
+
+  // #17 : groupe d'acteur TOTO/TUTU → un membre de TOTO (parent) n'est PAS acteur.
+  const appGroupChild = await ensureApplication(APP.groupChild, scopeAdmin.id);
+  await ensureActor(
+    "a0000000-0000-4000-8000-0000000000c4",
+    appGroupChild.id,
+    ORG.totoTutu.id,
+    true,
+    null,
+  );
+
+  console.log("✅ Seed QA terminé.");
+}
+
+seedQa()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/e2e/fixtures/api-client.ts
+++ b/e2e/fixtures/api-client.ts
@@ -88,6 +88,11 @@ export class ApiClient {
     return this.get<{ id: string; email: string }>(`/users/me`);
   }
 
+  /** Profil complet de l'utilisateur courant (inclut `organization`). */
+  meRaw(): Promise<Record<string, unknown> | null> {
+    return this.get<Record<string, unknown>>(`/users/me`);
+  }
+
   // --- Écriture (provisioning pour les tests de permissions) ---
 
   private async patch<T>(path: string, body: unknown): Promise<T | null> {
@@ -111,10 +116,15 @@ export class ApiClient {
     return page?.results?.find((u) => u.email === email) ?? null;
   }
 
-  /** Met à jour le rôle et/ou les permissions additionnelles d'un utilisateur. */
+  /** Met à jour le rôle, les permissions, l'organisation et/ou le périmètre d'un utilisateur. */
   setUser(
     id: string,
-    body: { role?: string; additionalPermissions?: string[] },
+    body: {
+      role?: string;
+      additionalPermissions?: string[];
+      organizationId?: string | null;
+      scopeOrganizationId?: string | null;
+    },
   ): Promise<UserAdmin | null> {
     return this.patch<UserAdmin>(`/users/${id}`, body);
   }
@@ -165,6 +175,21 @@ export class ApiClient {
   triggerDigest(day: "today" | "yesterday" = "today"): Promise<unknown> {
     return this.post(`/email/digest?day=${day}`);
   }
+
+  // --- Conformités (provisioning éco-index / homologation, requiert ComplianceWrite) ---
+  compliance(appId: string): Promise<ComplianceShape | null> {
+    return this.get<ComplianceShape>(`/applications/${appId}/compliances`);
+  }
+
+  setCompliance(
+    appId: string,
+    body: Partial<ComplianceShape>,
+  ): Promise<ComplianceShape | null> {
+    return this.patch<ComplianceShape>(
+      `/applications/${appId}/compliances`,
+      body,
+    );
+  }
 }
 
 export interface UserAdmin {
@@ -172,4 +197,12 @@ export interface UserAdmin {
   email: string;
   role: string;
   additionalPermissions: string[];
+}
+
+/** Champs de conformité utiles aux tests (sous-ensemble du DTO backend). */
+export interface ComplianceShape {
+  id: string;
+  homologation_status: string | null;
+  eco_index_target_url: string | null;
+  eco_index_score: number | null;
 }

--- a/e2e/fixtures/datafeature.ts
+++ b/e2e/fixtures/datafeature.ts
@@ -1,4 +1,5 @@
 import { ApiClient } from "./api-client";
+import { dbQuery } from "../support/db";
 
 export interface AppRef {
   id: string;
@@ -17,6 +18,14 @@ export class DataFeature {
   async firstApplication(): Promise<AppRef | null> {
     const page = await this.api.applications("pageSize=1&page=0");
     return page?.results?.[0] ?? null;
+  }
+
+  /** Application dont le libellé correspond exactement (fixtures QA seedées). */
+  async applicationByLabel(label: string): Promise<AppRef | null> {
+    const page = await this.api.applications(
+      `search=${encodeURIComponent(label)}&pageSize=20&page=0`,
+    );
+    return page?.results?.find((a) => a.label === label) ?? null;
   }
 
   /** Une application possédant au moins une relation inter-applications. */
@@ -106,6 +115,34 @@ export class DataFeature {
 
   triggerDigest(day: "today" | "yesterday" = "today") {
     return this.api.triggerDigest(day);
+  }
+
+  // --- Conformités (provisioning déterministe pour CMP-*, avec le token admin) ---
+
+  /** Conformité courante d'une application. */
+  getCompliance(appId: string) {
+    return this.api.compliance(appId);
+  }
+
+  /**
+   * Fixe une URL cible et un score éco-index connus, directement en base.
+   * `eco_index_score` n'est pas inscriptible via l'API (posé uniquement par un scan HTTP réel) → on
+   * établit l'état de départ par SQL.
+   */
+  async setEcoIndex(appId: string, url: string, score: number): Promise<void> {
+    await dbQuery(
+      `UPDATE "Compliance"
+         SET eco_index_target_url = $1,
+             eco_index_score = $2,
+             eco_index_last_calculated_at = NOW()
+       WHERE "applicationId" = $3`,
+      [url, score, appId],
+    );
+  }
+
+  /** Affecte un statut d'homologation. */
+  async setHomologationStatus(appId: string, status: string): Promise<void> {
+    await this.api.setCompliance(appId, { homologation_status: status });
   }
 }
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -15,6 +15,8 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@types/node": "^22.10.0",
+    "@types/pg": "^8.20.0",
+    "pg": "^8.21.0",
     "typescript": "^5.7.2"
   }
 }

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.20
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
+      pg:
+        specifier: ^8.21.0
+        version: 8.21.0
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -28,10 +34,47 @@ packages:
   '@types/node@22.19.20':
     resolution: {integrity: sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==}
 
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.13.0:
+    resolution: {integrity: sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.14.0:
+    resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.21.0:
+    resolution: {integrity: sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
@@ -43,6 +86,26 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -50,6 +113,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
 snapshots:
 
@@ -61,8 +128,49 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.19.20
+      pg-protocol: 1.14.0
+      pg-types: 2.2.0
+
   fsevents@2.3.2:
     optional: true
+
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.13.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.21.0):
+    dependencies:
+      pg: 8.21.0
+
+  pg-protocol@1.14.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.21.0:
+    dependencies:
+      pg-connection-string: 2.13.0
+      pg-pool: 3.14.0(pg@8.21.0)
+      pg-protocol: 1.14.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
 
   playwright-core@1.60.0: {}
 
@@ -72,6 +180,20 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  split2@4.2.0: {}
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  xtend@4.0.2: {}

--- a/e2e/pom/admin.page.ts
+++ b/e2e/pom/admin.page.ts
@@ -28,7 +28,19 @@ export class AdminPage extends BasePage {
 
   async searchUser(value: string): Promise<void> {
     // `admin-user-search` est un <form> : on remplit l'<input> à l'intérieur.
+    // On attend le refetch débouncé de la liste : sinon il peut survenir APRÈS l'ouverture du modal
+    // d'édition et le démonter (la ligne porte le modal) — cf. #1830.
+    const refetch = this.page
+      .waitForResponse(
+        (r) =>
+          /\/users\?/.test(r.url()) &&
+          r.url().includes("search") &&
+          r.request().method() === "GET",
+        { timeout: 10_000 },
+      )
+      .catch(() => null);
     await this.userSearch().locator("input").fill(value);
+    await refetch;
   }
 
   /** Recherche un utilisateur et vérifie qu'il apparaît dans la table (PRM-03). */

--- a/e2e/pom/admin.page.ts
+++ b/e2e/pom/admin.page.ts
@@ -87,6 +87,15 @@ export class AdminPage extends BasePage {
     await this.expectToaster(/mis à jour avec succès/i);
   }
 
+  /**
+   * Édite le rôle d'un utilisateur cible et enregistre (SCP-03 : un admin scopé édite un user de son
+   * périmètre). Réussite = toast de succès, donc le périmètre du requérant a autorisé l'édition.
+   */
+  async editUserRoleWithinScopeAndSave(email: string): Promise<void> {
+    await this.openEditUser(email);
+    await this.changeRoleAndSave();
+  }
+
   private matrixPanel = () => this.byTestId("panel-app-perms-matrix");
 
   /** Ouvre l'onglet « Matrice des permissions » et attend le panneau + la table. */
@@ -140,5 +149,19 @@ export class AdminPage extends BasePage {
   /** Vérifie qu'on n'est PAS sur la page admin (cas non-admin). */
   async expectAccessDenied(): Promise<void> {
     await expect(this.page).not.toHaveURL(/\/administration/);
+  }
+
+  // --- Onglet « Batch de données » : synchronisation MAIA (#1825, MAI-04) ---
+  async openBatchDataTab(): Promise<void> {
+    await this.adminTabs()
+      .getByRole("tab", { name: "Batch de données" })
+      .click();
+    await expect(this.byTestId("admin-actor-maia-batch-btn")).toBeVisible();
+  }
+
+  /** Lance la synchronisation des acteurs avec MAIA et vérifie le retour (MAI-04). */
+  async runMaiaActorBatchAndExpectToast(): Promise<void> {
+    await this.byTestId("admin-actor-maia-batch-btn").click();
+    await this.expectToaster(/Batch MAIA lancé en tâche de fond/i);
   }
 }

--- a/e2e/pom/application.page.ts
+++ b/e2e/pom/application.page.ts
@@ -185,4 +185,109 @@ export class ApplicationPage extends BasePage {
     await this.byTestId("application-copy-link-btn").click();
     await this.expectToaster(/Lien copié dans le presse-papier/i);
   }
+
+  // --- Conformités : éco-conception & homologation (#1825, CMP-*) ---
+  // Libellés de ligne du tableau des conformités (`labels` du composant).
+  private static readonly HOMOLOGATION_LABEL = "Homologation";
+  private static readonly ECO_INDEX_LABEL = "Ecoconception";
+
+  /** Ligne du tableau des conformités correspondant à un type (ciblée par son libellé). */
+  private complianceRow(label: string): Locator {
+    return this.byTestId("compliance-table")
+      .locator("tbody tr")
+      .filter({ hasText: label });
+  }
+
+  /** Ouvre le formulaire d'édition d'une conformité depuis sa ligne. */
+  private async openComplianceEdit(label: string): Promise<void> {
+    await this.complianceRow(label).getByTestId("compliance-edit-btn").click();
+    await expect(this.byTestId("compliance-form-container")).toBeVisible();
+  }
+
+  /** Sélectionne un statut d'homologation (par libellé) et enregistre (CMP-01). */
+  async setHomologationStatus(optionLabel: string): Promise<void> {
+    await this.openComplianceEdit(ApplicationPage.HOMOLOGATION_LABEL);
+    await this.byTestId("compliance-homologation-status").selectOption({
+      label: optionLabel,
+    });
+    await this.byTestId("compliance-submit-btn").click();
+    await this.expectToaster(/Conformité mise à jour avec succès/i);
+  }
+
+  /** Le résumé de la ligne homologation affiche le statut attendu (CMP-01). */
+  async expectHomologationPreview(text: string | RegExp): Promise<void> {
+    await expect(
+      this.complianceRow(ApplicationPage.HOMOLOGATION_LABEL),
+    ).toContainText(text);
+  }
+
+  /** Le résumé de la ligne éco-conception affiche le grade attendu (CMP-04). */
+  async expectEcoIndexGrade(grade: string): Promise<void> {
+    await expect(
+      this.complianceRow(ApplicationPage.ECO_INDEX_LABEL),
+    ).toContainText(new RegExp(`Score:\\s*${grade}\\b`));
+  }
+
+  /** Le résumé de la ligne éco-conception indique l'absence de score (CMP-03). */
+  async expectEcoIndexNotCalculated(): Promise<void> {
+    await expect(
+      this.complianceRow(ApplicationPage.ECO_INDEX_LABEL),
+    ).toContainText(/Non calculé/i);
+  }
+
+  /** Modifie l'URL cible éco-index et enregistre (déclenche le reset côté serveur, CMP-03). */
+  async changeEcoIndexUrlAndSave(url: string): Promise<void> {
+    await this.openComplianceEdit(ApplicationPage.ECO_INDEX_LABEL);
+    await this.byTestId("ecoindex-target-url-input").fill(url);
+    await this.byTestId("compliance-submit-btn").click();
+    await this.expectToaster(/Conformité mise à jour avec succès/i);
+  }
+
+  /** Le bouton « Calculer » l'éco-index est actif (droit d'écriture conformité, CMP-02). */
+  async expectEcoIndexScanEnabled(): Promise<void> {
+    await expect(
+      this.complianceRow(ApplicationPage.ECO_INDEX_LABEL).getByTestId(
+        "compliance-scan-ecoindex-btn",
+      ),
+    ).toBeEnabled();
+  }
+
+  /** Le bouton « Calculer » l'éco-index est désactivé (Lecteur sans droit, CMP-02). */
+  async expectEcoIndexScanDisabled(): Promise<void> {
+    await expect(
+      this.complianceRow(ApplicationPage.ECO_INDEX_LABEL).getByTestId(
+        "compliance-scan-ecoindex-btn",
+      ),
+    ).toBeDisabled();
+  }
+
+  // --- Onglet Acteurs : ajout & import MAIA (#1825, MAI-*) ---
+  /** Ouvre le formulaire d'ajout d'acteur depuis l'onglet Acteurs. */
+  async openAddActorForm(): Promise<void> {
+    await this.openTab("tab-actors");
+    await this.byTestId("actor-add-btn").click();
+    // Le data-testid parent (`actor-form-container`) écrase `actor-form` sur le <form> (fallthrough Vue).
+    await expect(this.byTestId("actor-form-container")).toBeVisible();
+  }
+
+  /** Saisit un email et importe les informations de l'acteur depuis MAIA (MAI-02). */
+  async importActorFromMaia(email: string): Promise<void> {
+    await this.byTestId("actor-email-input").fill(email);
+    await this.byTestId("admin-user-sync-maia-btn").click();
+    await this.expectToaster(/Organisation synchronisée depuis MAIA/i);
+  }
+
+  /** Le prénom de l'acteur a été renseigné (par l'import MAIA) — MAI-02. */
+  async expectActorFirstnameFilled(): Promise<void> {
+    await expect(this.byTestId("actor-firstname-input")).not.toHaveValue("");
+  }
+
+  /** Le champ email est positionné AVANT le champ organisation dans le formulaire (MAI-03). */
+  async expectActorEmailBeforeOrganization(): Promise<void> {
+    const emailBox = await this.byTestId("actor-email-input").boundingBox();
+    const orgBox = await this.byTestId("actor-organization").boundingBox();
+    expect(emailBox).not.toBeNull();
+    expect(orgBox).not.toBeNull();
+    expect(emailBox!.y).toBeLessThan(orgBox!.y);
+  }
 }

--- a/e2e/pom/auth.ts
+++ b/e2e/pom/auth.ts
@@ -2,11 +2,23 @@ import { type Page } from "@playwright/test";
 import { login, logout, type Credentials } from "../support/helpers";
 
 /** Rôles e2e disponibles (utilisateurs Keycloak préconfigurés, mot de passe `pass`). */
-export type Role = "admin" | "user";
+export type Role =
+  | "admin"
+  | "user"
+  | "scope-admin"
+  | "member-toto-tutu"
+  | "member-toto"
+  | "support";
 
 const CREDENTIALS: Record<Role, Credentials> = {
   admin: { user: "admin", pass: "pass" },
   user: { user: "user", pass: "pass" },
+  // Comptes scopés pour la non-régression « périmètres & groupes d'acteurs » (seed QA).
+  "scope-admin": { user: "scope-admin", pass: "pass" },
+  "member-toto-tutu": { user: "member-toto-tutu", pass: "pass" },
+  "member-toto": { user: "member-toto", pass: "pass" },
+  // Compte utilisé pour la première connexion (assignation d'organisation depuis MAIA).
+  support: { user: "support", pass: "pass" },
 };
 
 /** Connexion par rôle (`admin` par défaut — acteur par défaut de la datafeature). */

--- a/e2e/pom/search.page.ts
+++ b/e2e/pom/search.page.ts
@@ -15,6 +15,11 @@ export class SearchPage extends BasePage {
   private totalCounter = () => this.byTestId("sidebar-total-count");
   private resetButton = () => this.byTestId("sidebar-reset-filters-button");
   private myAppsToggle = () => this.byTestId("my-apps-filter-toggle");
+  private subscribedToggle = () =>
+    this.byTestId("my-apps-filter-toggle-subscribed");
+  private customizeColumnsButton = () =>
+    this.byTestId("customize-columns-button");
+  private columnsDialog = () => this.byTestId("customize-columns-dialog");
   private searchInput = () =>
     this.sidebar().getByTestId("application-filter-label");
 
@@ -93,6 +98,64 @@ export class SearchPage extends BasePage {
   async toggleMyApps(): Promise<void> {
     await expect(this.myAppsToggle()).toBeVisible();
     await this.myAppsToggle().click();
+  }
+
+  /** Active le filtre « Mes applications » et vérifie sa propagation dans l'URL (CAT-10). */
+  async toggleMyAppsAndExpectApplied(): Promise<void> {
+    await expect(this.myAppsToggle()).toBeVisible();
+    await this.myAppsToggle().click();
+    await waitForSearchParams(
+      this.page,
+      (params) => params.get("myApplications") === "true",
+    );
+  }
+
+  /** Active le filtre « Mes abonnements » et vérifie sa propagation dans l'URL (CAT-16). */
+  async toggleSubscribedAppsAndExpectApplied(): Promise<void> {
+    await expect(this.subscribedToggle()).toBeVisible();
+    await this.subscribedToggle().click();
+    await waitForSearchParams(
+      this.page,
+      (params) => params.get("subscribersEmail") === "true",
+    );
+  }
+
+  // --- Personnalisation des colonnes (CAT-17 : colonnes avancées MOA/MOE/Plateforme/Fournisseur) ---
+  async openColumnCustomization(): Promise<void> {
+    await this.customizeColumnsButton().click();
+    await expect(this.columnsDialog()).toBeVisible();
+  }
+
+  async closeColumnCustomization(): Promise<void> {
+    await this.byTestId("close-dialog-button").click();
+    await expect(this.columnsDialog()).toBeHidden();
+  }
+
+  /** Une colonne est proposée dans la boîte de personnalisation (droit ColumnRead). */
+  async expectColumnOptionAvailable(label: string): Promise<void> {
+    await expect(
+      this.columnsDialog().getByRole("checkbox", { name: label, exact: true }),
+    ).toBeVisible();
+  }
+
+  /** Active une colonne via sa case dans la boîte de personnalisation. */
+  async enableColumn(label: string): Promise<void> {
+    // Case DSFR : l'<input> est masqué et piloté par v-model → on clique le <label> interactif.
+    const box = this.columnsDialog().getByRole("checkbox", {
+      name: label,
+      exact: true,
+    });
+    if (!(await box.isChecked())) {
+      await this.columnsDialog().getByText(label, { exact: true }).click();
+      await expect(box).toBeChecked();
+    }
+  }
+
+  /** L'en-tête de colonne est visible dans le tableau. */
+  async expectColumnVisible(header: string): Promise<void> {
+    await expect(
+      this.page.getByRole("columnheader", { name: header, exact: true }),
+    ).toBeVisible();
   }
 
   // --- Tri ---

--- a/e2e/support/db.ts
+++ b/e2e/support/db.ts
@@ -1,0 +1,26 @@
+import { Client } from "pg";
+
+/**
+ * Accès direct à la base applicative pour le provisioning hors API (ex. `eco_index_score`, qui n'est
+ * pas un champ inscriptible côté API et n'est posé que par un scan HTTP réel). À réserver aux cas où
+ * l'API ne permet pas d'établir l'état de départ d'un protocole.
+ */
+const DATABASE_URL =
+  process.env.E2E_DATABASE_URL ??
+  process.env.DATABASE_URL ??
+  "postgresql://postgres:password@localhost:5432/postgres";
+
+/** Exécute une requête SQL paramétrée sur une connexion éphémère. */
+export async function dbQuery<T = unknown>(
+  text: string,
+  params: unknown[] = [],
+): Promise<T[]> {
+  const client = new Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    const res = await client.query(text, params);
+    return res.rows as T[];
+  } finally {
+    await client.end();
+  }
+}

--- a/e2e/tests/catalogue.spec.ts
+++ b/e2e/tests/catalogue.spec.ts
@@ -122,7 +122,7 @@ test.describe("Catalogue & recherche", () => {
 
     const search = new SearchPage(page);
     await search.open();
-    await search.toggleMyApps();
+    await search.toggleMyAppsAndExpectApplied();
     await search.expectResultsVisible();
   });
 
@@ -249,5 +249,41 @@ test.describe("Catalogue & recherche", () => {
     await search.open();
     const download = await search.exportExcel();
     expect(download.suggestedFilename()).toMatch(/\.(xlsx|xls)$/i);
+  });
+
+  test("CAT-16 - bascule « Mes abonnements »", async ({ page, data }) => {
+    test.skip(
+      !(await data.firstApplication()),
+      "Aucune application dans le jeu de données",
+    );
+
+    const search = new SearchPage(page);
+    await search.open();
+    await search.toggleSubscribedAppsAndExpectApplied();
+    await search.expectResultsVisible();
+  });
+
+  test("CAT-17 - colonnes avancées (MOA/MOE/Plateforme/Fournisseur)", async ({
+    page,
+    data,
+  }) => {
+    test.skip(
+      !(await data.firstApplication()),
+      "Aucune application dans le jeu de données",
+    );
+
+    const search = new SearchPage(page);
+    await search.open();
+    await search.openColumnCustomization();
+
+    for (const label of ["MOA", "MOE", "Plateforme", "Fournisseur"]) {
+      await search.expectColumnOptionAvailable(label);
+      await search.enableColumn(label);
+    }
+    await search.closeColumnCustomization();
+
+    for (const header of ["MOA", "MOE", "Plateforme", "Fournisseur"]) {
+      await search.expectColumnVisible(header);
+    }
   });
 });

--- a/e2e/tests/conformites.spec.ts
+++ b/e2e/tests/conformites.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from "../fixtures/test";
+import { ApplicationPage, loginAs } from "../pom";
+
+/**
+ * Non-régression — Conformités : éco-conception & homologation (protocole `qa/protocoles/conformites.md`).
+ * Couvre les nouveautés de l'issue #1825 (homologation, calcul/permission/reset éco-index, grade A→G).
+ * POM strict : aucune spec ne manipule de sélecteur. Provisioning déterministe via la datafeature (admin).
+ */
+test.describe("Conformités — éco-conception & homologation", () => {
+  const USER_EMAIL = "user@example.com";
+
+  test("CMP-01 - homologation : « Non réalisée » et « À mettre en place »", async ({
+    page,
+    data,
+  }) => {
+    const app = await data.firstApplication();
+    test.skip(!app, "Aucune application dans le jeu de données");
+
+    const fiche = new ApplicationPage(page);
+    await fiche.open(app!.id, "tab-compliances");
+
+    await fiche.setHomologationStatus("Non réalisée");
+    await fiche.expectHomologationPreview(/Non réalisée/i);
+
+    await fiche.setHomologationStatus("À mettre en place");
+    await fiche.expectHomologationPreview(/À mettre en place/i);
+  });
+
+  test("CMP-04 - éco-index : affichage du score et du grade A→G", async ({
+    page,
+    data,
+  }) => {
+    const app = await data.firstApplication();
+    test.skip(!app, "Aucune application dans le jeu de données");
+
+    // Score 95 → grade A
+    await data.setEcoIndex(app!.id, "https://ecoindex.example/cmp04", 95);
+    const fiche = new ApplicationPage(page);
+    await fiche.open(app!.id, "tab-compliances");
+    await fiche.expectEcoIndexGrade("A");
+
+    // Score 12 → grade F (vérifie le mapping de grade dans l'UI)
+    await data.setEcoIndex(app!.id, "https://ecoindex.example/cmp04", 12);
+    await fiche.openTab("tab-compliances");
+    await fiche.expectEcoIndexGrade("F");
+  });
+
+  test("CMP-03 - éco-index : modifier l'URL cible réinitialise le score", async ({
+    page,
+    data,
+  }) => {
+    const app = await data.firstApplication();
+    test.skip(!app, "Aucune application dans le jeu de données");
+
+    await data.setEcoIndex(app!.id, "https://ecoindex.example/before", 80);
+    const fiche = new ApplicationPage(page);
+    await fiche.open(app!.id, "tab-compliances");
+    await fiche.expectEcoIndexGrade("B"); // 80 → B, le score est bien posé
+
+    await fiche.changeEcoIndexUrlAndSave("https://ecoindex.example/after");
+    await fiche.expectEcoIndexNotCalculated();
+
+    // Confirme la réinitialisation côté serveur.
+    const compliance = await data.getCompliance(app!.id);
+    expect(compliance?.eco_index_score ?? null).toBeNull();
+  });
+
+  test("CMP-02 - éco-index : seuls les droits d'écriture peuvent calculer", async ({
+    page,
+    browser,
+    data,
+  }) => {
+    const app = await data.firstApplication();
+    test.skip(!app, "Aucune application dans le jeu de données");
+
+    // Admin : bouton « Calculer » actif.
+    const adminFiche = new ApplicationPage(page);
+    await adminFiche.open(app!.id, "tab-compliances");
+    await adminFiche.expectEcoIndexScanEnabled();
+
+    // Lecteur : bouton « Calculer » désactivé (contexte navigateur séparé, cf. PRM-09).
+    await data.resetUser(USER_EMAIL);
+    const ctx = await browser.newContext();
+    try {
+      const userPage = await ctx.newPage();
+      await loginAs(userPage, "user");
+      const userFiche = new ApplicationPage(userPage);
+      await userFiche.open(app!.id, "tab-compliances");
+      await userFiche.expectEcoIndexScanDisabled();
+    } finally {
+      await ctx.close();
+    }
+  });
+});

--- a/e2e/tests/maia.spec.ts
+++ b/e2e/tests/maia.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "../fixtures/test";
+import { AdminPage, ApplicationPage, loginAs } from "../pom";
+import { ApiClient } from "../fixtures/api-client";
+
+/**
+ * Non-régression — Intégration MAIA (protocole `qa/protocoles/maia.md`). Cas #1-4 de l'issue #1825.
+ * La stack tourne avec `MOCK_MAIA_SERVICE=true` (organisation mock « …SEINE-ET-MARNE… ») : les appels
+ * MAIA sont déterministes et sans dépendance réseau externe. POM strict.
+ */
+test.describe("Intégration MAIA", () => {
+  test("MAI-01 - première connexion : organisation MAIA assignée par défaut", async ({
+    page,
+  }) => {
+    // `support` n'a (a priori) jamais été provisionné : sa 1ʳᵉ connexion déclenche l'assignation MAIA.
+    await loginAs(page, "support");
+    const me = await (await ApiClient.fromPage(page)).meRaw();
+    const org = me?.organization as { path?: string } | null | undefined;
+    expect(org?.path ?? "").toMatch(/SEINE-ET-MARNE/i);
+  });
+
+  test("MAI-02 - import des informations d'un acteur depuis MAIA", async ({
+    page,
+    data,
+  }) => {
+    const app = await data.firstApplication();
+    test.skip(!app, "Aucune application dans le jeu de données");
+
+    const fiche = new ApplicationPage(page);
+    await fiche.open(app!.id, "tab-actors");
+    await fiche.openAddActorForm();
+    // L'import MAIA exige un email d'utilisateur existant (seedé) ; le mock renvoie alors ses infos.
+    await fiche.importActorFromMaia("user@example.com");
+    await fiche.expectActorFirstnameFilled();
+  });
+
+  test("MAI-03 - le champ email précède le champ organisation", async ({
+    page,
+    data,
+  }) => {
+    const app = await data.firstApplication();
+    test.skip(!app, "Aucune application dans le jeu de données");
+
+    const fiche = new ApplicationPage(page);
+    await fiche.open(app!.id, "tab-actors");
+    await fiche.openAddActorForm();
+    await fiche.expectActorEmailBeforeOrganization();
+  });
+
+  test("MAI-04 - batch admin : synchroniser les acteurs avec MAIA", async ({
+    page,
+  }) => {
+    await loginAs(page, "admin");
+    const admin = new AdminPage(page);
+    await admin.open();
+    await admin.openBatchDataTab();
+    await admin.runMaiaActorBatchAndExpectToast();
+  });
+});

--- a/e2e/tests/scope-acteurs.spec.ts
+++ b/e2e/tests/scope-acteurs.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from "../fixtures/test";
+import type { Page } from "@playwright/test";
+import { AdminPage, ApplicationPage, loginAs } from "../pom";
+import { ApiClient } from "../fixtures/api-client";
+import { DataFeature } from "../fixtures/datafeature";
+
+// Ids fixes des organisations du seed QA (cf. backend/prisma/seed-qa.ts).
+const ORG_TOTO_TUTU_ID = "a0000000-0000-4000-8000-000000000002";
+const ORG_ABCD_ID = "a0000000-0000-4000-8000-000000000003";
+
+/**
+ * Non-régression — Périmètres admin & groupes d'acteurs (protocole `qa/protocoles/scope-acteurs.md`).
+ * Couvre les cas #12-17 de l'issue #1825. Fixtures déterministes du seed QA (`pnpm db:seed:qa`) :
+ * organisations TOTO / TOTO/TUTU / ABCD, comptes Keycloak scopés, applications QA-SCOPE-* / QA-GROUP-*.
+ * POM strict. Le signal « est admin / est acteur » sur une application = bouton d'édition actif.
+ */
+const SEED_HINT = "Fixture QA absente — `pnpm db:seed:qa` a-t-il été lancé ?";
+
+/** Résout l'id d'une application fixture par son libellé, avec le token de l'utilisateur courant. */
+async function appByLabel(page: Page, label: string) {
+  const data = new DataFeature(await ApiClient.fromPage(page));
+  return data.applicationByLabel(label);
+}
+
+test.describe("Périmètres admin & groupes d'acteurs", () => {
+  test("SCP-01 - admin scopé TOTO/ est admin sur une app à acteur TOTO/*", async ({
+    page,
+  }) => {
+    await loginAs(page, "scope-admin");
+    const app = await appByLabel(page, "QA-SCOPE-TOTO");
+    test.skip(!app, SEED_HINT);
+
+    const fiche = new ApplicationPage(page);
+    await fiche.open(app!.id, "tab-infos");
+    await fiche.expectInfoEditAvailable();
+  });
+
+  test("SCP-02 - admin scopé TOTO/ n'est PAS admin sur une app à acteur ABCD/*", async ({
+    page,
+  }) => {
+    await loginAs(page, "scope-admin");
+    const app = await appByLabel(page, "QA-SCOPE-ABCD");
+    test.skip(!app, SEED_HINT);
+
+    const fiche = new ApplicationPage(page);
+    await fiche.open(app!.id, "tab-infos");
+    await fiche.expectInfoEditDisabled();
+  });
+
+  test("SCP-05 - un membre de TOTO/TUTU est acteur via un groupe TOTO/", async ({
+    page,
+  }) => {
+    await loginAs(page, "member-toto-tutu");
+    const app = await appByLabel(page, "QA-GROUP-PARENT");
+    test.skip(!app, SEED_HINT);
+
+    const fiche = new ApplicationPage(page);
+    await fiche.open(app!.id, "tab-infos");
+    await fiche.expectInfoEditAvailable();
+  });
+
+  test("SCP-06 - un membre de TOTO n'est PAS acteur via un groupe TOTO/TUTU", async ({
+    page,
+  }) => {
+    await loginAs(page, "member-toto");
+    const app = await appByLabel(page, "QA-GROUP-CHILD");
+    test.skip(!app, SEED_HINT);
+
+    const fiche = new ApplicationPage(page);
+    await fiche.open(app!.id, "tab-infos");
+    await fiche.expectInfoEditDisabled();
+  });
+
+  test("SCP-03 - éditer le rôle d'un utilisateur dans mon périmètre", async ({
+    page,
+  }) => {
+    await loginAs(page, "scope-admin");
+    const admin = new AdminPage(page);
+    await admin.open();
+    await admin.editUserRoleWithinScopeAndSave("qa-target@example.com");
+  });
+
+  // Note : la frontière de périmètre se vérifie au niveau de l'autorisation (cœur de #14/#15). Le widget
+  // de recherche d'organisation ferme le modal d'édition en e2e (bug UI #1830) et un payload partiel
+  // déclenche une 500 (#1831) → on valide la règle via l'endpoint, avec le token du requérant scopé.
+  test("SCP-04 - changer l'organisation dans le périmètre est autorisé, éditer un user hors périmètre est refusé", async ({
+    page,
+  }) => {
+    await loginAs(page, "scope-admin");
+    const api = await ApiClient.fromPage(page);
+    const target = await api.userByEmail("qa-target@example.com");
+    const outside = await api.userByEmail("qa-outside@example.com");
+    test.skip(!target || !outside, SEED_HINT);
+
+    // Payload complet (rôle + permissions + périmètre), comme l'UI, sur un user DANS le périmètre TOTO/.
+    const base = {
+      role: target!.role,
+      additionalPermissions: target!.additionalPermissions,
+      scopeOrganizationId: null,
+    };
+
+    // Affecter une organisation du périmètre (TOTO/TUTU) → autorisé.
+    const within = await api.setUser(target!.id, {
+      ...base,
+      organizationId: ORG_TOTO_TUTU_ID,
+    });
+    expect(within).not.toBeNull();
+
+    // Éditer un utilisateur HORS du périmètre (organisation ABCD/) → refusé par le contrôle de périmètre.
+    const denied = await api.setUser(outside!.id, {
+      role: outside!.role,
+      additionalPermissions: outside!.additionalPermissions,
+      scopeOrganizationId: null,
+      organizationId: ORG_ABCD_ID,
+    });
+    expect(denied).toBeNull();
+  });
+});

--- a/e2e/tests/scope-acteurs.spec.ts
+++ b/e2e/tests/scope-acteurs.spec.ts
@@ -80,9 +80,9 @@ test.describe("Périmètres admin & groupes d'acteurs", () => {
     await admin.editUserRoleWithinScopeAndSave("qa-target@example.com");
   });
 
-  // Note : la frontière de périmètre se vérifie au niveau de l'autorisation (cœur de #14/#15). Le widget
-  // de recherche d'organisation ferme le modal d'édition en e2e (bug UI #1830) et un payload partiel
-  // déclenche une 500 (#1831) → on valide la règle via l'endpoint, avec le token du requérant scopé.
+  // Note : la frontière de périmètre se vérifie au niveau de l'autorisation (cœur de #14/#15). L'édition
+  // via l'UI est instable (le modal d'édition se ferme au rafraîchissement de la liste, #1830) et un
+  // payload partiel déclenche une 500 (#1831) → on valide la règle via l'endpoint, token du requérant scopé.
   test("SCP-04 - changer l'organisation dans le périmètre est autorisé, éditer un user hors périmètre est refusé", async ({
     page,
   }) => {

--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -128,9 +128,7 @@
       ],
       "authorizationServicesEnabled": false,
       "serviceAccountsEnabled": true,
-      "webOrigins": [
-        "+"
-      ],
+      "webOrigins": ["+"],
       "directAccessGrantsEnabled": true
     }
   ],
@@ -155,20 +153,11 @@
       "createdTimestamp": 1728673413023,
       "totp": false,
       "serviceAccountClientId": "referentiel-applications",
-      "realmRoles": [
-        "default-roles-referentiel-applications"
-      ],
+      "realmRoles": ["default-roles-referentiel-applications"],
       "clientRoles": {
-        "realm-management": [
-          "impersonation",
-          "create-client"
-        ],
-        "referentiel-applications": [
-          "USER"
-        ],
-        "broker": [
-          "read-token"
-        ],
+        "realm-management": ["impersonation", "create-client"],
+        "referentiel-applications": ["USER"],
+        "broker": ["read-token"],
         "account": [
           "view-groups",
           "manage-account",
@@ -191,13 +180,9 @@
       "enabled": true,
       "createdTimestamp": 1728673414000,
       "totp": false,
-      "realmRoles": [
-        "user"
-      ],
+      "realmRoles": ["user"],
       "clientRoles": {
-        "referentiel-applications": [
-          "USER"
-        ]
+        "referentiel-applications": ["USER"]
       },
       "credentials": [
         {
@@ -206,9 +191,7 @@
           "temporary": false
         }
       ],
-      "groups": [
-        "/admin"
-      ]
+      "groups": ["/admin"]
     },
     {
       "id": "f15d1c13-8198-4ca5-a180-94656e20d567",
@@ -220,13 +203,9 @@
       "enabled": true,
       "createdTimestamp": 1728673414000,
       "totp": false,
-      "realmRoles": [
-        "user"
-      ],
+      "realmRoles": ["user"],
       "clientRoles": {
-        "referentiel-applications": [
-          "USER"
-        ]
+        "referentiel-applications": ["USER"]
       },
       "credentials": [
         {
@@ -246,13 +225,75 @@
       "enabled": true,
       "createdTimestamp": 1728673414000,
       "totp": false,
-      "realmRoles": [
-        "user"
-      ],
+      "realmRoles": ["user"],
       "clientRoles": {
-        "referentiel-applications": [
-          "USER"
-        ]
+        "referentiel-applications": ["USER"]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "pass",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "f15d1c13-8198-4ca5-a180-94656e20d570",
+      "username": "scope-admin",
+      "email": "scope-admin@example.com",
+      "firstName": "Sandra",
+      "lastName": "Cope",
+      "emailVerified": true,
+      "enabled": true,
+      "createdTimestamp": 1728673414000,
+      "totp": false,
+      "realmRoles": ["user"],
+      "clientRoles": {
+        "referentiel-applications": ["USER"]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "pass",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "f15d1c13-8198-4ca5-a180-94656e20d571",
+      "username": "member-toto-tutu",
+      "email": "member-toto-tutu@example.com",
+      "firstName": "Tom",
+      "lastName": "Tutu",
+      "emailVerified": true,
+      "enabled": true,
+      "createdTimestamp": 1728673414000,
+      "totp": false,
+      "realmRoles": ["user"],
+      "clientRoles": {
+        "referentiel-applications": ["USER"]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "pass",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "f15d1c13-8198-4ca5-a180-94656e20d572",
+      "username": "member-toto",
+      "email": "member-toto@example.com",
+      "firstName": "Théo",
+      "lastName": "Toto",
+      "emailVerified": true,
+      "enabled": true,
+      "createdTimestamp": 1728673414000,
+      "totp": false,
+      "realmRoles": ["user"],
+      "clientRoles": {
+        "referentiel-applications": ["USER"]
       },
       "credentials": [
         {

--- a/qa/protocoles/catalogue.md
+++ b/qa/protocoles/catalogue.md
@@ -94,3 +94,17 @@
 - **Datafeature** : utilisateur `admin`.
 - **Action** : cliquer `application-export-btn`.
 - **Résultat attendu** : un fichier `.xlsx` est téléchargé, cohérent avec les filtres actifs.
+
+### CAT-16 — Bascule « Mes abonnements » ✅
+
+- **Action** : activer `my-apps-filter-toggle-subscribed`.
+- **Résultat attendu** : l'URL porte `subscribersEmail=true` ; la liste se restreint aux applications
+  auxquelles l'utilisateur est abonné.
+
+### CAT-17 — Colonnes avancées (MOA / MOE / Plateforme / Fournisseur) ✅
+
+- **Datafeature** : utilisateur disposant du droit `ColumnRead` (Lecteur ou plus).
+- **Action** : ouvrir `customize-columns-button`, cocher les colonnes MOA, MOE, Plateforme et
+  Fournisseur, fermer la boîte.
+- **Résultat attendu** : les quatre colonnes sont proposées dans la personnalisation et leurs en-têtes
+  apparaissent dans le tableau.

--- a/qa/protocoles/conformites.md
+++ b/qa/protocoles/conformites.md
@@ -1,0 +1,42 @@
+# Protocole de non-régression — Conformités : éco-conception & homologation (`CMP-`)
+
+> Onglet `tab-compliances` d'une fiche (`/applications/:id/tab-compliances`). Couvre les nouveautés
+> de l'issue #1825 : valeurs d'homologation, calcul/permission/réinitialisation de l'éco-index et
+> affichage du grade A→G. Utilisateur par défaut : `admin` / `pass`.
+
+| Légende           |                                                         |
+| :---------------- | :------------------------------------------------------ |
+| **Automatisé** ✅ | `e2e/tests/conformites.spec.ts`                         |
+| **Statut**        | ✅ 100 % des cas automatisés (POM strict + datafeature) |
+
+---
+
+### CMP-01 — Homologation : « Non réalisée » et « À mettre en place » ✅
+
+- **Datafeature** : 1ʳᵉ application existante.
+- **Action** : onglet `tab-compliances` → éditer l'homologation → sélectionner successivement « Non
+  réalisée » puis « À mettre en place » dans `compliance-homologation-status` et enregistrer.
+- **Résultat attendu** : le résumé de la ligne Homologation reflète chaque statut sélectionné ; un
+  toast « Conformité mise à jour avec succès » confirme l'enregistrement.
+
+### CMP-02 — Éco-index : seuls les droits d'écriture peuvent calculer ✅
+
+- **Datafeature** : 1ʳᵉ application + utilisateur `user` (Lecteur).
+- **Action** : ouvrir l'onglet conformités en `admin` puis en `user`, observer le bouton
+  `compliance-scan-ecoindex-btn` de la ligne Écoconception.
+- **Résultat attendu** : le bouton « Calculer » est actif pour un droit d'écriture (admin), désactivé
+  pour un Lecteur.
+
+### CMP-03 — Éco-index : modifier l'URL cible réinitialise le score ✅
+
+- **Datafeature** : 1ʳᵉ application avec un score éco-index pré-positionné (via la datafeature).
+- **Action** : éditer l'éco-conception, changer `ecoindex-target-url-input` puis enregistrer.
+- **Résultat attendu** : le résumé passe à « Non calculé » ; `eco_index_score` est remis à `null`
+  côté serveur.
+
+### CMP-04 — Éco-index : affichage du score et du grade A→G ✅
+
+- **Datafeature** : 1ʳᵉ application avec un score éco-index connu (via la datafeature).
+- **Action** : ouvrir l'onglet conformités après avoir posé un score de 95 puis de 12.
+- **Résultat attendu** : le résumé de la ligne Écoconception affiche le grade correspondant (95 → A,
+  12 → F) selon les seuils 80/70/55/40/25/10.

--- a/qa/protocoles/maia.md
+++ b/qa/protocoles/maia.md
@@ -1,0 +1,35 @@
+# Protocole de non-régression — Intégration MAIA (`MAI-`)
+
+> Couvre les cas #1-4 de l'issue #1825 (annuaire MAIA). La stack tourne avec `MOCK_MAIA_SERVICE=true`
+> (organisation mock « …SEINE-ET-MARNE… ») : les appels MAIA sont déterministes, sans dépendance
+> réseau externe. Utilisateur par défaut : `admin` / `pass`.
+
+| Légende           |                                                       |
+| :---------------- | :---------------------------------------------------- |
+| **Automatisé** ✅ | `e2e/tests/maia.spec.ts`                              |
+| **Statut**        | ✅ 100 % des cas automatisés (POM strict + mock MAIA) |
+
+---
+
+### MAI-01 — Première connexion : organisation MAIA assignée par défaut ✅
+
+- **Datafeature** : compte Keycloak `support` (jamais provisionné en base).
+- **Action** : se connecter pour la première fois en `support`.
+- **Résultat attendu** : l'organisation de l'utilisateur est renseignée depuis MAIA (chemin contenant « SEINE-ET-MARNE »).
+
+### MAI-02 — Import des informations d'un acteur depuis MAIA ✅
+
+- **Datafeature** : une application existante ; un email d'utilisateur existant.
+- **Action** : fiche application → onglet Acteurs → « Ajouter un acteur », saisir un email puis cliquer « Synchroniser depuis MAIA ».
+- **Résultat attendu** : toast « Organisation synchronisée depuis MAIA » ; les champs nom/prénom de l'acteur sont pré-remplis.
+
+### MAI-03 — Le champ email précède le champ organisation ✅
+
+- **Action** : ouvrir le formulaire d'ajout d'acteur.
+- **Résultat attendu** : le champ email est positionné au-dessus du champ organisation (ordre corrigé, cf. #1825).
+
+### MAI-04 — Batch admin : synchroniser les acteurs avec MAIA ✅
+
+- **Datafeature** : utilisateur `admin`.
+- **Action** : administration → onglet « Batch de données » → cliquer « Synchroniser les acteurs MAIA ».
+- **Résultat attendu** : toast « Batch MAIA lancé en tâche de fond » (traitement asynchrone déclenché). Ne pas spammer le bouton.

--- a/qa/protocoles/scope-acteurs.md
+++ b/qa/protocoles/scope-acteurs.md
@@ -1,0 +1,50 @@
+# Protocole de non-régression — Périmètres admin & groupes d'acteurs (`SCP-`)
+
+> Couvre les cas #12-17 de l'issue #1825. Fixtures déterministes fournies par le seed QA
+> (`pnpm db:seed:qa`) : organisations hiérarchiques `TOTO` / `TOTO/TUTU` / `ABCD`, comptes Keycloak
+> scopés (`scope-admin`, `member-toto-tutu`, `member-toto`, mot de passe `pass`), applications
+> `QA-SCOPE-*` et `QA-GROUP-*`. Signal « est admin / est acteur » sur une application = bouton
+> d'édition des informations actif.
+
+| Légende           |                                                                          |
+| :---------------- | :----------------------------------------------------------------------- |
+| **Automatisé** ✅ | `e2e/tests/scope-acteurs.spec.ts`                                        |
+| **Statut**        | ✅ 100 % des cas automatisés (POM strict + seed QA). SCP-04 : voir note. |
+
+---
+
+### SCP-01 — Admin scopé `TOTO/` est admin sur une app à acteur `TOTO/*` ✅
+
+- **Datafeature** : compte `scope-admin` (périmètre `TOTO/`), application `QA-SCOPE-TOTO` (acteur d'org `TOTO/TUTU`).
+- **Action** : se connecter en `scope-admin`, ouvrir la fiche de `QA-SCOPE-TOTO`, onglet Informations.
+- **Résultat attendu** : le bouton d'édition des informations est actif (droits d'admin sur cette application).
+
+### SCP-02 — Admin scopé `TOTO/` n'est PAS admin sur une app à acteur `ABCD/*` ✅
+
+- **Datafeature** : compte `scope-admin`, application `QA-SCOPE-ABCD` (acteur d'org `ABCD`).
+- **Action** : se connecter en `scope-admin`, ouvrir la fiche de `QA-SCOPE-ABCD`, onglet Informations.
+- **Résultat attendu** : le bouton d'édition des informations est désactivé (hors périmètre).
+
+### SCP-03 — Éditer le rôle d'un utilisateur dans mon périmètre ✅
+
+- **Datafeature** : `scope-admin` (périmètre `TOTO/`), utilisateur cible `qa-target` (org `TOTO/TUTU`).
+- **Action** : en `scope-admin`, panneau d'administration, éditer `qa-target`, changer son niveau de privilège et enregistrer.
+- **Résultat attendu** : toast de succès — le périmètre autorise l'édition d'un utilisateur de l'arborescence `TOTO/`.
+
+### SCP-04 — Édition dans le périmètre autorisée, édition hors périmètre refusée ✅
+
+- **Datafeature** : `scope-admin`, `qa-target` (org `TOTO/TUTU`, dans le périmètre), `qa-outside` (org `ABCD`, hors périmètre).
+- **Action** : en `scope-admin`, affecter à `qa-target` une organisation du périmètre (`TOTO/TUTU`) ; tenter d'éditer `qa-outside`.
+- **Résultat attendu** : l'édition de `qa-target` réussit ; l'édition de `qa-outside` est refusée par le contrôle de périmètre.
+
+### SCP-05 — Un membre de `TOTO/TUTU` est acteur via un groupe `TOTO/` ✅
+
+- **Datafeature** : compte `member-toto-tutu` (org `TOTO/TUTU`), application `QA-GROUP-PARENT` (groupe d'acteur d'org `TOTO`).
+- **Action** : se connecter en `member-toto-tutu`, ouvrir la fiche de `QA-GROUP-PARENT`, onglet Informations.
+- **Résultat attendu** : le bouton d'édition est actif — le membre hérite des droits du groupe d'acteur parent.
+
+### SCP-06 — Un membre de `TOTO` n'est PAS acteur via un groupe `TOTO/TUTU` ✅
+
+- **Datafeature** : compte `member-toto` (org `TOTO`), application `QA-GROUP-CHILD` (groupe d'acteur d'org `TOTO/TUTU`).
+- **Action** : se connecter en `member-toto`, ouvrir la fiche de `QA-GROUP-CHILD`, onglet Informations.
+- **Résultat attendu** : le bouton d'édition est désactivé — un groupe d'acteur enfant ne confère pas de droits au parent.

--- a/qa/scripts/campaign.mjs
+++ b/qa/scripts/campaign.mjs
@@ -46,6 +46,27 @@ const DOMAINS = [
     template: "qa-signalements-abonnements.md",
     colorLabel: "qa:signalements",
   },
+  {
+    domain: "conformites",
+    prefix: "CMP",
+    label: "Conformités (éco-conception & homologation)",
+    template: "qa-conformites.md",
+    colorLabel: "qa:conformites",
+  },
+  {
+    domain: "scope-acteurs",
+    prefix: "SCP",
+    label: "Périmètres admin & groupes d'acteurs",
+    template: "qa-scope-acteurs.md",
+    colorLabel: "qa:scope-acteurs",
+  },
+  {
+    domain: "maia",
+    prefix: "MAI",
+    label: "Intégration MAIA",
+    template: "qa-maia.md",
+    colorLabel: "qa:maia",
+  },
 ];
 
 function required(key) {


### PR DESCRIPTION
## Objectif

Automatise les **17 cas de test** de l'issue #1825 dans la suite de non-régression e2e (Playwright, POM strict), répartis en 3 lots.

## Couverture (#1825)

| Lot | Domaine | Cas | Tests |
|-----|---------|-----|-------|
| 1 | Conformités + Catalogue | #5-11 | `CMP-01→04`, `CAT-16/17` (+ `CAT-10` renforcé) |
| 2 | Périmètres admin & groupes d'acteurs | #12-17 | `SCP-01→06` |
| 3 | Intégration MAIA | #1-4 | `MAI-01→04` |

## Contenu

- 3 nouveaux protocoles (`qa/protocoles/`), 3 templates d'issue, 3 domaines ajoutés à `campaign.mjs` (8 issues de campagne au total).
- **Seed QA dédié** idempotent (`backend/prisma/seed-qa.ts` + `pnpm db:seed:qa`) : organisations hiérarchiques, utilisateurs scopés mappés par email, type d'acteur QA isolé, applications fixtures. Câblé dans `qa-campaign.yml`.
- 4 utilisateurs Keycloak de test ajoutés au realm.
- POM/datafeature étendus (conformités, colonnes, filtres, acteurs/MAIA, scope). Accès SQL ciblé (`e2e/support/db.ts`) pour provisionner le score éco-index (non inscriptible par API).

## Bugs découverts pendant l'automatisation

- #1830 — le modal d'édition d'un utilisateur se ferme seul au rafraîchissement de la liste.
- #1831 — 500 sur `PATCH /users/:id` quand `scopeOrganizationId` est omis.

## Validation

Campagne complète exécutée en CI sur cette branche : **tous les domaines e2e verts** (chromium), seed QA + mock MAIA + comptes Keycloak OK.