### PR TITLE
feat: millésime MDIT — campagnes dette IT + sélecteur Time + admin (#1848)

### DIFF
--- a/.github/ISSUE_TEMPLATE/qa-administration-referentiels.md
+++ b/.github/ISSUE_TEMPLATE/qa-administration-referentiels.md
@@ -21,7 +21,7 @@ labels: ["qa", "non-regression", "qa:administration-referentiels"]
 
 | Total | ✅ Passés | ❌ Échecs | ⏭️ Non testés |
 | ----- | --------- | --------- | ------------- |
-| 6     |           |           |               |
+| 7     |           |           |               |
 
 ## Protocole
 

--- a/.github/ISSUE_TEMPLATE/qa-time.md
+++ b/.github/ISSUE_TEMPLATE/qa-time.md
@@ -21,7 +21,7 @@ labels: ["qa", "non-regression", "qa:time"]
 
 | Total | ✅ Passés | ❌ Échecs | ⏭️ Non testés |
 | ----- | --------- | --------- | ------------- |
-| 4     |           |           |               |
+| 6     |           |           |               |
 
 ## Protocole
 

--- a/backend/prisma/docs/schema.md
+++ b/backend/prisma/docs/schema.md
@@ -81,6 +81,13 @@ erDiagram
   Int millesime
   DateTime createdAt
 }
+"MditCampaign" {
+  String id PK
+  Int year UK
+  String label "nullable"
+  Boolean isActive
+  DateTime createdAt
+}
 "_ApplicationToUser" {
   String A FK
   String B FK
@@ -220,6 +227,20 @@ Properties as follows:
 - `costMaturity`: Score de maturité des coûts (0-1)
 - `millesime`: Millésime (année) de la campagne dette IT à laquelle se rattache l'évaluation
 - `createdAt`: Date de création de l'évaluation
+
+### `MditCampaign`
+
+Campagne annuelle de dette IT (millésime), gérée par l'administration.
+Les évaluations de dette (`TechnicalDebtInfo.millesime`) se rattachent à
+l'année d'une campagne.
+
+Properties as follows:
+
+- `id`: Identifiant unique
+- `year`: Année de la campagne (millésime), unique
+- `label`: Libellé optionnel de la campagne
+- `isActive`: Campagne active : présentée dans le sélecteur de campagne
+- `createdAt`: Date de création
 
 ### `_ApplicationToUser`
 

--- a/backend/prisma/docs/schema.md
+++ b/backend/prisma/docs/schema.md
@@ -78,6 +78,7 @@ erDiagram
   Decimal(3) technicalMaturity
   Decimal(3) businessMaturity
   Decimal(3) costMaturity
+  Int millesime
   DateTime createdAt
 }
 "_ApplicationToUser" {
@@ -217,6 +218,7 @@ Properties as follows:
 - `technicalMaturity`: Score de maturité technique (0-1)
 - `businessMaturity`: Score de maturité métier (0-1)
 - `costMaturity`: Score de maturité des coûts (0-1)
+- `millesime`: Millésime (année) de la campagne dette IT à laquelle se rattache l'évaluation
 - `createdAt`: Date de création de l'évaluation
 
 ### `_ApplicationToUser`

--- a/backend/prisma/migrations/20260618120000_add_millesime_to_technical_debt_info/migration.sql
+++ b/backend/prisma/migrations/20260618120000_add_millesime_to_technical_debt_info/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "TechnicalDebtInfo" ADD COLUMN     "millesime" INTEGER NOT NULL DEFAULT (EXTRACT(YEAR FROM CURRENT_DATE))::integer;
+
+-- CreateIndex
+CREATE INDEX "TechnicalDebtInfo_applicationId_millesime_idx" ON "TechnicalDebtInfo"("applicationId", "millesime" DESC);

--- a/backend/prisma/migrations/20260618130000_add_mdit_campaign/migration.sql
+++ b/backend/prisma/migrations/20260618130000_add_mdit_campaign/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "MditCampaign" (
+    "id" TEXT NOT NULL,
+    "year" INTEGER NOT NULL,
+    "label" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MditCampaign_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MditCampaign_year_key" ON "MditCampaign"("year");
+
+-- CreateIndex
+CREATE INDEX "MditCampaign_year_idx" ON "MditCampaign"("year" DESC);

--- a/backend/prisma/schema/mdit-campaign.prisma
+++ b/backend/prisma/schema/mdit-campaign.prisma
@@ -1,0 +1,19 @@
+/// Campagne annuelle de dette IT (millésime), gérée par l'administration.
+/// Les évaluations de dette (`TechnicalDebtInfo.millesime`) se rattachent à
+/// l'année d'une campagne.
+///
+/// @namespace Applications
+model MditCampaign {
+  /// Identifiant unique
+  id        String   @id @default(uuid())
+  /// Année de la campagne (millésime), unique
+  year      Int      @unique
+  /// Libellé optionnel de la campagne
+  label     String?
+  /// Campagne active : présentée dans le sélecteur de campagne
+  isActive  Boolean  @default(true)
+  /// Date de création
+  createdAt DateTime @default(now())
+
+  @@index([year(sort: Desc)])
+}

--- a/backend/prisma/schema/technical-debt-info.prisma
+++ b/backend/prisma/schema/technical-debt-info.prisma
@@ -17,8 +17,11 @@ model TechnicalDebtInfo {
   businessMaturity  Decimal  @default(0) @db.Decimal(3, 2)
   /// Score de maturité des coûts (0-1)
   costMaturity      Decimal  @default(0) @db.Decimal(3, 2)
+  /// Millésime (année) de la campagne dette IT à laquelle se rattache l'évaluation
+  millesime         Int      @default(dbgenerated("(EXTRACT(YEAR FROM CURRENT_DATE))::integer"))
   /// Date de création de l'évaluation
   createdAt         DateTime @default(now())
 
   @@index([applicationId, createdAt(sort: Desc)])
+  @@index([applicationId, millesime(sort: Desc)])
 }

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -144,12 +144,23 @@ async function seed({
     });
   }
 
-  // Add technical debt info across several IT-debt campaigns (millésimes), so the
-  // campaign selector has previous years to pick from. The most recent campaign
-  // is the current year.
-  console.log("💸 Adding technical debt info...");
+  // Register the IT-debt campaigns (millésimes) managed by the admin. The most
+  // recent campaign is the current year; previous years let the selector offer
+  // earlier campaigns.
+  console.log("🗓️  Creating MDIT campaigns...");
   const currentYear = new Date().getFullYear();
   const campaignMillesimes = [currentYear - 2, currentYear - 1, currentYear];
+  for (const year of campaignMillesimes) {
+    await prisma.mditCampaign.upsert({
+      where: { year },
+      update: {},
+      create: { year, label: `Campagne dette IT ${year}`, isActive: true },
+    });
+  }
+
+  // Add technical debt info across the registered campaigns, so each application
+  // has data for every millésime.
+  console.log("💸 Adding technical debt info...");
   for (const app of applications) {
     for (const millesime of campaignMillesimes) {
       await TechnicalDebtInfoFaker.create({

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -144,13 +144,20 @@ async function seed({
     });
   }
 
-  // Add technical debt info
+  // Add technical debt info across several IT-debt campaigns (millésimes), so the
+  // campaign selector has previous years to pick from. The most recent campaign
+  // is the current year.
   console.log("💸 Adding technical debt info...");
+  const currentYear = new Date().getFullYear();
+  const campaignMillesimes = [currentYear - 2, currentYear - 1, currentYear];
   for (const app of applications) {
-    await TechnicalDebtInfoFaker.create({
-      application: app,
-      user: adminUser,
-    });
+    for (const millesime of campaignMillesimes) {
+      await TechnicalDebtInfoFaker.create({
+        application: app,
+        user: adminUser,
+        millesime,
+      });
+    }
   }
 
   // Create Business Division

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -29,6 +29,7 @@ import { TechnicalDebtInfoModule } from "./technical-debt-info/technical-debt-in
 import { TokenModule } from "./token/token.module";
 import { UserModule } from "./user/user.module";
 import { LabelSourceModule } from "./label-source/label-source.module";
+import { MditCampaignModule } from "./mdit-campaign/mdit-campaign.module";
 import { RgaaModule } from "./rgaa/rgaa.module";
 import { DataCatalogModule } from "./data-catalog/data-catalogue.module";
 import { OrganizationMaiaReferencesModule } from "./organization-maia-references/organization-maia-references.module";
@@ -60,6 +61,7 @@ import { OrganizationMaiaReferencesModule } from "./organization-maia-references
     HostingOptionModule,
     LabelsModule,
     LabelSourceModule,
+    MditCampaignModule,
     LinksModule,
     TagsModule,
     TechnicalDebtInfoModule,

--- a/backend/src/applications/application.service.ts
+++ b/backend/src/applications/application.service.ts
@@ -408,6 +408,10 @@ export class ApplicationService {
     return [];
   }
 
+  public async getTechnicalDebtMillesimes(): Promise<number[]> {
+    return this.applicationRepository.findDistinctMillesimes();
+  }
+
   public async exportApplications(): Promise<any[]> {
     return this.applicationRepository.findAllWithFullRelations();
   }

--- a/backend/src/applications/application.service.ts
+++ b/backend/src/applications/application.service.ts
@@ -360,6 +360,12 @@ export class ApplicationService {
     const { sortBy = "shortName", order = "asc" } = searchParams;
     const orderBy = this.prismaQueryBuilder.buildOrderBy(sortBy, order);
 
+    // Par défaut, on présente le millésime de campagne le plus récent disponible.
+    const millesime =
+      searchParams.millesime ??
+      (await this.applicationRepository.findLatestMillesime()) ??
+      undefined;
+
     const hasMDITList = await this.checkPermissions.can(
       [Permission.MDITList],
       requestor,
@@ -369,8 +375,12 @@ export class ApplicationService {
         searchParams,
         requestor,
       );
-      where.AND.push(this.prismaQueryBuilder.buildTechnicalDebtInfo());
-      return this.applicationRepository.findTechnicalDebtPoints(where, orderBy);
+      where.AND.push(this.prismaQueryBuilder.buildTechnicalDebtInfo(millesime));
+      return this.applicationRepository.findTechnicalDebtPoints(
+        where,
+        orderBy,
+        millesime,
+      );
     }
 
     const hasAppRead = await this.checkPermissions.can(
@@ -387,8 +397,12 @@ export class ApplicationService {
           businessDivisionId: requestor?.organization?.businessDivisionId,
         },
       );
-      where.AND.push(this.prismaQueryBuilder.buildTechnicalDebtInfo());
-      return this.applicationRepository.findTechnicalDebtPoints(where, orderBy);
+      where.AND.push(this.prismaQueryBuilder.buildTechnicalDebtInfo(millesime));
+      return this.applicationRepository.findTechnicalDebtPoints(
+        where,
+        orderBy,
+        millesime,
+      );
     }
 
     return [];

--- a/backend/src/applications/dto/search-application.dto.ts
+++ b/backend/src/applications/dto/search-application.dto.ts
@@ -418,4 +418,17 @@ export class ApplicationSearchDto extends PaginationDto {
   @IsOptional()
   @IsString()
   dataSourceName?: string;
+
+  @ApiPropertyOptional({
+    description:
+      "Millésime (année) de la campagne dette IT à présenter. " +
+      "Par défaut, le millésime le plus récent disponible.",
+    example: 2026,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(2000)
+  @Max(2100)
+  millesime?: number;
 }

--- a/backend/src/applications/infrastructure/repository/application.repository.interface.ts
+++ b/backend/src/applications/infrastructure/repository/application.repository.interface.ts
@@ -29,4 +29,5 @@ export interface IApplicationRepository {
     millesime?: number,
   ) => Promise<TechnicalDebtPointDto[]>;
   findLatestMillesime: () => Promise<number | null>;
+  findDistinctMillesimes: () => Promise<number[]>;
 }

--- a/backend/src/applications/infrastructure/repository/application.repository.interface.ts
+++ b/backend/src/applications/infrastructure/repository/application.repository.interface.ts
@@ -26,5 +26,7 @@ export interface IApplicationRepository {
   findTechnicalDebtPoints: (
     where: Prisma.ApplicationWhereInput,
     orderBy: Prisma.ApplicationOrderByWithRelationInput,
+    millesime?: number,
   ) => Promise<TechnicalDebtPointDto[]>;
+  findLatestMillesime: () => Promise<number | null>;
 }

--- a/backend/src/applications/infrastructure/repository/application.repository.ts
+++ b/backend/src/applications/infrastructure/repository/application.repository.ts
@@ -200,9 +200,21 @@ export class ApplicationRepository implements IApplicationRepository {
     } as unknown as ApplicationSearchResultDto;
   }
 
+  /**
+   * Millésime de campagne dette IT le plus récent enregistré, tous applications
+   * confondues. `null` s'il n'existe aucune évaluation.
+   */
+  public async findLatestMillesime(): Promise<number | null> {
+    const latest = await this.prisma.technicalDebtInfo.aggregate({
+      _max: { millesime: true },
+    });
+    return latest._max.millesime ?? null;
+  }
+
   public async findTechnicalDebtPoints(
     where: Prisma.ApplicationWhereInput,
     orderBy: Prisma.ApplicationOrderByWithRelationInput,
+    millesime?: number,
   ): Promise<TechnicalDebtPointDto[]> {
     const results = await this.prisma.application.findMany({
       where,
@@ -212,12 +224,14 @@ export class ApplicationRepository implements IApplicationRepository {
         label: true,
         shortName: true,
         technicalDebtInfo: {
+          where: millesime != null ? { millesime } : undefined,
           orderBy: { createdAt: "desc" as const },
           take: 1,
           select: {
             technicalMaturity: true,
             businessMaturity: true,
             costMaturity: true,
+            millesime: true,
           },
         },
       },

--- a/backend/src/applications/infrastructure/repository/application.repository.ts
+++ b/backend/src/applications/infrastructure/repository/application.repository.ts
@@ -211,6 +211,19 @@ export class ApplicationRepository implements IApplicationRepository {
     return latest._max.millesime ?? null;
   }
 
+  /**
+   * Millésimes de campagne dette IT disponibles, triés du plus récent au plus
+   * ancien.
+   */
+  public async findDistinctMillesimes(): Promise<number[]> {
+    const rows = await this.prisma.technicalDebtInfo.findMany({
+      distinct: ["millesime"],
+      select: { millesime: true },
+      orderBy: { millesime: "desc" },
+    });
+    return rows.map((row) => row.millesime);
+  }
+
   public async findTechnicalDebtPoints(
     where: Prisma.ApplicationWhereInput,
     orderBy: Prisma.ApplicationOrderByWithRelationInput,

--- a/backend/src/applications/prisma-query-builder.service.ts
+++ b/backend/src/applications/prisma-query-builder.service.ts
@@ -664,7 +664,9 @@ export class PrismaQueryBuilder {
     return sortOptions[sortKey] || { shortName: safeOrder };
   }
 
-  public buildTechnicalDebtInfo() {
-    return { technicalDebtInfo: { some: {} } };
+  public buildTechnicalDebtInfo(millesime?: number) {
+    return {
+      technicalDebtInfo: { some: millesime != null ? { millesime } : {} },
+    };
   }
 }

--- a/backend/src/mdit-campaign/dto/mdit-campaign.dto.ts
+++ b/backend/src/mdit-campaign/dto/mdit-campaign.dto.ts
@@ -1,0 +1,64 @@
+import { ApiProperty, ApiPropertyOptional, PartialType } from "@nestjs/swagger";
+import { Type } from "class-transformer";
+import {
+  IsBoolean,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from "class-validator";
+import { PaginationDto } from "src/common/dto";
+
+export class CreateMditCampaignDto {
+  @ApiProperty({
+    description: "Année de la campagne (millésime)",
+    example: 2027,
+    minimum: 2000,
+    maximum: 2100,
+  })
+  @Type(() => Number)
+  @IsInt()
+  @Min(2000)
+  @Max(2100)
+  year: number;
+
+  @ApiPropertyOptional({
+    description: "Libellé optionnel de la campagne",
+    example: "Campagne dette IT 2027",
+  })
+  @IsOptional()
+  @IsString()
+  label?: string;
+
+  @ApiPropertyOptional({
+    description: "Campagne active (présentée dans le sélecteur)",
+    example: true,
+    default: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}
+
+export class UpdateMditCampaignDto extends PartialType(CreateMditCampaignDto) {}
+
+export class MditCampaignFiltersDto extends PaginationDto {
+  @ApiPropertyOptional({
+    description: "Ne retourner que les campagnes actives",
+    example: true,
+  })
+  @IsOptional()
+  @Type(() => Boolean)
+  @IsBoolean()
+  onlyActive?: boolean;
+}
+
+export class MditCampaignDto extends CreateMditCampaignDto {
+  @ApiProperty({
+    description: "Identifiant unique de la campagne",
+    example: "5708d232-8338-4abf-8f38-8370acc89497",
+  })
+  @IsString()
+  id: string;
+}

--- a/backend/src/mdit-campaign/mdit-campaign.controller.ts
+++ b/backend/src/mdit-campaign/mdit-campaign.controller.ts
@@ -1,0 +1,99 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import {
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from "@nestjs/swagger";
+import { Permission } from "@prisma/client";
+import { RequiredPermissions } from "src/common/decorators/required-permissions.decorator";
+import { PaginatedResponseDto } from "src/common/dto";
+import { PermissionGuard } from "src/common/guards/permission.guard";
+import {
+  CreateMditCampaignDto,
+  MditCampaignDto,
+  MditCampaignFiltersDto,
+  UpdateMditCampaignDto,
+} from "./dto/mdit-campaign.dto";
+import { MditCampaignService } from "./mdit-campaign.service";
+
+@ApiTags("MDIT Campaigns")
+@Controller("mdit-campaigns")
+@UseGuards(PermissionGuard)
+export class MditCampaignController {
+  constructor(private readonly mditCampaignService: MditCampaignService) {}
+
+  @Post()
+  @RequiredPermissions([Permission.AdminPanelManage])
+  @ApiOperation({ summary: "Créer une campagne dette IT (millésime)" })
+  @HttpCode(201)
+  @ApiCreatedResponse({
+    description: "Campagne créée avec succès",
+    type: MditCampaignDto,
+  })
+  @ApiConflictResponse({
+    description: "Une campagne existe déjà pour ce millésime",
+  })
+  @ApiForbiddenResponse({
+    description: "Accès refusé - Privilège admin requis",
+  })
+  create(@Body() createDto: CreateMditCampaignDto) {
+    return this.mditCampaignService.createCampaign(createDto);
+  }
+
+  @Get()
+  @ApiOperation({
+    summary:
+      "Lister les campagnes dette IT, triées du millésime le plus récent au plus ancien",
+  })
+  @ApiOkResponse({
+    description: "Liste des campagnes",
+    type: PaginatedResponseDto.of(MditCampaignDto),
+  })
+  findAll(@Query() filters: MditCampaignFiltersDto) {
+    return this.mditCampaignService.findAllCampaigns(filters);
+  }
+
+  @Patch(":id")
+  @RequiredPermissions([Permission.AdminPanelManage])
+  @ApiOperation({ summary: "Modifier une campagne dette IT" })
+  @ApiOkResponse({ description: "Campagne mise à jour", type: MditCampaignDto })
+  @ApiConflictResponse({
+    description: "Une campagne existe déjà pour ce millésime",
+  })
+  @ApiForbiddenResponse({
+    description: "Accès refusé - Privilège admin requis",
+  })
+  @ApiNotFoundResponse({ description: "Campagne non trouvée" })
+  update(@Param("id") id: string, @Body() updateDto: UpdateMditCampaignDto) {
+    return this.mditCampaignService.updateCampaign(id, updateDto);
+  }
+
+  @Delete(":id")
+  @RequiredPermissions([Permission.AdminPanelManage])
+  @ApiOperation({ summary: "Supprimer une campagne dette IT" })
+  @HttpCode(204)
+  @ApiNoContentResponse({ description: "Campagne supprimée avec succès" })
+  @ApiForbiddenResponse({
+    description: "Accès refusé - Privilège admin requis",
+  })
+  @ApiNotFoundResponse({ description: "Campagne non trouvée" })
+  remove(@Param("id") id: string) {
+    return this.mditCampaignService.delete(id);
+  }
+}

--- a/backend/src/mdit-campaign/mdit-campaign.module.ts
+++ b/backend/src/mdit-campaign/mdit-campaign.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { CommonModule } from "src/common/common.module";
+import { PrismaModule } from "../prisma/prisma.module";
+import { MditCampaignController } from "./mdit-campaign.controller";
+import { MditCampaignService } from "./mdit-campaign.service";
+
+@Module({
+  imports: [PrismaModule, CommonModule],
+  controllers: [MditCampaignController],
+  providers: [MditCampaignService],
+  exports: [MditCampaignService],
+})
+export class MditCampaignModule {}

--- a/backend/src/mdit-campaign/mdit-campaign.service.ts
+++ b/backend/src/mdit-campaign/mdit-campaign.service.ts
@@ -1,0 +1,61 @@
+import type { MditCampaign, Prisma } from "@prisma/client";
+import { ConflictException, Injectable } from "@nestjs/common";
+import { BaseService } from "../common/base.service";
+import { PrismaService } from "../prisma/prisma.service";
+import { PaginatedResponseDto } from "src/common/dto";
+import {
+  CreateMditCampaignDto,
+  MditCampaignFiltersDto,
+} from "./dto/mdit-campaign.dto";
+
+@Injectable()
+export class MditCampaignService extends BaseService<MditCampaign> {
+  constructor(prisma: PrismaService) {
+    super(prisma.mditCampaign, prisma);
+  }
+
+  async createCampaign(dto: CreateMditCampaignDto): Promise<MditCampaign> {
+    const existing = await this.prisma.mditCampaign.findUnique({
+      where: { year: dto.year },
+    });
+    if (existing) {
+      throw new ConflictException(
+        `Une campagne existe déjà pour le millésime ${dto.year}`,
+      );
+    }
+    return this.create(dto);
+  }
+
+  async updateCampaign(
+    id: string,
+    dto: Partial<CreateMditCampaignDto>,
+  ): Promise<MditCampaign> {
+    if (dto.year != null) {
+      const existing = await this.prisma.mditCampaign.findUnique({
+        where: { year: dto.year },
+      });
+      if (existing && existing.id !== id) {
+        throw new ConflictException(
+          `Une campagne existe déjà pour le millésime ${dto.year}`,
+        );
+      }
+    }
+    return this.update(id, dto);
+  }
+
+  async findAllCampaigns(
+    filters?: MditCampaignFiltersDto,
+  ): Promise<PaginatedResponseDto<MditCampaign>> {
+    const where: Prisma.MditCampaignWhereInput = {};
+    if (filters?.onlyActive) {
+      where.isActive = true;
+    }
+
+    return this.findAll({
+      where,
+      orderBy: [{ year: "desc" }],
+      page: filters?.page,
+      pageSize: filters?.pageSize,
+    });
+  }
+}

--- a/backend/src/technical-debt-info/dto/create-technical-debt-info.dto.ts
+++ b/backend/src/technical-debt-info/dto/create-technical-debt-info.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNumber, IsOptional, Max, Min } from "class-validator";
+import { Type } from "class-transformer";
+import { IsInt, IsNumber, IsOptional, Max, Min } from "class-validator";
 
 export class CreateTechnicalDebtInfoDto {
   @ApiProperty({
@@ -40,6 +41,21 @@ export class CreateTechnicalDebtInfoDto {
   @Min(0)
   @Max(5)
   costMaturity?: number;
+
+  @ApiProperty({
+    example: 2026,
+    description:
+      "Millésime (année) de la campagne dette IT. Par défaut, l'année courante.",
+    required: false,
+    minimum: 2000,
+    maximum: 2100,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(2000)
+  @Max(2100)
+  millesime?: number;
 }
 
 export class TechnicalDebtInfoDto extends CreateTechnicalDebtInfoDto {

--- a/backend/src/technical-debt-info/entities/technical-debt-info.entity.ts
+++ b/backend/src/technical-debt-info/entities/technical-debt-info.entity.ts
@@ -4,4 +4,5 @@ export class TechnicalDebtInfo {
   technicalMaturity?: number | null;
   businessMaturity?: number | null;
   costMaturity?: number | null;
+  millesime?: number | null;
 }

--- a/backend/src/technical-debt-info/technical-debt.controller.ts
+++ b/backend/src/technical-debt-info/technical-debt.controller.ts
@@ -31,4 +31,20 @@ export class TechnicalDebtController {
       requestor,
     );
   }
+
+  @Get("millesimes")
+  @ApiOperation({
+    summary: "Lister les millésimes de campagne dette IT disponibles",
+    description:
+      "Retourne les millésimes (années) de campagne dette IT enregistrés, " +
+      "triés du plus récent au plus ancien.",
+  })
+  @ApiOkResponse({
+    description: "Liste des millésimes disponibles",
+    type: Number,
+    isArray: true,
+  })
+  async getMillesimes(): Promise<number[]> {
+    return this.applicationService.getTechnicalDebtMillesimes();
+  }
 }

--- a/backend/tests/fakers/technical-debt-info.faker.ts
+++ b/backend/tests/fakers/technical-debt-info.faker.ts
@@ -9,6 +9,7 @@ export class TechnicalDebtInfoFaker {
     technicalMaturity?: number | null;
     businessMaturity?: number | null;
     costMaturity?: number | null;
+    millesime?: number;
   }) {
     const prisma = getPrismaClient();
 
@@ -43,6 +44,9 @@ export class TechnicalDebtInfoFaker {
           faker.helpers.maybe(() =>
             faker.number.float({ min: 0, max: 5, multipleOf: 0.01 }),
           ),
+        ...(restOverride.millesime != null
+          ? { millesime: restOverride.millesime }
+          : {}),
       },
     });
   }

--- a/backend/tests/mdit-campaign.e2e-spec.ts
+++ b/backend/tests/mdit-campaign.e2e-spec.ts
@@ -1,0 +1,134 @@
+import type { UserFakerReturnType } from "./fakers/user.faker";
+import { Roles } from "@prisma/client";
+import request from "supertest";
+import { UserFaker } from "./fakers/user.faker";
+import { getToken } from "./getToken";
+import { setupTestSuite } from "./setup";
+
+describe("MditCampaign", () => {
+  const app = setupTestSuite();
+  let admin: UserFakerReturnType;
+  let contributor: UserFakerReturnType;
+  let ADMIN_TOKEN: string;
+  let CONTRIBUTOR_TOKEN: string;
+  // Millésimes dédiés au test (hors campagnes seedées), supprimés en fin de suite.
+  const YEAR_A = 2090;
+  const YEAR_B = 2091;
+  const createdIds: string[] = [];
+
+  beforeAll(async () => {
+    admin = await UserFaker.create({ role: Roles.ADMIN });
+    contributor = await UserFaker.create({ role: Roles.CONTRIBUTOR });
+    ADMIN_TOKEN = await getToken(admin);
+    CONTRIBUTOR_TOKEN = await getToken(contributor);
+  });
+
+  afterAll(async () => {
+    for (const id of createdIds) {
+      await request(app().getHttpServer())
+        .delete(`/mdit-campaigns/${id}`)
+        .set("Authorization", `Bearer ${ADMIN_TOKEN}`);
+    }
+  });
+
+  it("/POST mdit-campaigns - should reject a non-admin user", async () => {
+    await request(app().getHttpServer())
+      .post("/mdit-campaigns")
+      .send({ year: YEAR_A })
+      .set("Authorization", `Bearer ${CONTRIBUTOR_TOKEN}`)
+      .expect(403);
+  });
+
+  it("/POST mdit-campaigns - should create a campaign as admin", async () => {
+    const response = await request(app().getHttpServer())
+      .post("/mdit-campaigns")
+      .send({ year: YEAR_A, label: "Campagne test A" })
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .expect(201);
+
+    expect(response.body.id).toBeDefined();
+    expect(response.body.year).toEqual(YEAR_A);
+    expect(response.body.label).toEqual("Campagne test A");
+    expect(response.body.isActive).toBe(true);
+    createdIds.push(response.body.id);
+  });
+
+  it("/POST mdit-campaigns - should reject a duplicate millesime", async () => {
+    await request(app().getHttpServer())
+      .post("/mdit-campaigns")
+      .send({ year: YEAR_A })
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .expect(409);
+  });
+
+  it("/POST mdit-campaigns - should reject an out-of-range millesime", async () => {
+    await request(app().getHttpServer())
+      .post("/mdit-campaigns")
+      .send({ year: 1999 })
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .expect(400);
+  });
+
+  it("/GET mdit-campaigns - should list campaigns sorted by year desc", async () => {
+    const response = await request(app().getHttpServer())
+      .post("/mdit-campaigns")
+      .send({ year: YEAR_B, isActive: false })
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .expect(201);
+    createdIds.push(response.body.id);
+
+    const list = await request(app().getHttpServer())
+      .get("/mdit-campaigns")
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .expect(200);
+
+    const years: number[] = list.body.results.map(
+      (c: { year: number }) => c.year,
+    );
+    expect(years).toContain(YEAR_A);
+    expect(years).toContain(YEAR_B);
+    expect(years).toEqual([...years].sort((a, b) => b - a));
+  });
+
+  it("/GET mdit-campaigns?onlyActive=true - should exclude inactive campaigns", async () => {
+    const list = await request(app().getHttpServer())
+      .get("/mdit-campaigns")
+      .query({ onlyActive: true, pageSize: 100 })
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .expect(200);
+
+    const years: number[] = list.body.results.map(
+      (c: { year: number }) => c.year,
+    );
+    expect(years).toContain(YEAR_A);
+    expect(years).not.toContain(YEAR_B); // YEAR_B a été créé inactif
+  });
+
+  it("/PATCH mdit-campaigns/:id - should update a campaign as admin", async () => {
+    const id = createdIds[0];
+    const response = await request(app().getHttpServer())
+      .patch(`/mdit-campaigns/${id}`)
+      .send({ label: "Campagne test A modifiée", isActive: false })
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .expect(200);
+
+    expect(response.body.label).toEqual("Campagne test A modifiée");
+    expect(response.body.isActive).toBe(false);
+  });
+
+  it("/PATCH mdit-campaigns/:id - should reject a non-admin user", async () => {
+    await request(app().getHttpServer())
+      .patch(`/mdit-campaigns/${createdIds[0]}`)
+      .send({ label: "x" })
+      .set("Authorization", `Bearer ${CONTRIBUTOR_TOKEN}`)
+      .expect(403);
+  });
+
+  it("/DELETE mdit-campaigns/:id - should delete a campaign as admin", async () => {
+    const id = createdIds.pop()!;
+    await request(app().getHttpServer())
+      .delete(`/mdit-campaigns/${id}`)
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .expect(204);
+  });
+});

--- a/backend/tests/technical-debt-info.e2e-spec.ts
+++ b/backend/tests/technical-debt-info.e2e-spec.ts
@@ -43,6 +43,35 @@ describe("TechnicalDebtInfo", () => {
     expect(response.body.technicalMaturity).toEqual(3.25);
     expect(response.body.businessMaturity).toEqual(4.1);
     expect(response.body.costMaturity).toEqual(2.75);
+    // Le millésime est renseigné par défaut avec l'année courante.
+    expect(response.body.millesime).toEqual(new Date().getFullYear());
+  });
+
+  it("/POST applications/:applicationId/technical-debt-info - should accept an explicit millesime", async () => {
+    const newApplication = await ApplicationFaker.create(user);
+
+    const response = await request(app().getHttpServer())
+      .post(`/applications/${newApplication.id}/technical-debt-info`)
+      .send({
+        technicalMaturity: 2,
+        millesime: 2024,
+      })
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .expect(201);
+
+    expect(response.body.millesime).toEqual(2024);
+  });
+
+  it("/POST applications/:applicationId/technical-debt-info - should reject an out-of-range millesime", async () => {
+    const newApplication = await ApplicationFaker.create(user);
+
+    await request(app().getHttpServer())
+      .post(`/applications/${newApplication.id}/technical-debt-info`)
+      .send({
+        millesime: 1999,
+      })
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .expect(400);
   });
 
   it("/GET applications/:applicationId/technical-debt-info - should return the technical debt info", async () => {
@@ -208,5 +237,49 @@ describe("TechnicalDebts", () => {
     const resultIds = response.body.map((item: { id: string }) => item.id);
     expect(resultIds).toContain(applicationA.id);
     expect(resultIds).not.toContain(applicationB.id);
+  });
+
+  it("/GET technical-debts - should filter by millesime and default to the latest", async () => {
+    const application = await ApplicationFaker.create(user);
+
+    // Deux campagnes pour la même application.
+    await request(app().getHttpServer())
+      .post(`/applications/${application.id}/technical-debt-info`)
+      .send({ technicalMaturity: 1, millesime: 2030 })
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .expect(201);
+    await request(app().getHttpServer())
+      .post(`/applications/${application.id}/technical-debt-info`)
+      .send({ technicalMaturity: 4, millesime: 2031 })
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .expect(201);
+
+    // Millésime explicite : on récupère la campagne demandée.
+    const filtered = await request(app().getHttpServer())
+      .get("/technical-debts")
+      .query({ label: application.label, millesime: 2030 })
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .expect(200);
+
+    const point2030 = filtered.body.find(
+      (item: { id: string }) => item.id === application.id,
+    );
+    expect(point2030).toBeDefined();
+    expect(point2030.technicalDebtInfo.millesime).toEqual(2030);
+    expect(point2030.technicalDebtInfo.technicalMaturity).toEqual(1);
+
+    // Sans millésime : on présente la campagne la plus récente.
+    const latest = await request(app().getHttpServer())
+      .get("/technical-debts")
+      .query({ label: application.label })
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .expect(200);
+
+    const pointLatest = latest.body.find(
+      (item: { id: string }) => item.id === application.id,
+    );
+    expect(pointLatest).toBeDefined();
+    expect(pointLatest.technicalDebtInfo.millesime).toEqual(2031);
+    expect(pointLatest.technicalDebtInfo.technicalMaturity).toEqual(4);
   });
 });

--- a/backend/tests/technical-debt-info.e2e-spec.ts
+++ b/backend/tests/technical-debt-info.e2e-spec.ts
@@ -196,12 +196,17 @@ describe("TechnicalDebts", () => {
   let TOKEN: string;
   let applicationA: AsyncReturnType<typeof ApplicationFaker.create>;
   let applicationB: AsyncReturnType<typeof ApplicationFaker.create>;
+  const currentYear = new Date().getFullYear();
+  // Applications créées par les tests : supprimées en fin de suite (le cascade
+  // retire leurs entrées de dette, pour ne pas polluer le millésime « courant »).
+  const createdAppIds: string[] = [];
 
   beforeAll(async () => {
     user = await UserFaker.create({ role: Roles.CONTRIBUTOR });
     TOKEN = await getToken(user);
     applicationA = await ApplicationFaker.create(user);
     applicationB = await ApplicationFaker.create(user);
+    createdAppIds.push(applicationA.id, applicationB.id);
 
     await request(app().getHttpServer())
       .post(`/applications/${applicationA.id}/technical-debt-info`)
@@ -224,6 +229,12 @@ describe("TechnicalDebts", () => {
       .expect(201);
   });
 
+  afterAll(async () => {
+    for (const id of createdAppIds) {
+      await ApplicationFaker.delete(id);
+    }
+  });
+
   it("/GET technical-debts - should return points and honor filters", async () => {
     const response = await request(app().getHttpServer())
       .get("/technical-debts")
@@ -241,34 +252,36 @@ describe("TechnicalDebts", () => {
 
   it("/GET technical-debts - should filter by millesime and default to the latest", async () => {
     const application = await ApplicationFaker.create(user);
+    createdAppIds.push(application.id);
+    const previousYear = currentYear - 1;
 
-    // Deux campagnes pour la même application.
+    // Deux campagnes pour la même application : l'an dernier et l'année courante.
     await request(app().getHttpServer())
       .post(`/applications/${application.id}/technical-debt-info`)
-      .send({ technicalMaturity: 1, millesime: 2030 })
+      .send({ technicalMaturity: 1, millesime: previousYear })
       .set("Authorization", `Bearer ${TOKEN}`)
       .expect(201);
     await request(app().getHttpServer())
       .post(`/applications/${application.id}/technical-debt-info`)
-      .send({ technicalMaturity: 4, millesime: 2031 })
+      .send({ technicalMaturity: 4, millesime: currentYear })
       .set("Authorization", `Bearer ${TOKEN}`)
       .expect(201);
 
     // Millésime explicite : on récupère la campagne demandée.
     const filtered = await request(app().getHttpServer())
       .get("/technical-debts")
-      .query({ label: application.label, millesime: 2030 })
+      .query({ label: application.label, millesime: previousYear })
       .set("Authorization", `Bearer ${TOKEN}`)
       .expect(200);
 
-    const point2030 = filtered.body.find(
+    const pointPrevious = filtered.body.find(
       (item: { id: string }) => item.id === application.id,
     );
-    expect(point2030).toBeDefined();
-    expect(point2030.technicalDebtInfo.millesime).toEqual(2030);
-    expect(point2030.technicalDebtInfo.technicalMaturity).toEqual(1);
+    expect(pointPrevious).toBeDefined();
+    expect(pointPrevious.technicalDebtInfo.millesime).toEqual(previousYear);
+    expect(pointPrevious.technicalDebtInfo.technicalMaturity).toEqual(1);
 
-    // Sans millésime : on présente la campagne la plus récente.
+    // Sans millésime : on présente la campagne la plus récente (année courante).
     const latest = await request(app().getHttpServer())
       .get("/technical-debts")
       .query({ label: application.label })
@@ -279,7 +292,36 @@ describe("TechnicalDebts", () => {
       (item: { id: string }) => item.id === application.id,
     );
     expect(pointLatest).toBeDefined();
-    expect(pointLatest.technicalDebtInfo.millesime).toEqual(2031);
+    expect(pointLatest.technicalDebtInfo.millesime).toEqual(currentYear);
     expect(pointLatest.technicalDebtInfo.technicalMaturity).toEqual(4);
+  });
+
+  it("/GET technical-debts/millesimes - should list available campaigns sorted desc", async () => {
+    const application = await ApplicationFaker.create(user);
+    createdAppIds.push(application.id);
+    // Deux millésimes passés distincts (n'altèrent pas le « plus récent » global).
+    const older = currentYear - 5;
+    const newer = currentYear - 4;
+    for (const millesime of [older, newer]) {
+      await request(app().getHttpServer())
+        .post(`/applications/${application.id}/technical-debt-info`)
+        .send({ technicalMaturity: 3, millesime })
+        .set("Authorization", `Bearer ${TOKEN}`)
+        .expect(201);
+    }
+
+    const response = await request(app().getHttpServer())
+      .get("/technical-debts/millesimes")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .expect(200);
+
+    const millesimes: number[] = response.body;
+    expect(Array.isArray(millesimes)).toBe(true);
+    expect(millesimes).toContain(older);
+    expect(millesimes).toContain(newer);
+    // Pas de doublon et tri décroissant.
+    expect(new Set(millesimes).size).toEqual(millesimes.length);
+    expect(millesimes).toEqual([...millesimes].sort((a, b) => b - a));
+    expect(millesimes.indexOf(newer)).toBeLessThan(millesimes.indexOf(older));
   });
 });

--- a/e2e/fixtures/api-client.ts
+++ b/e2e/fixtures/api-client.ts
@@ -118,6 +118,22 @@ export class ApiClient {
     return this.get<{ id: string; email: string }>(`/users/me`);
   }
 
+  /** Millésimes de campagne dette IT disponibles (triés du plus récent au plus ancien). */
+  technicalDebtMillesimes(): Promise<number[] | null> {
+    return this.get<number[]>(`/technical-debts/millesimes`);
+  }
+
+  /** Crée une évaluation de dette technique (campagne `millesime`) pour une application. */
+  createTechnicalDebtInfo(
+    appId: string,
+    body: Record<string, unknown>,
+  ): Promise<{ id: string; millesime?: number } | null> {
+    return this.post<{ id: string; millesime?: number }>(
+      `/applications/${appId}/technical-debt-info`,
+      body,
+    );
+  }
+
   /** Profil complet de l'utilisateur courant (inclut `organization`). */
   meRaw(): Promise<Record<string, unknown> | null> {
     return this.get<Record<string, unknown>>(`/users/me`);

--- a/e2e/fixtures/api-client.ts
+++ b/e2e/fixtures/api-client.ts
@@ -123,6 +123,29 @@ export class ApiClient {
     return this.get<number[]>(`/technical-debts/millesimes`);
   }
 
+  /** Campagnes dette IT (millésimes) gérées par l'admin, actives, triées desc. */
+  mditCampaigns(): Promise<Paginated<{ id: string; year: number }> | null> {
+    return this.get<Paginated<{ id: string; year: number }>>(
+      `/mdit-campaigns?onlyActive=true&pageSize=100&page=0`,
+    );
+  }
+
+  /** Crée une campagne dette IT (requiert AdminPanelManage). */
+  createMditCampaign(
+    body: Record<string, unknown>,
+  ): Promise<{ id: string; year: number } | null> {
+    return this.post<{ id: string; year: number }>(`/mdit-campaigns`, body);
+  }
+
+  /** Supprime la campagne du millésime donné si elle existe (idempotence des tests). */
+  async deleteMditCampaignByYear(year: number): Promise<void> {
+    const list = await this.get<Paginated<{ id: string; year: number }>>(
+      `/mdit-campaigns?pageSize=100&page=0`,
+    );
+    const found = list?.results?.find((c) => c.year === year);
+    if (found) await this.del(`/mdit-campaigns/${found.id}`);
+  }
+
   /** Crée une évaluation de dette technique (campagne `millesime`) pour une application. */
   createTechnicalDebtInfo(
     appId: string,

--- a/e2e/fixtures/datafeature.ts
+++ b/e2e/fixtures/datafeature.ts
@@ -90,6 +90,45 @@ export class DataFeature {
     return this.api.me();
   }
 
+  // --- Campagnes dette IT / millésimes (TIM-05/06) ---
+
+  /** Millésimes de campagne dette IT disponibles, triés du plus récent au plus ancien. */
+  async availableMillesimes(): Promise<number[]> {
+    const list = await this.api.technicalDebtMillesimes();
+    return (list ?? []).slice().sort((a, b) => b - a);
+  }
+
+  /**
+   * Garantit l'existence d'au moins deux campagnes dette IT (millésimes) afin de
+   * pouvoir tester le sélecteur. Sème une campagne précédente sur la première
+   * application si nécessaire (jamais un millésime futur, pour ne pas altérer le
+   * « plus récent » présenté par défaut). Renvoie les deux millésimes les plus
+   * récents `[latest, previous]`, ou `null` si l'état ne peut être garanti.
+   */
+  async ensureTwoMillesimes(): Promise<[number, number] | null> {
+    const existing = await this.availableMillesimes();
+    if (existing.length >= 2) return [existing[0], existing[1]];
+
+    const app = await this.firstApplication();
+    if (!app) return null;
+
+    const latest = existing[0] ?? new Date().getFullYear();
+    const previous = latest - 1;
+    if (existing.length === 0) {
+      await this.api.createTechnicalDebtInfo(app.id, {
+        technicalMaturity: 3,
+        millesime: latest,
+      });
+    }
+    await this.api.createTechnicalDebtInfo(app.id, {
+      technicalMaturity: 2,
+      millesime: previous,
+    });
+
+    const refreshed = await this.availableMillesimes();
+    return refreshed.length >= 2 ? [refreshed[0], refreshed[1]] : null;
+  }
+
   // --- Provisioning pour les tests de permissions (effectué avec le token admin) ---
 
   /** Récupère un utilisateur (admin) par email. */

--- a/e2e/fixtures/datafeature.ts
+++ b/e2e/fixtures/datafeature.ts
@@ -92,41 +92,38 @@ export class DataFeature {
 
   // --- Campagnes dette IT / millésimes (TIM-05/06) ---
 
-  /** Millésimes de campagne dette IT disponibles, triés du plus récent au plus ancien. */
-  async availableMillesimes(): Promise<number[]> {
-    const list = await this.api.technicalDebtMillesimes();
-    return (list ?? []).slice().sort((a, b) => b - a);
+  /** Millésimes des campagnes dette IT actives, triés du plus récent au plus ancien. */
+  async availableCampaignYears(): Promise<number[]> {
+    const list = await this.api.mditCampaigns();
+    return (list?.results ?? [])
+      .map((c) => c.year)
+      .slice()
+      .sort((a, b) => b - a);
   }
 
   /**
-   * Garantit l'existence d'au moins deux campagnes dette IT (millésimes) afin de
-   * pouvoir tester le sélecteur. Sème une campagne précédente sur la première
-   * application si nécessaire (jamais un millésime futur, pour ne pas altérer le
-   * « plus récent » présenté par défaut). Renvoie les deux millésimes les plus
-   * récents `[latest, previous]`, ou `null` si l'état ne peut être garanti.
+   * Garantit l'existence d'au moins deux campagnes dette IT afin de pouvoir tester
+   * le sélecteur. Crée une campagne précédente (jamais future, pour ne pas altérer
+   * la campagne la plus récente présentée par défaut) via l'API admin si besoin.
+   * Renvoie les deux millésimes les plus récents `[latest, previous]`, ou `null`.
    */
-  async ensureTwoMillesimes(): Promise<[number, number] | null> {
-    const existing = await this.availableMillesimes();
+  async ensureTwoCampaigns(): Promise<[number, number] | null> {
+    const existing = await this.availableCampaignYears();
     if (existing.length >= 2) return [existing[0], existing[1]];
 
-    const app = await this.firstApplication();
-    if (!app) return null;
-
     const latest = existing[0] ?? new Date().getFullYear();
-    const previous = latest - 1;
     if (existing.length === 0) {
-      await this.api.createTechnicalDebtInfo(app.id, {
-        technicalMaturity: 3,
-        millesime: latest,
-      });
+      await this.api.createMditCampaign({ year: latest });
     }
-    await this.api.createTechnicalDebtInfo(app.id, {
-      technicalMaturity: 2,
-      millesime: previous,
-    });
+    await this.api.createMditCampaign({ year: latest - 1 });
 
-    const refreshed = await this.availableMillesimes();
+    const refreshed = await this.availableCampaignYears();
     return refreshed.length >= 2 ? [refreshed[0], refreshed[1]] : null;
+  }
+
+  /** Supprime la campagne d'un millésime si elle existe (idempotence des tests admin). */
+  removeCampaignYear(year: number): Promise<void> {
+    return this.api.deleteMditCampaignByYear(year);
   }
 
   // --- Provisioning pour les tests de permissions (effectué avec le token admin) ---

--- a/e2e/pom/admin.page.ts
+++ b/e2e/pom/admin.page.ts
@@ -376,6 +376,43 @@ export class AdminPage extends BasePage {
     await this.expectToaster(/Source supprimée avec succès/i);
   }
 
+  // --- Onglet « Campagnes dette IT » (ADM-07) ---
+
+  private campaignsTable = () => this.byTestId("admin-campaigns-table");
+
+  async openCampaignsTab(): Promise<void> {
+    await this.adminTabs()
+      .getByRole("tab", { name: /campagnes dette/i })
+      .click();
+    await expect(this.campaignsTable()).toBeVisible();
+  }
+
+  async createCampaign(year: number, label?: string): Promise<void> {
+    await this.byTestId("admin-create-campaign-btn").click();
+    const dialog = this.visibleDialog();
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel(/Millésime/i).fill(String(year));
+    if (label) {
+      await dialog.getByLabel(/Libellé/i).fill(label);
+    }
+    await dialog.getByRole("button", { name: /Enregistrer/i }).click();
+    await this.expectToaster(/Campagne créée avec succès/i);
+  }
+
+  async expectCampaignRow(year: number): Promise<void> {
+    await expect(this.campaignsTable()).toContainText(String(year));
+  }
+
+  async deleteCampaign(year: number): Promise<void> {
+    const row = this.campaignsTable().locator("tr", { hasText: String(year) });
+    await row.getByTestId("admin-campaign-delete-btn").click();
+    await expect(
+      this.byTestId("admin-campaign-delete-confirm-btn"),
+    ).toBeVisible();
+    await this.byTestId("admin-campaign-delete-confirm-btn").click();
+    await this.expectToaster(/Campagne supprimée avec succès/i);
+  }
+
   // --- Onglet « Batch de données » : synchronisation MAIA (#1825, MAI-04) ---
   async openBatchDataTab(): Promise<void> {
     await this.adminTabs()

--- a/e2e/pom/time.page.ts
+++ b/e2e/pom/time.page.ts
@@ -15,9 +15,18 @@ export class TimePage extends BasePage {
   // L'aria-label du SVG est posé dynamiquement par D3 (« …maturites TIME »).
   private scatter = () => this.page.getByRole("img", { name: /maturit/i });
   private empty = () => this.byTestId("technical-debt-empty");
-  // Sélecteur de campagne dette IT (millésime). Le `data-testid` du DsfrSelect porte le <select>.
+  // Sélecteur de campagne dette IT (millésime), dans l'accordéon « Général » de la sidebar.
+  // Le `data-testid` du DsfrSelect porte le <select>.
+  private generalAccordion = () => this.byTestId("sidebar-accordion-general");
   private millesimeSelector = () => this.byTestId("time-millesime");
   private millesimeSelect = () => this.byTestId("time-millesime-select");
+
+  /** Déploie l'accordéon « Général » si le sélecteur de campagne n'est pas déjà visible. */
+  private async ensureCampaignVisible(): Promise<void> {
+    if (await this.millesimeSelector().isVisible()) return;
+    await this.generalAccordion().getByRole("button").first().click();
+    await expect(this.millesimeSelector()).toBeVisible();
+  }
 
   async open(): Promise<void> {
     await this.goto("/time");
@@ -40,18 +49,21 @@ export class TimePage extends BasePage {
     await expect(this.filters()).toBeVisible();
   }
 
-  /** Le sélecteur de campagne dette IT (millésime) est présent. */
+  /** Le sélecteur de campagne dette IT (millésime) est présent (accordéon « Général »). */
   async expectMillesimeSelectorPresent(): Promise<void> {
+    await this.ensureCampaignVisible();
     await expect(this.millesimeSelector()).toBeVisible();
   }
 
   /** Millésime actuellement sélectionné dans le sélecteur de campagne. */
   async selectedMillesime(): Promise<string> {
+    await this.ensureCampaignVisible();
     return this.millesimeSelect().inputValue();
   }
 
   /** Millésimes proposés par le sélecteur (valeurs numériques, hors option vide). */
   async availableMillesimes(): Promise<string[]> {
+    await this.ensureCampaignVisible();
     const values = await this.millesimeSelect()
       .locator("option")
       .evaluateAll((options) =>
@@ -62,6 +74,7 @@ export class TimePage extends BasePage {
 
   /** Sélectionne un millésime et attend sa propagation dans l'URL (`millesime`). */
   async selectMillesime(year: string): Promise<void> {
+    await this.ensureCampaignVisible();
     await this.millesimeSelect().selectOption(year);
     await waitForSearchParams(
       this.page,

--- a/e2e/pom/time.page.ts
+++ b/e2e/pom/time.page.ts
@@ -1,5 +1,6 @@
 import { expect } from "@playwright/test";
 import { BasePage } from "./base.page";
+import { waitForSearchParams } from "../support/helpers";
 
 /**
  * Page Object — Diagramme Time (`/time`, `TimePage`) : nuage de points D3 de maturité TIME (dette
@@ -14,6 +15,9 @@ export class TimePage extends BasePage {
   // L'aria-label du SVG est posé dynamiquement par D3 (« …maturites TIME »).
   private scatter = () => this.page.getByRole("img", { name: /maturit/i });
   private empty = () => this.byTestId("technical-debt-empty");
+  // Sélecteur de campagne dette IT (millésime). Le `data-testid` du DsfrSelect porte le <select>.
+  private millesimeSelector = () => this.byTestId("time-millesime");
+  private millesimeSelect = () => this.byTestId("time-millesime-select");
 
   async open(): Promise<void> {
     await this.goto("/time");
@@ -34,5 +38,34 @@ export class TimePage extends BasePage {
   /** La sidebar de filtres est présente sur la page Time. */
   async expectFiltersPresent(): Promise<void> {
     await expect(this.filters()).toBeVisible();
+  }
+
+  /** Le sélecteur de campagne dette IT (millésime) est présent. */
+  async expectMillesimeSelectorPresent(): Promise<void> {
+    await expect(this.millesimeSelector()).toBeVisible();
+  }
+
+  /** Millésime actuellement sélectionné dans le sélecteur de campagne. */
+  async selectedMillesime(): Promise<string> {
+    return this.millesimeSelect().inputValue();
+  }
+
+  /** Millésimes proposés par le sélecteur (valeurs numériques, hors option vide). */
+  async availableMillesimes(): Promise<string[]> {
+    const values = await this.millesimeSelect()
+      .locator("option")
+      .evaluateAll((options) =>
+        options.map((o) => (o as HTMLOptionElement).value),
+      );
+    return values.filter((v) => v !== "");
+  }
+
+  /** Sélectionne un millésime et attend sa propagation dans l'URL (`millesime`). */
+  async selectMillesime(year: string): Promise<void> {
+    await this.millesimeSelect().selectOption(year);
+    await waitForSearchParams(
+      this.page,
+      (params) => params.get("millesime") === year,
+    );
   }
 }

--- a/e2e/tests/administration-referentiels.spec.ts
+++ b/e2e/tests/administration-referentiels.spec.ts
@@ -100,4 +100,20 @@ test.describe("Administration des référentiels", () => {
     await admin.expectLabelSourceRow(renamedSource);
     await admin.deleteLabelSource(renamedSource);
   });
+
+  test("ADM-07 - créer une campagne dette IT et la retrouver", async ({
+    page,
+    data,
+  }) => {
+    const year = 2099;
+    // Idempotence : repartir d'un état propre si un run précédent a laissé la campagne.
+    await data.removeCampaignYear(year);
+
+    const admin = new AdminPage(page);
+    await admin.open();
+    await admin.openCampaignsTab();
+    await admin.createCampaign(year, "Campagne E2E ADM-07");
+    await admin.expectCampaignRow(year);
+    await admin.deleteCampaign(year);
+  });
 });

--- a/e2e/tests/time.spec.ts
+++ b/e2e/tests/time.spec.ts
@@ -50,7 +50,7 @@ test.describe("Diagramme Time", () => {
     page,
     data,
   }) => {
-    const millesimes = await data.ensureTwoMillesimes();
+    const millesimes = await data.ensureTwoCampaigns();
     test.skip(!millesimes, "Impossible de garantir deux campagnes dette IT");
 
     const time = new TimePage(page);
@@ -68,7 +68,7 @@ test.describe("Diagramme Time", () => {
     page,
     data,
   }) => {
-    const millesimes = await data.ensureTwoMillesimes();
+    const millesimes = await data.ensureTwoCampaigns();
     test.skip(!millesimes, "Impossible de garantir deux campagnes dette IT");
     const [, previous] = millesimes!;
 

--- a/e2e/tests/time.spec.ts
+++ b/e2e/tests/time.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "../fixtures/test";
+import { test, expect } from "../fixtures/test";
 import { SearchPage, TimePage } from "../pom";
 
 /**
@@ -43,6 +43,38 @@ test.describe("Diagramme Time", () => {
     await time.open();
     // La sidebar est le composant partagé du catalogue → on réutilise son interaction (POM strict).
     await new SearchPage(page).filterByQualityRange(30, 70);
+    await time.expectChartOrEmpty();
+  });
+
+  test("TIM-05 - le sélecteur de campagne présente le millésime le plus récent par défaut", async ({
+    page,
+    data,
+  }) => {
+    const millesimes = await data.ensureTwoMillesimes();
+    test.skip(!millesimes, "Impossible de garantir deux campagnes dette IT");
+
+    const time = new TimePage(page);
+    await time.open();
+    await time.expectMillesimeSelectorPresent();
+
+    const available = await time.availableMillesimes();
+    expect(available.length).toBeGreaterThanOrEqual(2);
+    // La campagne la plus récente (millésime le plus élevé) est présentée par défaut.
+    const latest = String(Math.max(...available.map(Number)));
+    expect(await time.selectedMillesime()).toEqual(latest);
+  });
+
+  test("TIM-06 - sélectionner une campagne précédente reflète millesime dans l'URL et recharge le diagramme", async ({
+    page,
+    data,
+  }) => {
+    const millesimes = await data.ensureTwoMillesimes();
+    test.skip(!millesimes, "Impossible de garantir deux campagnes dette IT");
+    const [, previous] = millesimes!;
+
+    const time = new TimePage(page);
+    await time.open();
+    await time.selectMillesime(String(previous));
     await time.expectChartOrEmpty();
   });
 });

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -799,6 +799,16 @@ paths:
           description: Recherche par nom de source de données
           schema:
             type: string
+        - name: millesime
+          required: false
+          in: query
+          description: Millésime (année) de la campagne dette IT à présenter. Par défaut,
+            le millésime le plus récent disponible.
+          schema:
+            minimum: 2000
+            maximum: 2100
+            example: 2026
+            type: number
       responses:
         "200":
           description: Liste des applications correspondant aux critères de recherche avec
@@ -1295,6 +1305,16 @@ paths:
           description: Recherche par nom de source de données
           schema:
             type: string
+        - name: millesime
+          required: false
+          in: query
+          description: Millésime (année) de la campagne dette IT à présenter. Par défaut,
+            le millésime le plus récent disponible.
+          schema:
+            minimum: 2000
+            maximum: 2100
+            example: 2026
+            type: number
       responses:
         "200":
           description: Export Excel des applications
@@ -4279,6 +4299,16 @@ paths:
           description: Recherche par nom de source de données
           schema:
             type: string
+        - name: millesime
+          required: false
+          in: query
+          description: Millésime (année) de la campagne dette IT à présenter. Par défaut,
+            le millésime le plus récent disponible.
+          schema:
+            minimum: 2000
+            maximum: 2100
+            example: 2026
+            type: number
       responses:
         "200":
           description: Liste des points de dette technique filtrés
@@ -5413,6 +5443,13 @@ components:
           maximum: 5
           example: 2.75
           description: Cost maturity score (0-5)
+        millesime:
+          type: number
+          minimum: 2000
+          maximum: 2100
+          example: 2026
+          description: Millésime (année) de la campagne dette IT. Par défaut, l'année
+            courante.
         id:
           type: string
           example: uuid-example
@@ -7205,6 +7242,13 @@ components:
           maximum: 5
           example: 2.75
           description: Cost maturity score (0-5)
+        millesime:
+          type: number
+          minimum: 2000
+          maximum: 2100
+          example: 2026
+          description: Millésime (année) de la campagne dette IT. Par défaut, l'année
+            courante.
     PaginatedTechnicalDebtInfoDto:
       type: object
       properties:

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -4318,8 +4318,25 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/TechnicalDebtPointDto"
-      tags:
+      tags: &a24
         - technical-debts
+  /api/v2/technical-debts/millesimes:
+    get:
+      operationId: TechnicalDebtController_getMillesimes
+      summary: Lister les millésimes de campagne dette IT disponibles
+      description: Retourne les millésimes (années) de campagne dette IT enregistrés,
+        triés du plus récent au plus ancien.
+      parameters: []
+      responses:
+        "200":
+          description: Liste des millésimes disponibles
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: number
+      tags: *a24
   /api/v2/applications/{applicationId}/rgaa-compliances:
     get:
       operationId: RgaaController_findAll
@@ -4340,7 +4357,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/RgaaComplianceDto"
-      tags: &a24
+      tags: &a25
         - RGAA Compliances
     post:
       operationId: RgaaController_create
@@ -4371,7 +4388,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RgaaComplianceErrorResponseDto"
-      tags: *a24
+      tags: *a25
   /api/v2/applications/{applicationId}/rgaa-compliances/{id}:
     patch:
       operationId: RgaaController_update
@@ -4402,7 +4419,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RgaaComplianceDto"
-      tags: *a24
+      tags: *a25
     delete:
       operationId: RgaaController_delete
       summary: Supprimer une conformité RGAA
@@ -4422,7 +4439,7 @@ paths:
       responses:
         "204":
           description: Conformité RGAA supprimée
-      tags: *a24
+      tags: *a25
   /api/v2/stats/iq-avg/period:
     get:
       operationId: StatsController_getIqAvgGrouped
@@ -4553,7 +4570,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PaginatedReportDto"
-      tags: &a25
+      tags: &a26
         - Reports
     post:
       operationId: ReportsController_create
@@ -4572,7 +4589,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReportDto"
-      tags: *a25
+      tags: *a26
   /api/v2/reports/{id}:
     patch:
       operationId: ReportsController_update
@@ -4603,7 +4620,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReportDto"
-      tags: *a25
+      tags: *a26
   /api/v2/applications/{applicationId}/reports:
     post:
       operationId: ApplicationReportsController_create
@@ -4628,7 +4645,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReportDto"
-      tags: &a26
+      tags: &a27
         - ApplicationReports
     get:
       operationId: ApplicationReportsController_findAll
@@ -4692,7 +4709,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PaginatedReportDto"
-      tags: *a26
+      tags: *a27
   /api/v2/applications/{applicationId}/reports/{id}:
     get:
       operationId: ApplicationReportsController_findOne
@@ -4716,7 +4733,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReportDto"
-      tags: *a26
+      tags: *a27
     patch:
       operationId: ApplicationReportsController_update
       summary: Mettre à jour un signalement
@@ -4752,7 +4769,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReportDto"
-      tags: *a26
+      tags: *a27
     delete:
       operationId: ApplicationReportsController_remove
       summary: Supprimer un signalement
@@ -4771,7 +4788,7 @@ paths:
       responses:
         "204":
           description: Signalement supprimé avec succès
-      tags: *a26
+      tags: *a27
   /api/v2/health-check:
     get:
       operationId: HealthCheckController_checkHealth
@@ -5357,7 +5374,7 @@ components:
           example: An amazing application
           description: Description of the application
         targetPopulations:
-          example: &a27
+          example: &a28
             - population 1
             - population 2
           description: population associated with the application
@@ -5367,7 +5384,7 @@ components:
         priorityRestart:
           $ref: "#/components/schemas/ApplicationPriorityRestart"
         purposes:
-          example: &a28
+          example: &a29
             - finance
             - HR
           description: Purposes of the application
@@ -5378,7 +5395,7 @@ components:
           example: business
           $ref: "#/components/schemas/ApplicationType"
         tags:
-          example: &a29
+          example: &a30
             - tag1
             - tag2
           type: array
@@ -5664,7 +5681,7 @@ components:
           example: An amazing application
           description: Description of the application
         targetPopulations:
-          example: *a27
+          example: *a28
           description: population associated with the application
           type: array
           items:
@@ -5672,7 +5689,7 @@ components:
         priorityRestart:
           $ref: "#/components/schemas/ApplicationPriorityRestart"
         purposes:
-          example: *a28
+          example: *a29
           description: Purposes of the application
           type: array
           items:
@@ -5681,7 +5698,7 @@ components:
           example: business
           $ref: "#/components/schemas/ApplicationType"
         tags:
-          example: *a29
+          example: *a30
           type: array
           items:
             type: string
@@ -6602,7 +6619,7 @@ components:
           example: 2023-01-01
           description: DIMA last test date
         dima_test_result:
-          enum: &a30
+          enum: &a31
             - OK
             - KO
           type: string
@@ -6628,7 +6645,7 @@ components:
           example: Snapshot, backup incrémental
           description: PDMA backup method used
         pdma_backup_storage:
-          enum: &a31
+          enum: &a32
             - S3
             - LOCAL
             - EXTERNE
@@ -6639,7 +6656,7 @@ components:
           example: 2023-01-01
           description: PDMA last test date
         pdma_test_result:
-          enum: &a32
+          enum: &a33
             - OK
             - KO
           type: string
@@ -6649,7 +6666,7 @@ components:
           example: Marie Martin
           description: PDMA restoration manager
         homologation_status:
-          enum: &a33
+          enum: &a34
             - homologuee
             - en_cours
             - dispensee
@@ -6713,7 +6730,7 @@ components:
           example: 2023-01-01
           description: DIMA last test date
         dima_test_result:
-          enum: *a30
+          enum: *a31
           type: string
           description: DIMA test result
         dima_recovery_manager:
@@ -6737,7 +6754,7 @@ components:
           example: Snapshot, backup incrémental
           description: PDMA backup method used
         pdma_backup_storage:
-          enum: *a31
+          enum: *a32
           type: string
           description: PDMA backup storage
         pdma_last_test_date:
@@ -6745,7 +6762,7 @@ components:
           example: 2023-01-01
           description: PDMA last test date
         pdma_test_result:
-          enum: *a32
+          enum: *a33
           type: string
           description: PDMA test result
         pdma_restoration_manager:
@@ -6753,7 +6770,7 @@ components:
           example: Marie Martin
           description: PDMA restoration manager
         homologation_status:
-          enum: *a33
+          enum: *a34
           type: string
           description: Homologation status
         homologation_date_end:
@@ -6835,7 +6852,7 @@ components:
           example: 2023-01-01
           description: DIMA last test date
         dima_test_result:
-          enum: *a30
+          enum: *a31
           type: string
           description: DIMA test result
         dima_recovery_manager:
@@ -6859,7 +6876,7 @@ components:
           example: Snapshot, backup incrémental
           description: PDMA backup method used
         pdma_backup_storage:
-          enum: *a31
+          enum: *a32
           type: string
           description: PDMA backup storage
         pdma_last_test_date:
@@ -6867,7 +6884,7 @@ components:
           example: 2023-01-01
           description: PDMA last test date
         pdma_test_result:
-          enum: *a32
+          enum: *a33
           type: string
           description: PDMA test result
         pdma_restoration_manager:
@@ -6875,7 +6892,7 @@ components:
           example: Marie Martin
           description: PDMA restoration manager
         homologation_status:
-          enum: *a33
+          enum: *a34
           type: string
           description: Homologation status
         homologation_date_end:

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -3671,6 +3671,132 @@ paths:
         "404":
           description: Source non trouvée
       tags: *a21
+  /api/v2/mdit-campaigns:
+    post:
+      operationId: MditCampaignController_create
+      summary: Créer une campagne dette IT (millésime)
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateMditCampaignDto"
+      responses:
+        "201":
+          description: Campagne créée avec succès
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MditCampaignDto"
+        "403":
+          description: Accès refusé - Privilège admin requis
+        "409":
+          description: Une campagne existe déjà pour ce millésime
+      tags: &a22
+        - MDIT Campaigns
+    get:
+      operationId: MditCampaignController_findAll
+      summary: Lister les campagnes dette IT, triées du millésime le plus récent au
+        plus ancien
+      parameters:
+        - name: page
+          required: false
+          in: query
+          description: Numéro de page
+          schema:
+            minimum: 0
+            example: 0
+            type: number
+        - name: pageSize
+          required: false
+          in: query
+          description: Nombre de résultats par page, 0 pour supprimer la pagination
+          schema:
+            minimum: 0
+            maximum: 100
+            default: 15
+            example: 15
+            type: number
+        - name: sortBy
+          required: false
+          in: query
+          description: Champ utilisé pour le tri
+          schema:
+            example: label
+            type: string
+        - name: order
+          required: false
+          in: query
+          description: Ordre de tri
+          schema:
+            example: asc
+            enum:
+              - asc
+              - desc
+            type: string
+        - name: onlyActive
+          required: false
+          in: query
+          description: Ne retourner que les campagnes actives
+          schema:
+            example: true
+            type: boolean
+      responses:
+        "200":
+          description: Liste des campagnes
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaginatedMditCampaignDto"
+      tags: *a22
+  /api/v2/mdit-campaigns/{id}:
+    patch:
+      operationId: MditCampaignController_update
+      summary: Modifier une campagne dette IT
+      parameters:
+        - name: id
+          required: true
+          in: path
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateMditCampaignDto"
+      responses:
+        "200":
+          description: Campagne mise à jour
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MditCampaignDto"
+        "403":
+          description: Accès refusé - Privilège admin requis
+        "404":
+          description: Campagne non trouvée
+        "409":
+          description: Une campagne existe déjà pour ce millésime
+      tags: *a22
+    delete:
+      operationId: MditCampaignController_remove
+      summary: Supprimer une campagne dette IT
+      parameters:
+        - name: id
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Campagne supprimée avec succès
+        "403":
+          description: Accès refusé - Privilège admin requis
+        "404":
+          description: Campagne non trouvée
+      tags: *a22
   /api/v2/applications/{applicationId}/links:
     post:
       operationId: ApplicationLinksController_create
@@ -3695,7 +3821,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/LinkDto"
-      tags: &a22
+      tags: &a23
         - Links
     get:
       operationId: ApplicationLinksController_findAll
@@ -3750,7 +3876,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PaginatedLinkDto"
-      tags: *a22
+      tags: *a23
   /api/v2/applications/{applicationId}/links/{id}:
     patch:
       operationId: ApplicationLinksController_update
@@ -3781,7 +3907,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/LinkDto"
-      tags: *a22
+      tags: *a23
     delete:
       operationId: ApplicationLinksController_delete
       summary: Delete a link for an application
@@ -3801,7 +3927,7 @@ paths:
       responses:
         "204":
           description: Link deleted successfully
-      tags: *a22
+      tags: *a23
   /api/v2/applications/{applicationId}/technical-debt-info:
     post:
       operationId: ApplicationTechnicalDebtInfoController_create
@@ -3828,7 +3954,7 @@ paths:
                 $ref: "#/components/schemas/TechnicalDebtInfoDto"
         "409":
           description: Technical debt info already exists for this application
-      tags: &a23
+      tags: &a24
         - Technical Debt Info
     get:
       operationId: ApplicationTechnicalDebtInfoController_find
@@ -3882,7 +4008,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PaginatedTechnicalDebtInfoDto"
-      tags: *a23
+      tags: *a24
   /api/v2/technical-debts:
     get:
       operationId: TechnicalDebtController_getTechnicalDebtPoints
@@ -4318,7 +4444,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/TechnicalDebtPointDto"
-      tags: &a24
+      tags: &a25
         - technical-debts
   /api/v2/technical-debts/millesimes:
     get:
@@ -4336,7 +4462,7 @@ paths:
                 type: array
                 items:
                   type: number
-      tags: *a24
+      tags: *a25
   /api/v2/applications/{applicationId}/rgaa-compliances:
     get:
       operationId: RgaaController_findAll
@@ -4357,7 +4483,7 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/RgaaComplianceDto"
-      tags: &a25
+      tags: &a26
         - RGAA Compliances
     post:
       operationId: RgaaController_create
@@ -4388,7 +4514,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RgaaComplianceErrorResponseDto"
-      tags: *a25
+      tags: *a26
   /api/v2/applications/{applicationId}/rgaa-compliances/{id}:
     patch:
       operationId: RgaaController_update
@@ -4419,7 +4545,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RgaaComplianceDto"
-      tags: *a25
+      tags: *a26
     delete:
       operationId: RgaaController_delete
       summary: Supprimer une conformité RGAA
@@ -4439,7 +4565,7 @@ paths:
       responses:
         "204":
           description: Conformité RGAA supprimée
-      tags: *a25
+      tags: *a26
   /api/v2/stats/iq-avg/period:
     get:
       operationId: StatsController_getIqAvgGrouped
@@ -4570,7 +4696,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PaginatedReportDto"
-      tags: &a26
+      tags: &a27
         - Reports
     post:
       operationId: ReportsController_create
@@ -4589,7 +4715,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReportDto"
-      tags: *a26
+      tags: *a27
   /api/v2/reports/{id}:
     patch:
       operationId: ReportsController_update
@@ -4620,7 +4746,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReportDto"
-      tags: *a26
+      tags: *a27
   /api/v2/applications/{applicationId}/reports:
     post:
       operationId: ApplicationReportsController_create
@@ -4645,7 +4771,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReportDto"
-      tags: &a27
+      tags: &a28
         - ApplicationReports
     get:
       operationId: ApplicationReportsController_findAll
@@ -4709,7 +4835,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PaginatedReportDto"
-      tags: *a27
+      tags: *a28
   /api/v2/applications/{applicationId}/reports/{id}:
     get:
       operationId: ApplicationReportsController_findOne
@@ -4733,7 +4859,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReportDto"
-      tags: *a27
+      tags: *a28
     patch:
       operationId: ApplicationReportsController_update
       summary: Mettre à jour un signalement
@@ -4769,7 +4895,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReportDto"
-      tags: *a27
+      tags: *a28
     delete:
       operationId: ApplicationReportsController_remove
       summary: Supprimer un signalement
@@ -4788,7 +4914,7 @@ paths:
       responses:
         "204":
           description: Signalement supprimé avec succès
-      tags: *a27
+      tags: *a28
   /api/v2/health-check:
     get:
       operationId: HealthCheckController_checkHealth
@@ -5374,7 +5500,7 @@ components:
           example: An amazing application
           description: Description of the application
         targetPopulations:
-          example: &a28
+          example: &a29
             - population 1
             - population 2
           description: population associated with the application
@@ -5384,7 +5510,7 @@ components:
         priorityRestart:
           $ref: "#/components/schemas/ApplicationPriorityRestart"
         purposes:
-          example: &a29
+          example: &a30
             - finance
             - HR
           description: Purposes of the application
@@ -5395,7 +5521,7 @@ components:
           example: business
           $ref: "#/components/schemas/ApplicationType"
         tags:
-          example: &a30
+          example: &a31
             - tag1
             - tag2
           type: array
@@ -5681,7 +5807,7 @@ components:
           example: An amazing application
           description: Description of the application
         targetPopulations:
-          example: *a28
+          example: *a29
           description: population associated with the application
           type: array
           items:
@@ -5689,7 +5815,7 @@ components:
         priorityRestart:
           $ref: "#/components/schemas/ApplicationPriorityRestart"
         purposes:
-          example: *a29
+          example: *a30
           description: Purposes of the application
           type: array
           items:
@@ -5698,7 +5824,7 @@ components:
           example: business
           $ref: "#/components/schemas/ApplicationType"
         tags:
-          example: *a30
+          example: *a31
           type: array
           items:
             type: string
@@ -6619,7 +6745,7 @@ components:
           example: 2023-01-01
           description: DIMA last test date
         dima_test_result:
-          enum: &a31
+          enum: &a32
             - OK
             - KO
           type: string
@@ -6645,7 +6771,7 @@ components:
           example: Snapshot, backup incrémental
           description: PDMA backup method used
         pdma_backup_storage:
-          enum: &a32
+          enum: &a33
             - S3
             - LOCAL
             - EXTERNE
@@ -6656,7 +6782,7 @@ components:
           example: 2023-01-01
           description: PDMA last test date
         pdma_test_result:
-          enum: &a33
+          enum: &a34
             - OK
             - KO
           type: string
@@ -6666,7 +6792,7 @@ components:
           example: Marie Martin
           description: PDMA restoration manager
         homologation_status:
-          enum: &a34
+          enum: &a35
             - homologuee
             - en_cours
             - dispensee
@@ -6730,7 +6856,7 @@ components:
           example: 2023-01-01
           description: DIMA last test date
         dima_test_result:
-          enum: *a31
+          enum: *a32
           type: string
           description: DIMA test result
         dima_recovery_manager:
@@ -6754,7 +6880,7 @@ components:
           example: Snapshot, backup incrémental
           description: PDMA backup method used
         pdma_backup_storage:
-          enum: *a32
+          enum: *a33
           type: string
           description: PDMA backup storage
         pdma_last_test_date:
@@ -6762,7 +6888,7 @@ components:
           example: 2023-01-01
           description: PDMA last test date
         pdma_test_result:
-          enum: *a33
+          enum: *a34
           type: string
           description: PDMA test result
         pdma_restoration_manager:
@@ -6770,7 +6896,7 @@ components:
           example: Marie Martin
           description: PDMA restoration manager
         homologation_status:
-          enum: *a34
+          enum: *a35
           type: string
           description: Homologation status
         homologation_date_end:
@@ -6852,7 +6978,7 @@ components:
           example: 2023-01-01
           description: DIMA last test date
         dima_test_result:
-          enum: *a31
+          enum: *a32
           type: string
           description: DIMA test result
         dima_recovery_manager:
@@ -6876,7 +7002,7 @@ components:
           example: Snapshot, backup incrémental
           description: PDMA backup method used
         pdma_backup_storage:
-          enum: *a32
+          enum: *a33
           type: string
           description: PDMA backup storage
         pdma_last_test_date:
@@ -6884,7 +7010,7 @@ components:
           example: 2023-01-01
           description: PDMA last test date
         pdma_test_result:
-          enum: *a33
+          enum: *a34
           type: string
           description: PDMA test result
         pdma_restoration_manager:
@@ -6892,7 +7018,7 @@ components:
           example: Marie Martin
           description: PDMA restoration manager
         homologation_status:
-          enum: *a34
+          enum: *a35
           type: string
           description: Homologation status
         homologation_date_end:
@@ -7164,6 +7290,84 @@ components:
           example: CODE_PAI
       required:
         - source
+    CreateMditCampaignDto:
+      type: object
+      properties:
+        year:
+          type: number
+          minimum: 2000
+          maximum: 2100
+          description: Année de la campagne (millésime)
+          example: 2027
+        label:
+          type: string
+          description: Libellé optionnel de la campagne
+          example: Campagne dette IT 2027
+        isActive:
+          type: boolean
+          description: Campagne active (présentée dans le sélecteur)
+          example: true
+          default: true
+      required:
+        - year
+    MditCampaignDto:
+      type: object
+      properties:
+        year:
+          type: number
+          minimum: 2000
+          maximum: 2100
+          description: Année de la campagne (millésime)
+          example: 2027
+        label:
+          type: string
+          description: Libellé optionnel de la campagne
+          example: Campagne dette IT 2027
+        isActive:
+          type: boolean
+          description: Campagne active (présentée dans le sélecteur)
+          example: true
+          default: true
+        id:
+          type: string
+          description: Identifiant unique de la campagne
+          example: 5708d232-8338-4abf-8f38-8370acc89497
+      required:
+        - year
+        - id
+    PaginatedMditCampaignDto:
+      type: object
+      properties:
+        results:
+          description: Array of results
+          type: array
+          items:
+            $ref: "#/components/schemas/MditCampaignDto"
+        total:
+          type: number
+          description: Total number of items
+          example: 100
+      required:
+        - results
+        - total
+    UpdateMditCampaignDto:
+      type: object
+      properties:
+        year:
+          type: number
+          minimum: 2000
+          maximum: 2100
+          description: Année de la campagne (millésime)
+          example: 2027
+        label:
+          type: string
+          description: Libellé optionnel de la campagne
+          example: Campagne dette IT 2027
+        isActive:
+          type: boolean
+          description: Campagne active (présentée dans le sélecteur)
+          example: true
+          default: true
     ExternalRessourceType:
       type: string
       description: Type of the external resource

--- a/frontend/src/components/admin/AdminMditCampaignsTab.vue
+++ b/frontend/src/components/admin/AdminMditCampaignsTab.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from "vue";
+import type { MditCampaignDto } from "@/client/types.gen";
+import MditCampaignActions from "./MditCampaignActions.vue";
+import api from "@/api";
+import RefAppTable from "@/components/RefAppTable.vue";
+import type { TableColumn } from "@/types/table";
+
+const data = ref<{ results: MditCampaignDto[]; total: number }>({ results: [], total: 0 });
+
+const headers = [
+  { key: "year", label: "Millésime" },
+  { key: "label", label: "Libellé" },
+  { key: "isActive", label: "Active" },
+  { key: "actions", label: "Actions" },
+] as const;
+
+const tableColumns: TableColumn[] = headers.map((h) => ({
+  field: h.key,
+  header: h.label,
+  sortable: false,
+}));
+
+const isLoading = ref(false);
+const itemsPerPage = ref(15);
+const currentPage = ref(0);
+const firstIndex = computed(() => currentPage.value * itemsPerPage.value);
+
+async function fetchCampaigns() {
+  isLoading.value = true;
+  const response = await api.mditCampaignControllerFindAll({
+    query: { page: currentPage.value, pageSize: itemsPerPage.value },
+  });
+  if (response.data?.results) {
+    data.value = response.data;
+  }
+  isLoading.value = false;
+}
+
+const tableRows = computed(() =>
+  data.value.results.map((campaign) => ({
+    year: campaign.year,
+    label: campaign.label ?? "—",
+    isActive: campaign.isActive ? "Oui" : "Non",
+    actions: campaign,
+  })),
+);
+
+function onPage(event: { page: number; rows: number }) {
+  currentPage.value = event.page;
+  itemsPerPage.value = event.rows;
+  fetchCampaigns();
+}
+
+onMounted(fetchCampaigns);
+</script>
+
+<template>
+  <div class="header-row">
+    <h1 class="fr-h1" data-testid="admin-campaigns-title">Gestion des campagnes dette IT</h1>
+
+    <MditCampaignActions @fetch-campaigns="fetchCampaigns" />
+  </div>
+
+  <div v-if="isLoading" class="fr-alert fr-alert--info" data-testid="admin-campaigns-loading">
+    <p>Chargement des campagnes...</p>
+  </div>
+
+  <div v-else>
+    <RefAppTable
+      :items="tableRows"
+      :columns="tableColumns"
+      :paginator="true"
+      :lazy="true"
+      :rows="itemsPerPage"
+      :first="firstIndex"
+      :total-records="data.total"
+      data-testid="admin-campaigns-table"
+      @page="onPage"
+    >
+      <template #body-actions="{ data: row }">
+        <MditCampaignActions :campaign="row.actions" @fetch-campaigns="fetchCampaigns" />
+      </template>
+    </RefAppTable>
+  </div>
+</template>
+
+<style scoped>
+.header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+</style>

--- a/frontend/src/components/admin/MditCampaignActions.vue
+++ b/frontend/src/components/admin/MditCampaignActions.vue
@@ -131,54 +131,66 @@ async function deleteCampaign() {
 
   <DsfrModal
     :opened="isEditModalOpen"
-    :title="!campaign?.id ? 'Créer une campagne' : 'Modifier la campagne'"
+    :title="!campaign?.id ? 'Créer une campagne dette IT' : `Modifier la campagne ${campaign?.year}`"
     :data-testid="!campaign?.id ? 'admin-create-campaign-modal' : 'admin-edit-campaign-modal'"
     @close="closeEditModal"
   >
+    <p class="fr-text--sm fr-hint-text fr-mb-3w">
+      Une campagne correspond à un millésime (année) de collecte de la dette IT. La campagne active la plus récente est présentée par défaut
+      dans le diagramme Time.
+    </p>
+
+    <DsfrAlert v-if="errorMessage" type="error" :description="errorMessage" small class="fr-mb-3w" data-testid="campaign-form-error" />
+
     <DsfrInputGroup
       v-model.number="editingYear"
-      class="fr-mb-2w"
+      class="fr-mb-3w"
       type="number"
       label="Millésime (année)"
-      hint="Année de la campagne, ex. 2027"
+      hint="Année sur 4 chiffres, entre 2000 et 2100 (ex. 2027)"
       label-visible
       required
+      :min="2000"
+      :max="2100"
       data-testid="campaign-year"
     />
 
     <DsfrInputGroup
       v-model="editingLabel"
-      class="fr-mb-2w"
+      class="fr-mb-3w"
       label="Libellé (optionnel)"
+      hint="Texte affiché dans le sélecteur de campagne ; à défaut, l'année est utilisée"
       label-visible
-      :error-message="errorMessage"
       data-testid="campaign-label"
     />
 
     <DsfrToggleSwitch
       :model-value="editingActive"
       label="Campagne active"
+      hint="Seules les campagnes actives apparaissent dans le sélecteur du diagramme Time"
       data-testid="campaign-active"
       @update:model-value="editingActive = $event"
     />
 
     <template #footer>
-      <DsfrButton
-        label="Annuler"
-        secondary
-        data-testid="admin-campaign-cancel-btn"
-        title="Annuler"
-        aria-label="Annuler"
-        @click="closeEditModal"
-      />
-      <DsfrButton
-        label="Enregistrer"
-        title="Enregistrer"
-        aria-label="Enregistrer"
-        :disabled="isSaving"
-        data-testid="admin-campaign-save-btn"
-        @click="saveCampaign"
-      />
+      <DsfrButtonGroup :inline-layout-when="true" :reverse="true">
+        <DsfrButton
+          label="Annuler"
+          secondary
+          data-testid="admin-campaign-cancel-btn"
+          title="Annuler"
+          aria-label="Annuler"
+          @click="closeEditModal"
+        />
+        <DsfrButton
+          :label="isSaving ? 'Enregistrement…' : 'Enregistrer'"
+          title="Enregistrer"
+          aria-label="Enregistrer"
+          :disabled="isSaving"
+          data-testid="admin-campaign-save-btn"
+          @click="saveCampaign"
+        />
+      </DsfrButtonGroup>
     </template>
   </DsfrModal>
 
@@ -193,23 +205,25 @@ async function deleteCampaign() {
     />
 
     <template #footer>
-      <DsfrButton
-        label="Annuler"
-        secondary
-        data-testid="admin-campaign-delete-cancel-btn"
-        title="Annuler la suppression"
-        aria-label="Annuler la suppression"
-        @click="closeDeleteModal"
-      />
-      <DsfrButton
-        label="Supprimer"
-        data-testid="admin-campaign-delete-confirm-btn"
-        title="Confirmer la suppression"
-        aria-label="Confirmer la suppression"
-        danger
-        :disabled="isDeleting"
-        @click="deleteCampaign"
-      />
+      <DsfrButtonGroup :inline-layout-when="true" :reverse="true">
+        <DsfrButton
+          label="Annuler"
+          secondary
+          data-testid="admin-campaign-delete-cancel-btn"
+          title="Annuler la suppression"
+          aria-label="Annuler la suppression"
+          @click="closeDeleteModal"
+        />
+        <DsfrButton
+          label="Supprimer"
+          data-testid="admin-campaign-delete-confirm-btn"
+          title="Confirmer la suppression"
+          aria-label="Confirmer la suppression"
+          danger
+          :disabled="isDeleting"
+          @click="deleteCampaign"
+        />
+      </DsfrButtonGroup>
     </template>
   </DsfrModal>
 </template>

--- a/frontend/src/components/admin/MditCampaignActions.vue
+++ b/frontend/src/components/admin/MditCampaignActions.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import type { MditCampaignDto } from "@/client/types.gen";
+import { useToasterStore } from "@/stores/toasterStore";
+import api from "@/api";
+
+const props = defineProps<{
+  campaign?: MditCampaignDto;
+}>();
+
+const emit = defineEmits<{
+  fetchCampaigns: [];
+}>();
+
+const toaster = useToasterStore();
+
+const isEditModalOpen = ref(false);
+const isDeleteModalOpen = ref(false);
+const isSaving = ref(false);
+const isDeleting = ref(false);
+const editingYear = ref<number | undefined>(undefined);
+const editingLabel = ref<string>("");
+const editingActive = ref<boolean>(true);
+const errorMessage = ref<string>("");
+
+function openEditModal() {
+  editingYear.value = props.campaign?.year;
+  editingLabel.value = props.campaign?.label || "";
+  editingActive.value = props.campaign?.isActive ?? true;
+  errorMessage.value = "";
+  isEditModalOpen.value = true;
+}
+
+function openDeleteModal() {
+  isDeleteModalOpen.value = true;
+}
+
+function closeEditModal() {
+  isEditModalOpen.value = false;
+  errorMessage.value = "";
+}
+
+function closeDeleteModal() {
+  isDeleteModalOpen.value = false;
+}
+
+async function saveCampaign() {
+  const year = Number(editingYear.value);
+  if (!Number.isInteger(year) || year < 2000 || year > 2100) {
+    errorMessage.value = "Le millésime doit être une année entre 2000 et 2100.";
+    return;
+  }
+
+  isSaving.value = true;
+  errorMessage.value = "";
+
+  const body = {
+    year,
+    label: editingLabel.value || undefined,
+    isActive: editingActive.value,
+  };
+
+  const response = !props.campaign?.id
+    ? await api.mditCampaignControllerCreate({ body })
+    : await api.mditCampaignControllerUpdate({ path: { id: props.campaign.id }, body });
+
+  if (!response.response.ok) {
+    if (response.response.status === 409) {
+      errorMessage.value = "Une campagne existe déjà pour ce millésime.";
+    } else if (response.response.status === 400) {
+      errorMessage.value = "Les informations saisies sont incorrectes.";
+    } else {
+      errorMessage.value = "Erreur lors de la sauvegarde de la campagne.";
+    }
+  } else {
+    toaster.addSuccessMessage(!props.campaign?.id ? "Campagne créée avec succès" : "Campagne mise à jour avec succès");
+    closeEditModal();
+    emit("fetchCampaigns");
+  }
+  isSaving.value = false;
+}
+
+async function deleteCampaign() {
+  if (!props.campaign?.id) return;
+
+  isDeleting.value = true;
+
+  const response = await api.mditCampaignControllerRemove({ path: { id: props.campaign.id } });
+  if (!response.response.ok) {
+    toaster.addErrorMessage("Erreur lors de la suppression de la campagne");
+  } else {
+    toaster.addSuccessMessage("Campagne supprimée avec succès");
+    closeDeleteModal();
+    emit("fetchCampaigns");
+  }
+  isDeleting.value = false;
+}
+</script>
+
+<template>
+  <DsfrButton
+    v-if="!campaign?.id"
+    class="fr-btn--icon-left fr-icon-add-line"
+    label="Créer une campagne"
+    data-testid="admin-create-campaign-btn"
+    title="Créer une nouvelle campagne"
+    aria-label="Créer une nouvelle campagne"
+    @click="openEditModal"
+  />
+
+  <div v-else class="button-row">
+    <DsfrButton
+      label="Modifier"
+      size="sm"
+      secondary
+      data-testid="admin-campaign-edit-btn"
+      title="Modifier la campagne"
+      aria-label="Modifier la campagne"
+      @click="openEditModal"
+    />
+    <DsfrButton
+      label="Supprimer"
+      size="sm"
+      secondary
+      data-testid="admin-campaign-delete-btn"
+      title="Supprimer la campagne"
+      aria-label="Supprimer la campagne"
+      @click="openDeleteModal"
+    />
+  </div>
+
+  <DsfrModal
+    :opened="isEditModalOpen"
+    :title="!campaign?.id ? 'Créer une campagne' : 'Modifier la campagne'"
+    :data-testid="!campaign?.id ? 'admin-create-campaign-modal' : 'admin-edit-campaign-modal'"
+    @close="closeEditModal"
+  >
+    <DsfrInputGroup
+      v-model.number="editingYear"
+      class="fr-mb-2w"
+      type="number"
+      label="Millésime (année)"
+      hint="Année de la campagne, ex. 2027"
+      label-visible
+      required
+      data-testid="campaign-year"
+    />
+
+    <DsfrInputGroup
+      v-model="editingLabel"
+      class="fr-mb-2w"
+      label="Libellé (optionnel)"
+      label-visible
+      :error-message="errorMessage"
+      data-testid="campaign-label"
+    />
+
+    <DsfrToggleSwitch
+      :model-value="editingActive"
+      label="Campagne active"
+      data-testid="campaign-active"
+      @update:model-value="editingActive = $event"
+    />
+
+    <template #footer>
+      <DsfrButton
+        label="Annuler"
+        secondary
+        data-testid="admin-campaign-cancel-btn"
+        title="Annuler"
+        aria-label="Annuler"
+        @click="closeEditModal"
+      />
+      <DsfrButton
+        label="Enregistrer"
+        title="Enregistrer"
+        aria-label="Enregistrer"
+        :disabled="isSaving"
+        data-testid="admin-campaign-save-btn"
+        @click="saveCampaign"
+      />
+    </template>
+  </DsfrModal>
+
+  <DsfrModal :opened="isDeleteModalOpen" title="Supprimer la campagne" data-testid="admin-delete-campaign-modal" @close="closeDeleteModal">
+    <DsfrAlert
+      id="campaign-delete-alert"
+      title="Cette action est irréversible"
+      :description="`Êtes-vous sûr de vouloir supprimer la campagne : ${campaign?.year} ?`"
+      type="warning"
+      class="fr-mb-3w alert-multiline"
+      data-testid="campaign-delete-alert"
+    />
+
+    <template #footer>
+      <DsfrButton
+        label="Annuler"
+        secondary
+        data-testid="admin-campaign-delete-cancel-btn"
+        title="Annuler la suppression"
+        aria-label="Annuler la suppression"
+        @click="closeDeleteModal"
+      />
+      <DsfrButton
+        label="Supprimer"
+        data-testid="admin-campaign-delete-confirm-btn"
+        title="Confirmer la suppression"
+        aria-label="Confirmer la suppression"
+        danger
+        :disabled="isDeleting"
+        @click="deleteCampaign"
+      />
+    </template>
+  </DsfrModal>
+</template>
+
+<style scoped>
+.button-row {
+  display: flex;
+  gap: 1rem;
+}
+.alert-multiline {
+  white-space: normal;
+  word-wrap: break-word;
+}
+</style>

--- a/frontend/src/components/search/CampaignFilter.vue
+++ b/frontend/src/components/search/CampaignFilter.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { computed, onMounted } from "vue";
+import { DsfrSelect } from "@gouvminint/vue-dsfr";
+import { useApplicationSearch } from "@/composables/use-application-search";
+import { useMditCampaigns } from "@/composables/use-mdit-campaigns";
+
+const { filters, setFilter } = useApplicationSearch();
+const { campaigns, loadActiveCampaigns } = useMditCampaigns();
+
+const options = computed(() =>
+  campaigns.value.map((campaign) => ({ value: String(campaign.year), text: campaign.label || String(campaign.year) })),
+);
+
+// La campagne la plus récente est présentée par défaut ; sinon celle choisie.
+const selected = computed(() => {
+  const current = filters.value.millesime ?? campaigns.value[0]?.year;
+  return current != null ? String(current) : "";
+});
+
+function onSelect(value: string | number): void {
+  const year = Number(value);
+  if (!Number.isNaN(year)) {
+    setFilter({ millesime: year, page: 0 });
+  }
+}
+
+onMounted(loadActiveCampaigns);
+</script>
+
+<template>
+  <div v-if="options.length" class="campaign-filter" data-testid="time-millesime">
+    <DsfrSelect
+      :model-value="selected"
+      label="Campagne dette IT (millésime)"
+      :options="options"
+      data-testid="time-millesime-select"
+      @update:model-value="onSelect($event)"
+    />
+  </div>
+</template>
+
+<style scoped>
+.campaign-filter {
+  margin-bottom: 0.5rem;
+}
+</style>

--- a/frontend/src/components/search/SidebarFilter.vue
+++ b/frontend/src/components/search/SidebarFilter.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
+import { useRoute } from "vue-router";
 import { useApplicationSearch } from "@/composables/use-application-search";
+import CampaignFilter from "@/components/search/CampaignFilter.vue";
 import ActorFilter from "@/components/search/ActorFilter.vue";
 import HostingFilter from "@/components/search/HostingFilter.vue";
 import QualityFilter from "@/components/search/QualityFilter.vue";
@@ -16,6 +18,9 @@ import { DsfrButton, DsfrToggleSwitch } from "@gouvminint/vue-dsfr";
 defineOptions({ inheritAttrs: false });
 
 const sidebarOpen = ref(true);
+const route = useRoute();
+// Le sélecteur de campagne (millésime) ne concerne que le diagramme Time.
+const isTimeRoute = computed(() => route.path === "/time");
 const { total, resetFilters, filters, setFilter } = useApplicationSearch();
 const statsStore = useStatisticsStore();
 const userStore = useUserStore();
@@ -50,6 +55,8 @@ function toggleSubscribedAppsFilter(value: boolean) {
         <p class="total-count" data-testid="sidebar-total-count">
           {{ total }} application(s) trouvée(s) sur {{ statsStore.totalApplications }}
         </p>
+
+        <CampaignFilter v-if="isTimeRoute" />
 
         <DsfrToggleSwitch
           v-if="userStore.user?.email"

--- a/frontend/src/components/search/SidebarFilter.vue
+++ b/frontend/src/components/search/SidebarFilter.vue
@@ -56,8 +56,6 @@ function toggleSubscribedAppsFilter(value: boolean) {
           {{ total }} application(s) trouvée(s) sur {{ statsStore.totalApplications }}
         </p>
 
-        <CampaignFilter v-if="isTimeRoute" />
-
         <DsfrToggleSwitch
           v-if="userStore.user?.email"
           :model-value="isMyAppsFilterActive"
@@ -78,6 +76,7 @@ function toggleSubscribedAppsFilter(value: boolean) {
         />
 
         <DsfrAccordion :selected="openAccordions.includes(0)" title="Général" data-testid="sidebar-accordion-general" @click="toggle(0)">
+          <CampaignFilter v-if="isTimeRoute" />
           <ApplicationFilter />
           <PriorityRestartFilter />
         </DsfrAccordion>

--- a/frontend/src/composables/use-application-search.ts
+++ b/frontend/src/composables/use-application-search.ts
@@ -295,12 +295,6 @@ export function useApplicationSearch() {
     return response.data ?? [];
   }
 
-  /** Millésimes de campagne dette IT disponibles, triés du plus récent au plus ancien. */
-  async function fetchTechnicalDebtMillesimes(): Promise<number[]> {
-    const response = await api.technicalDebtControllerGetMillesimes({ throwOnError: true });
-    return response.data ?? [];
-  }
-
   // Auto-search when filters change
   watch(
     () => route.query,
@@ -324,7 +318,6 @@ export function useApplicationSearch() {
     DEFAULT_FILTERS,
     searchApplications,
     fetchTechnicalDebtPoints,
-    fetchTechnicalDebtMillesimes,
     setFilter,
     setOrder,
     resetFilters,

--- a/frontend/src/composables/use-application-search.ts
+++ b/frontend/src/composables/use-application-search.ts
@@ -53,6 +53,7 @@ const DEFAULT_FILTERS: Filters = {
   relationAppId: undefined,
   businessDivisionId: undefined,
   dataSourceName: undefined,
+  millesime: undefined,
 };
 
 // Shared state across components (singleton pattern)
@@ -191,6 +192,7 @@ function queryToFilters(query: Record<string, LocationQueryValue | LocationQuery
     relationAppId: parseQueryParam(query.relationAppId),
     businessDivisionId: parseQueryParam(query.businessDivisionId),
     dataSourceName: parseQueryParam(query.dataSourceName),
+    millesime: parseQueryParamNumber(query.millesime),
   };
 }
 
@@ -293,6 +295,12 @@ export function useApplicationSearch() {
     return response.data ?? [];
   }
 
+  /** Millésimes de campagne dette IT disponibles, triés du plus récent au plus ancien. */
+  async function fetchTechnicalDebtMillesimes(): Promise<number[]> {
+    const response = await api.technicalDebtControllerGetMillesimes({ throwOnError: true });
+    return response.data ?? [];
+  }
+
   // Auto-search when filters change
   watch(
     () => route.query,
@@ -316,6 +324,7 @@ export function useApplicationSearch() {
     DEFAULT_FILTERS,
     searchApplications,
     fetchTechnicalDebtPoints,
+    fetchTechnicalDebtMillesimes,
     setFilter,
     setOrder,
     resetFilters,

--- a/frontend/src/composables/use-mdit-campaigns.ts
+++ b/frontend/src/composables/use-mdit-campaigns.ts
@@ -1,0 +1,27 @@
+import { computed, ref } from "vue";
+import api from "@/api";
+import type { MditCampaignDto } from "@/client/types.gen";
+
+// État partagé (singleton) des campagnes dette IT actives, présentées dans le
+// sélecteur de campagne du diagramme Time. Triées du millésime le plus récent
+// au plus ancien (ordre fourni par l'API).
+const campaigns = ref<MditCampaignDto[]>([]);
+let loaded = false;
+
+export function useMditCampaigns() {
+  async function loadActiveCampaigns(force = false): Promise<MditCampaignDto[]> {
+    if (loaded && !force) return campaigns.value;
+    const response = await api.mditCampaignControllerFindAll({
+      query: { onlyActive: true, page: 0, pageSize: 100 },
+      throwOnError: true,
+    });
+    campaigns.value = response.data?.results ?? [];
+    loaded = true;
+    return campaigns.value;
+  }
+
+  /** Millésime de la campagne la plus récente (présentée par défaut). */
+  const latestYear = computed<number | undefined>(() => campaigns.value[0]?.year);
+
+  return { campaigns, loadActiveCampaigns, latestYear };
+}

--- a/frontend/src/views/AdminPage.vue
+++ b/frontend/src/views/AdminPage.vue
@@ -6,6 +6,7 @@ import AdminOrganizationsTab from "@/components/admin/AdminOrganizationsTab.vue"
 import { markRaw, ref } from "vue";
 import AdminPermsMatrixTab from "@/components/admin/AdminPermsMatrixTab.vue";
 import AdminLabelSourcesTab from "@/components/admin/AdminLabelSourcesTab.vue";
+import AdminMditCampaignsTab from "@/components/admin/AdminMditCampaignsTab.vue";
 
 interface DsfrTab {
   title: string;
@@ -44,6 +45,13 @@ const tabs = ref<DsfrTab[]>([
     tabId: "tab-label-sources",
     panelId: "panel-label-sources",
     component: markRaw(AdminLabelSourcesTab),
+  },
+  {
+    title: "Campagnes dette IT",
+    icon: "ri-calendar-event-line",
+    tabId: "tab-mdit-campaigns",
+    panelId: "panel-mdit-campaigns",
+    component: markRaw(AdminMditCampaignsTab),
   },
   {
     title: "Batch de données",

--- a/frontend/src/views/TimePage.vue
+++ b/frontend/src/views/TimePage.vue
@@ -1,25 +1,53 @@
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
+import { ref, computed, onMounted } from "vue";
 import { useApplicationSearch, type TechnicalDebtPoint } from "@/composables/use-application-search";
 import SidebarFilters from "@/components/search/SidebarFilter.vue";
 import AppLoader from "@/components/AppLoader.vue";
 import TechnicalDebtChart from "@/components/technical-debt/TechnicalDebtChart.vue";
+import { DsfrSelect } from "@gouvminint/vue-dsfr";
 import { watchDebounced } from "@vueuse/core";
 import { useUserStore } from "@/stores/userStore";
 
-const { filters, setFilter, fetchTechnicalDebtPoints } = useApplicationSearch();
+const { filters, setFilter, fetchTechnicalDebtPoints, fetchTechnicalDebtMillesimes } = useApplicationSearch();
 const userStore = useUserStore();
 
 const technicalDebtPoints = ref<TechnicalDebtPoint[]>([]);
 const isTechnicalDebtLoading = ref(false);
 
-onMounted(() => {
+// Campagnes dette IT (millésimes) disponibles : la plus récente est présentée par défaut,
+// l'utilisateur peut sélectionner une campagne précédente.
+const availableMillesimes = ref<number[]>([]);
+
+const millesimeOptions = computed(() => availableMillesimes.value.map((year) => ({ value: String(year), text: String(year) })));
+
+const selectedMillesime = computed(() => {
+  const current = filters.value.millesime ?? availableMillesimes.value[0];
+  return current != null ? String(current) : "";
+});
+
+function onSelectMillesime(value: string | number): void {
+  const year = Number(value);
+  if (!Number.isNaN(year)) {
+    setFilter({ millesime: year, page: 0 });
+  }
+}
+
+onMounted(async () => {
   const businessDivisionId = userStore.getBusinessDivisionId();
   if (businessDivisionId && !filters.value.businessDivisionId) {
     setFilter({ businessDivisionId });
   }
+  await loadMillesimes();
   loadTechnicalDebtPoints();
 });
+
+async function loadMillesimes() {
+  try {
+    availableMillesimes.value = await fetchTechnicalDebtMillesimes();
+  } catch {
+    availableMillesimes.value = [];
+  }
+}
 
 async function loadTechnicalDebtPoints() {
   isTechnicalDebtLoading.value = true;
@@ -47,6 +75,16 @@ watchDebounced(
 
     <main class="main-content" id="main-content" data-testid="main-content" role="main">
       <h1 class="fr-h1" data-testid="time-title">Diagramme Time</h1>
+
+      <div v-if="millesimeOptions.length" class="millesime-selector" data-testid="time-millesime">
+        <DsfrSelect
+          :model-value="selectedMillesime"
+          label="Campagne dette IT (millésime)"
+          :options="millesimeOptions"
+          data-testid="time-millesime-select"
+          @update:model-value="onSelectMillesime($event)"
+        />
+      </div>
 
       <section id="technical-debt-chart" class="chart-section" data-testid="technical-debt-chart-section">
         <div v-if="isTechnicalDebtLoading" class="loader" role="status" aria-live="polite" aria-atomic="true">
@@ -81,6 +119,11 @@ watchDebounced(
   display: flex;
   justify-content: center;
   margin-top: 3rem;
+}
+
+.millesime-selector {
+  max-width: 18rem;
+  margin-top: 1rem;
 }
 
 .chart-section {

--- a/frontend/src/views/TimePage.vue
+++ b/frontend/src/views/TimePage.vue
@@ -1,58 +1,37 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from "vue";
+import { ref, onMounted } from "vue";
 import { useApplicationSearch, type TechnicalDebtPoint } from "@/composables/use-application-search";
+import { useMditCampaigns } from "@/composables/use-mdit-campaigns";
 import SidebarFilters from "@/components/search/SidebarFilter.vue";
 import AppLoader from "@/components/AppLoader.vue";
 import TechnicalDebtChart from "@/components/technical-debt/TechnicalDebtChart.vue";
-import { DsfrSelect } from "@gouvminint/vue-dsfr";
 import { watchDebounced } from "@vueuse/core";
 import { useUserStore } from "@/stores/userStore";
 
-const { filters, setFilter, fetchTechnicalDebtPoints, fetchTechnicalDebtMillesimes } = useApplicationSearch();
+const { filters, setFilter, fetchTechnicalDebtPoints } = useApplicationSearch();
+const { loadActiveCampaigns, latestYear } = useMditCampaigns();
 const userStore = useUserStore();
 
 const technicalDebtPoints = ref<TechnicalDebtPoint[]>([]);
 const isTechnicalDebtLoading = ref(false);
-
-// Campagnes dette IT (millésimes) disponibles : la plus récente est présentée par défaut,
-// l'utilisateur peut sélectionner une campagne précédente.
-const availableMillesimes = ref<number[]>([]);
-
-const millesimeOptions = computed(() => availableMillesimes.value.map((year) => ({ value: String(year), text: String(year) })));
-
-const selectedMillesime = computed(() => {
-  const current = filters.value.millesime ?? availableMillesimes.value[0];
-  return current != null ? String(current) : "";
-});
-
-function onSelectMillesime(value: string | number): void {
-  const year = Number(value);
-  if (!Number.isNaN(year)) {
-    setFilter({ millesime: year, page: 0 });
-  }
-}
 
 onMounted(async () => {
   const businessDivisionId = userStore.getBusinessDivisionId();
   if (businessDivisionId && !filters.value.businessDivisionId) {
     setFilter({ businessDivisionId });
   }
-  await loadMillesimes();
+  // Charge les campagnes (sélecteur en sidebar) avant le premier rendu : la plus
+  // récente est présentée par défaut.
+  await loadActiveCampaigns();
   loadTechnicalDebtPoints();
 });
-
-async function loadMillesimes() {
-  try {
-    availableMillesimes.value = await fetchTechnicalDebtMillesimes();
-  } catch {
-    availableMillesimes.value = [];
-  }
-}
 
 async function loadTechnicalDebtPoints() {
   isTechnicalDebtLoading.value = true;
   try {
-    technicalDebtPoints.value = await fetchTechnicalDebtPoints();
+    // Sans choix explicite, on présente la campagne la plus récente.
+    const millesime = filters.value.millesime ?? latestYear.value;
+    technicalDebtPoints.value = await fetchTechnicalDebtPoints(millesime != null ? { millesime } : undefined);
   } catch {
     technicalDebtPoints.value = [];
   } finally {
@@ -75,16 +54,6 @@ watchDebounced(
 
     <main class="main-content" id="main-content" data-testid="main-content" role="main">
       <h1 class="fr-h1" data-testid="time-title">Diagramme Time</h1>
-
-      <div v-if="millesimeOptions.length" class="millesime-selector" data-testid="time-millesime">
-        <DsfrSelect
-          :model-value="selectedMillesime"
-          label="Campagne dette IT (millésime)"
-          :options="millesimeOptions"
-          data-testid="time-millesime-select"
-          @update:model-value="onSelectMillesime($event)"
-        />
-      </div>
 
       <section id="technical-debt-chart" class="chart-section" data-testid="technical-debt-chart-section">
         <div v-if="isTechnicalDebtLoading" class="loader" role="status" aria-live="polite" aria-atomic="true">
@@ -119,11 +88,6 @@ watchDebounced(
   display: flex;
   justify-content: center;
   margin-top: 3rem;
-}
-
-.millesime-selector {
-  max-width: 18rem;
-  margin-top: 1rem;
 }
 
 .chart-section {

--- a/qa/protocoles/administration-referentiels.md
+++ b/qa/protocoles/administration-referentiels.md
@@ -8,7 +8,7 @@
 | Légende           |                                                                              |
 | :---------------- | :--------------------------------------------------------------------------- |
 | **Automatisé** ✅ | tests Playwright dédiés dans `e2e/tests/administration-referentiels.spec.ts` |
-| **Statut**        | 🟢 automatisé — 6 cas couverts par la CI                                     |
+| **Statut**        | 🟢 automatisé — 7 cas couverts par la CI                                     |
 
 ---
 
@@ -54,3 +54,12 @@
   `admin-label-source-edit-btn` pour la modifier → `admin-label-source-delete-btn` pour la supprimer.
 - **Résultat attendu** : `admin-label-sources-table` reflète chaque étape ; le compteur de noms
   alternatifs liés est cohérent.
+
+### ADM-07 — Créer une campagne dette IT et la retrouver ✅
+
+- **Datafeature** : nettoyage idempotent du millésime de test via l'API admin (suppression si présent).
+- **Action** : administration → onglet Campagnes dette IT → `admin-create-campaign-btn` pour créer une
+  campagne (millésime + libellé) → vérifier sa présence dans `admin-campaigns-table` →
+  `admin-campaign-delete-btn` pour la supprimer.
+- **Résultat attendu** : la campagne créée apparaît dans le tableau ; sa suppression la retire ; les
+  actions admin sont réservées au privilège `AdminPanelManage`.

--- a/qa/protocoles/time.md
+++ b/qa/protocoles/time.md
@@ -39,15 +39,15 @@
 
 ### TIM-05 — Le sélecteur de campagne présente le millésime le plus récent par défaut ✅
 
-- **Datafeature** : garantir au moins deux campagnes dette IT (millésimes) via l'API (semis d'une
-  campagne précédente sur la première application si besoin).
+- **Datafeature** : garantir au moins deux campagnes dette IT via l'API admin (`/mdit-campaigns`,
+  création d'une campagne précédente si besoin).
 - **Action** : ouvrir `/time`.
-- **Résultat attendu** : le sélecteur de campagne dette IT (millésime) est visible et propose au
-  moins deux millésimes ; le plus récent est présenté (sélectionné) par défaut.
+- **Résultat attendu** : le sélecteur de campagne dette IT (millésime), dans la sidebar, est visible
+  et propose au moins deux millésimes ; le plus récent est présenté (sélectionné) par défaut.
 
 ### TIM-06 — Sélectionner une campagne précédente reflète millesime dans l'URL et recharge le diagramme ✅
 
-- **Datafeature** : garantir au moins deux campagnes dette IT (millésimes) via l'API.
+- **Datafeature** : garantir au moins deux campagnes dette IT via l'API admin (`/mdit-campaigns`).
 - **Action** : depuis `/time`, sélectionner une campagne précédente dans le sélecteur de millésime.
 - **Résultat attendu** : l'URL porte `millesime=<année>` ; le diagramme se recharge et reste affiché
   (graphique ou état vide), sans erreur.

--- a/qa/protocoles/time.md
+++ b/qa/protocoles/time.md
@@ -36,3 +36,18 @@
 - **Action** : depuis la sidebar, régler une borne de Qualité (IQ min/max).
 - **Résultat attendu** : l'URL porte `iqGte`/`iqLte` ; le diagramme se recharge et reste affiché
   (graphique ou état vide), sans erreur.
+
+### TIM-05 — Le sélecteur de campagne présente le millésime le plus récent par défaut ✅
+
+- **Datafeature** : garantir au moins deux campagnes dette IT (millésimes) via l'API (semis d'une
+  campagne précédente sur la première application si besoin).
+- **Action** : ouvrir `/time`.
+- **Résultat attendu** : le sélecteur de campagne dette IT (millésime) est visible et propose au
+  moins deux millésimes ; le plus récent est présenté (sélectionné) par défaut.
+
+### TIM-06 — Sélectionner une campagne précédente reflète millesime dans l'URL et recharge le diagramme ✅
+
+- **Datafeature** : garantir au moins deux campagnes dette IT (millésimes) via l'API.
+- **Action** : depuis `/time`, sélectionner une campagne précédente dans le sélecteur de millésime.
+- **Résultat attendu** : l'URL porte `millesime=<année>` ; le diagramme se recharge et reste affiché
+  (graphique ou état vide), sans erreur.


### PR DESCRIPTION
Ferme #1848.

## Contexte

En tant que responsable de la gestion de la dette IT, on mène des campagnes annuelles. Cette PR introduit la notion de **millésime/campagne** sur la dette IT : enregistrement de la campagne sur chaque évaluation, gestion admin des campagnes, et sélection de la campagne à afficher dans le diagramme Time (la plus récente par défaut, possibilité de revenir à une précédente).

## Changements

### Backend
- `TechnicalDebtInfo.millesime` (Int, défaut = année courante) + index ; migration.
- Filtre `?millesime=` sur `GET /technical-debts` (défaut = campagne la plus récente) ; `GET /technical-debts/millesimes`.
- Entité **`MditCampaign`** (année unique, libellé, actif) + module CRUD : `GET /mdit-campaigns` (authentifié) ; `POST/PATCH/DELETE` réservés à `AdminPanelManage`.
- Seed : enregistre les 3 dernières campagnes et alimente la dette par millésime.

### Frontend
- Sélecteur de **campagne (millésime)** dans la sidebar du diagramme Time (accordéon « Général »), par défaut la campagne la plus récente.
- Onglet d'administration **« Campagnes dette IT »** (créer / éditer / activer / supprimer).

## Tests
- **Backend e2e (jest)** : dette (millésime défaut/explicite/hors-plage, filtre + défaut au plus récent, liste) et campagnes (CRUD + permissions 403, conflit 409, hors-plage 400, tri/filtre).
- **Non-régression e2e (POM strict)** : `TIM-05/06` (sélecteur alimenté par les campagnes), `ADM-07` (création d'une campagne côté admin) — verts sur chromium/firefox/webkit. Protocoles `qa/protocoles/{time,administration-referentiels}.md` et templates d'issue mis à jour.
- `build`, lint, `type-check` (front + e2e), prettier : OK.

## Définition du fini
- [x] Fonctionnalité terminée
- [x] Tests ajoutés (backend + e2e non-régression)
- [x] Documentation (protocoles QA + schema.md)