### PR TITLE
feat: impersonation d'un utilisateur par un administrateur (#1764)

### DIFF
--- a/.github/ISSUE_TEMPLATE/qa-impersonation.md
+++ b/.github/ISSUE_TEMPLATE/qa-impersonation.md
@@ -1,0 +1,37 @@
+---
+name: "🧪 QA — Impersonation"
+about: "Campagne de non-régression de l'impersonation (se connecter en tant que) pour une version"
+title: "[QA][vX.Y.Z] Impersonation"
+labels: ["qa", "non-regression", "qa:impersonation"]
+---
+
+## Campagne
+
+- **Version testée** : `vX.Y.Z`
+- **Environnement** : (prod / recette / local)
+- **Navigateur** :
+- **Testeur** :
+- **Date** :
+
+> Protocole de référence : [`qa/protocoles/impersonation.md`](../blob/main/qa/protocoles/impersonation.md).
+> Prévoir un compte Admin et un compte non-admin (Lecteur). Cocher chaque étape validée et **glisser
+> une capture** dans la zone `📎`. Tout échec → 🐛 lié, case décochée.
+
+## Récapitulatif
+
+| Total | ✅ Passés | ❌ Échecs | ⏭️ Non testés |
+| ----- | --------- | --------- | ------------- |
+| 7     |           |           |               |
+
+## Protocole
+
+<!-- qa-steps -->
+
+## Bugs liés
+
+-
+
+## Verdict
+
+- [ ] `qa:pass` — aucune régression bloquante
+- [ ] `qa:fail` — régression(s) constatée(s) (voir bugs liés)

--- a/backend/prisma/migrations/20260618120000_add_impersonation_log/migration.sql
+++ b/backend/prisma/migrations/20260618120000_add_impersonation_log/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "ImpersonationLog" (
+    "id" TEXT NOT NULL,
+    "adminId" TEXT NOT NULL,
+    "targetId" TEXT NOT NULL,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "endedAt" TIMESTAMP(3),
+
+    CONSTRAINT "ImpersonationLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ImpersonationLog_adminId_startedAt_idx" ON "ImpersonationLog"("adminId", "startedAt");
+
+-- AddForeignKey
+ALTER TABLE "ImpersonationLog" ADD CONSTRAINT "ImpersonationLog_adminId_fkey" FOREIGN KEY ("adminId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ImpersonationLog" ADD CONSTRAINT "ImpersonationLog_targetId_fkey" FOREIGN KEY ("targetId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema/user-log.prisma
+++ b/backend/prisma/schema/user-log.prisma
@@ -14,8 +14,26 @@ model UserConnexionLog {
   id             String   @id @default(cuid())
   userId         String
   user           User     @relation(fields: [userId], references: [id], onDelete: Restrict)
-  authTime  DateTime @db.Date 
+  authTime  DateTime @db.Date
   createdAt      DateTime @default(now())
 
   @@unique([userId, authTime])
+}
+
+/// Journal des sessions d'impersonation : trace quel administrateur s'est fait
+/// passer pour quel utilisateur, et sur quelle période.
+model ImpersonationLog {
+  id        String    @id @default(cuid())
+  /// Administrateur réel à l'origine de l'impersonation
+  adminId   String
+  admin     User      @relation("ImpersonationAdmin", fields: [adminId], references: [id], onDelete: Restrict)
+  /// Utilisateur cible impersonné
+  targetId  String
+  target    User      @relation("ImpersonationTarget", fields: [targetId], references: [id], onDelete: Restrict)
+  /// Début de la session d'impersonation
+  startedAt DateTime  @default(now())
+  /// Fin de la session d'impersonation (null tant qu'elle est active)
+  endedAt   DateTime?
+
+  @@index([adminId, startedAt])
 }

--- a/backend/prisma/schema/users.prisma
+++ b/backend/prisma/schema/users.prisma
@@ -41,6 +41,10 @@ model User {
   additionalPermissions     Permission[]
   userPermissionLog         UserPermissionLog[]
   userConnexionLog          UserConnexionLog[]
+  /// Sessions d'impersonation initiées par cet utilisateur (en tant qu'admin)
+  impersonationsAsAdmin     ImpersonationLog[]  @relation("ImpersonationAdmin")
+  /// Sessions où cet utilisateur a été impersonné
+  impersonationsAsTarget    ImpersonationLog[]  @relation("ImpersonationTarget")
 }
 
 /// @namespace Roles

--- a/backend/src/common/decorators/impersonator.decorator.ts
+++ b/backend/src/common/decorators/impersonator.decorator.ts
@@ -1,0 +1,15 @@
+import type { ExecutionContext } from "@nestjs/common";
+import type { Request } from "express";
+import type { Requestor } from "src/user/entities/user.entity";
+import { createParamDecorator } from "@nestjs/common";
+
+/// Récupère l'administrateur réel lorsqu'une impersonation est en cours.
+/// Retourne `undefined` en l'absence d'impersonation.
+export const Impersonator = createParamDecorator<
+  unknown,
+  ExecutionContext,
+  Requestor | undefined
+>((_data: unknown, ctx: ExecutionContext): Requestor | undefined => {
+  const request = ctx.switchToHttp().getRequest<Request>();
+  return request.impersonator ?? undefined;
+});

--- a/backend/src/middlewares/auth.middleware.ts
+++ b/backend/src/middlewares/auth.middleware.ts
@@ -1,24 +1,29 @@
 import {
+  ForbiddenException,
   Inject,
   Injectable,
   NestMiddleware,
+  NotFoundException,
   UnauthorizedException,
 } from "@nestjs/common";
 import { ConfigType } from "@nestjs/config";
+import { Roles } from "@prisma/client";
 import { NextFunction, Request, Response } from "express";
 import { createRemoteJWKSet, decodeJwt, jwtVerify } from "jose";
 import { oidcConfig } from "src/config/configs";
 import { roleToPermissions } from "src/permissions/role-to-permissions";
 import { TokenService } from "src/token/token.service";
-import { Requestor, UserEntity } from "src/user/entities/user.entity";
+import { Requestor, UserEntity, UserType } from "src/user/entities/user.entity";
 import { UserConnexionLogService } from "src/user/user-connexion-log.service";
 import { UserService } from "src/user/user.service";
-import { API_KEY_HEADER } from "src/utils/constants.util";
+import { API_KEY_HEADER, IMPERSONATE_HEADER } from "src/utils/constants.util";
 import { LoggerService } from "src/logger/logger.service";
 
 declare module "express" {
   export interface Request {
     user?: Requestor | null;
+    /// Administrateur réel lorsqu'une impersonation est en cours.
+    impersonator?: Requestor | null;
   }
 }
 
@@ -60,18 +65,65 @@ export class AuthMiddleware implements NestMiddleware {
         res.json({ message: "L'authentification a échoué" });
         return;
       }
-      req.user = {
+
+      // L'utilisateur réellement authentifié (avant toute impersonation).
+      const authenticatedUser: Requestor = {
         ...user,
         permissions: roleToPermissions(user.role),
       };
+      req.user = authenticatedUser;
 
-      await this.userConnexionLogService.log(user.id);
+      // Impersonation : un administrateur peut se faire passer pour un autre
+      // utilisateur en fournissant son identifiant via un header dédié. Seule
+      // l'authentification humaine (JWT) y donne droit, pas les tokens API.
+      const impersonateUserId = req.headers[IMPERSONATE_HEADER] as
+        | string
+        | undefined;
+      if (impersonateUserId && authorization) {
+        req.user = await this.resolveImpersonatedUser(
+          authenticatedUser,
+          impersonateUserId,
+        );
+        req.impersonator = authenticatedUser;
+      }
+
+      // On journalise toujours la connexion de l'utilisateur réellement
+      // authentifié, jamais celle de la cible impersonnée.
+      await this.userConnexionLogService.log(authenticatedUser.id);
 
       next();
     } catch (error) {
       this.logger.error(error);
 
+      if (
+        error instanceof ForbiddenException ||
+        error instanceof NotFoundException
+      ) {
+        throw error;
+      }
+
       throw new UnauthorizedException("L'authentification a échoué");
     }
+  }
+
+  private async resolveImpersonatedUser(
+    admin: Requestor,
+    targetUserId: string,
+  ): Promise<Requestor> {
+    if (admin.role !== Roles.ADMIN) {
+      throw new ForbiddenException(
+        "Seuls les administrateurs peuvent impersonner un utilisateur",
+      );
+    }
+
+    const target = await this.userService.findByIdWithRelations(targetUserId);
+    if (!target || target.type === UserType.bot) {
+      throw new NotFoundException("Utilisateur à impersonner introuvable");
+    }
+
+    return {
+      ...target,
+      permissions: roleToPermissions(target.role),
+    };
   }
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -18,6 +18,7 @@ import {
   ApiCreatedResponse,
   ApiExtraModels,
   ApiForbiddenResponse,
+  ApiNoContentResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -176,13 +177,13 @@ export class UserController {
   }
 
   @Post("impersonate/stop")
-  @HttpCode(HttpStatus.OK)
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
     summary: "Arrêter l'impersonation en cours",
     description:
       "Clôture la session d'impersonation active de l'administrateur. À appeler en conservant le header d'impersonation pour que le serveur identifie l'administrateur réel.",
   })
-  @ApiOkResponse({ description: "Impersonation arrêtée" })
+  @ApiNoContentResponse({ description: "Impersonation arrêtée" })
   async stopImpersonation(
     @Impersonator() impersonator: Requestor | undefined,
     @User() current: UserEntity,

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -24,6 +25,7 @@ import {
   ApiTags,
 } from "@nestjs/swagger";
 import { Permission } from "@prisma/client";
+import { Impersonator } from "src/common/decorators/impersonator.decorator";
 import { RequiredPermissions } from "src/common/decorators/required-permissions.decorator";
 import { User } from "src/common/decorators/user.decorator";
 import { PaginatedResponseDto } from "src/common/dto";
@@ -171,6 +173,48 @@ export class UserController {
   })
   async syncOrganizationsFromMaia(@Body() body: SyncOrganizationsDto) {
     return this.userService.startSyncOrganizationsFromMaiaInBackground(body);
+  }
+
+  @Post("impersonate/stop")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: "Arrêter l'impersonation en cours",
+    description:
+      "Clôture la session d'impersonation active de l'administrateur. À appeler en conservant le header d'impersonation pour que le serveur identifie l'administrateur réel.",
+  })
+  @ApiOkResponse({ description: "Impersonation arrêtée" })
+  async stopImpersonation(
+    @Impersonator() impersonator: Requestor | undefined,
+    @User() current: UserEntity,
+  ): Promise<void> {
+    if (!impersonator) {
+      throw new BadRequestException("Aucune impersonation en cours");
+    }
+    return this.userService.stopImpersonation(impersonator.id, current.id);
+  }
+
+  @Post(":id/impersonate")
+  @HttpCode(HttpStatus.OK)
+  @RequiredPermissions([Permission.AdminPanelManage])
+  @ApiOperation({
+    summary: "Impersonner un utilisateur",
+    description:
+      "Démarre une session d'impersonation : l'administrateur se fait passer pour l'utilisateur cible. Renvoie les informations de l'utilisateur impersonné. Accès limité aux administrateurs.",
+  })
+  @ApiParam({ name: "id", description: "ID de l'utilisateur à impersonner" })
+  @ApiOkResponse({
+    description: "Session d'impersonation démarrée",
+    type: UserWithPermissions,
+  })
+  @ApiForbiddenResponse({
+    description: "Accès refusé - Privilège admin requis",
+  })
+  @ApiNotFoundResponse({ description: "Utilisateur non trouvé" })
+  async impersonate(
+    @Param("id") id: string,
+    @User() requestor: Requestor,
+  ): Promise<UserEntity> {
+    return this.userService.startImpersonation(requestor, id);
   }
 
   @Patch(":id")

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,5 +1,9 @@
-import { Injectable, NotFoundException } from "@nestjs/common";
-import { Prisma, Roles, User } from "@prisma/client";
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { Prisma, Roles, User, UserType } from "@prisma/client";
 import { PaginatedResponseDto } from "src/common/dto";
 import { OrganizationMaiaReferencesService } from "src/organization-maia-references/organization-maia-references.service";
 import { PrismaService } from "src/prisma/prisma.service";
@@ -222,6 +226,64 @@ export class UserService {
 
   getCurrentUser(requestor: UserEntity): UserEntity {
     return requestor;
+  }
+
+  findByIdWithRelations(id: string): Promise<UserEntity | null> {
+    return this.prisma.user.findUnique({
+      where: { id },
+      include: {
+        organization: true,
+        followedApplications: true,
+        scopeOrganization: true,
+      },
+    });
+  }
+
+  async startImpersonation(
+    admin: Requestor,
+    targetId: string,
+  ): Promise<UserEntity> {
+    if (admin.id === targetId) {
+      throw new BadRequestException("Vous ne pouvez pas vous impersonner.");
+    }
+
+    const target = await this.findByIdWithRelations(targetId);
+    if (!target) {
+      throw new NotFoundException("Utilisateur introuvable");
+    }
+    if (target.type === UserType.bot) {
+      throw new BadRequestException(
+        "Impossible d'impersonner un compte de service.",
+      );
+    }
+
+    await this.prisma.impersonationLog.create({
+      data: { adminId: admin.id, targetId },
+    });
+
+    this.logger.warn(
+      `[Impersonation] ${admin.email} (admin ${admin.id}) impersonne ${target.email} (${target.id})`,
+    );
+
+    return target;
+  }
+
+  async stopImpersonation(adminId: string, targetId: string): Promise<void> {
+    const openLog = await this.prisma.impersonationLog.findFirst({
+      where: { adminId, targetId, endedAt: null },
+      orderBy: { startedAt: "desc" },
+    });
+
+    if (openLog) {
+      await this.prisma.impersonationLog.update({
+        where: { id: openLog.id },
+        data: { endedAt: new Date() },
+      });
+    }
+
+    this.logger.warn(
+      `[Impersonation] Fin de l'impersonation de ${targetId} par l'admin ${adminId}`,
+    );
   }
 
   async syncOrganizationFromMaiaByEmail(email: string) {

--- a/backend/src/utils/constants.util.ts
+++ b/backend/src/utils/constants.util.ts
@@ -2,6 +2,10 @@ import type { MetadataAction } from "@prisma/client";
 
 export const API_KEY_HEADER = "x-refapp-token";
 
+/// Header envoyé par un administrateur pour impersonner un autre utilisateur.
+/// Contient l'identifiant de l'utilisateur cible.
+export const IMPERSONATE_HEADER = "x-impersonate-user-id";
+
 export const MetadataTypes: Record<
   string,
   { label: string; dbAction: MetadataAction }

--- a/backend/tests/swagger.e2e-spec.ts
+++ b/backend/tests/swagger.e2e-spec.ts
@@ -41,6 +41,8 @@ describe("Test Swagger documentation", () => {
       "/users/me/subscribe/{appId}",
       "/applications/{applicationId}/compliances/ecoindex/scan",
       "/users/{id}/sync-organization-from-maia",
+      "/users/{id}/impersonate",
+      "/users/impersonate/stop",
       "/actors/sync-maia",
       "/email/digest",
     ];

--- a/e2e/fixtures/api-client.ts
+++ b/e2e/fixtures/api-client.ts
@@ -138,6 +138,44 @@ export class ApiClient {
     return (await res.json()) as T;
   }
 
+  /**
+   * Tente de démarrer une impersonation et renvoie le code HTTP brut (sans suivre la redirection
+   * d'identité). `impersonateUserId` permet de simuler une requête déjà impersonnée (chaînage).
+   */
+  async impersonateStatus(
+    targetId: string,
+    opts: { impersonateUserId?: string } = {},
+  ): Promise<number> {
+    const res = await this.page.request.post(
+      `/api/v2/users/${targetId}/impersonate`,
+      {
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          Accept: "application/json",
+          ...(opts.impersonateUserId
+            ? { "x-impersonate-user-id": opts.impersonateUserId }
+            : {}),
+        },
+      },
+    );
+    return res.status();
+  }
+
+  /** Crée un token de service (génère un compte de service `bot` côté backend). */
+  createServiceToken(body: {
+    name: string;
+    description: string;
+    expiresAt: string;
+    role: string;
+  }): Promise<{ id: string } | null> {
+    return this.post<{ id: string }>("/tokens", body);
+  }
+
+  /** Révoque (supprime) un token de service. */
+  deleteToken(id: string): Promise<boolean> {
+    return this.del(`/tokens/${id}`);
+  }
+
   /** Récupère un utilisateur par email (recherche admin). */
   async userByEmail(email: string): Promise<UserAdmin | null> {
     const page = await this.get<Paginated<UserAdmin>>(

--- a/e2e/fixtures/datafeature.ts
+++ b/e2e/fixtures/datafeature.ts
@@ -1,3 +1,4 @@
+import { type Page } from "@playwright/test";
 import { ApiClient } from "./api-client";
 import { dbQuery } from "../support/db";
 
@@ -13,6 +14,11 @@ export interface AppRef {
  */
 export class DataFeature {
   constructor(private readonly api: ApiClient) {}
+
+  /** Construit une datafeature depuis une page déjà authentifiée (rôle quelconque). */
+  static async forPage(page: Page): Promise<DataFeature> {
+    return new DataFeature(await ApiClient.fromPage(page));
+  }
 
   /** Première application du catalogue. */
   async firstApplication(): Promise<AppRef | null> {
@@ -125,6 +131,60 @@ export class DataFeature {
       role: "READER",
       additionalPermissions: [],
     });
+  }
+
+  // --- Impersonation (#1764) ---
+
+  /** Tente de démarrer une impersonation et renvoie le code HTTP (autorisations). */
+  impersonateStatus(
+    targetId: string,
+    opts: { impersonateUserId?: string } = {},
+  ): Promise<number> {
+    return this.api.impersonateStatus(targetId, opts);
+  }
+
+  /** Id d'un compte de service (bot) du jeu de données, ou `null` si aucun. */
+  async findBotUserId(): Promise<string | null> {
+    const rows = await dbQuery<{ id: string }>(
+      `SELECT id FROM "User" WHERE type = 'bot' LIMIT 1`,
+    );
+    return rows[0]?.id ?? null;
+  }
+
+  /** Crée un token de service (donc un compte `bot`) ; renvoie l'id du token, ou `null`. */
+  async createServiceToken(name: string): Promise<string | null> {
+    const expiresAt = new Date(
+      Date.now() + 7 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const token = await this.api.createServiceToken({
+      name,
+      description:
+        "Compte de service éphémère pour la non-régression impersonation",
+      expiresAt,
+      role: "VISITOR",
+    });
+    return token?.id ?? null;
+  }
+
+  /** Révoque un token de service (nettoyage). */
+  revokeToken(id: string): Promise<boolean> {
+    return this.api.deleteToken(id);
+  }
+
+  /** Dernière entrée d'audit d'impersonation visant la cible `email`, ou `null`. */
+  async latestImpersonationLog(
+    email: string,
+  ): Promise<{ startedAt: string; endedAt: string | null } | null> {
+    const rows = await dbQuery<{ startedAt: string; endedAt: string | null }>(
+      `SELECT l."startedAt", l."endedAt"
+         FROM "ImpersonationLog" l
+         JOIN "User" u ON u.id = l."targetId"
+        WHERE u.email = $1
+        ORDER BY l."startedAt" DESC
+        LIMIT 1`,
+      [email],
+    );
+    return rows[0] ?? null;
   }
 
   // --- Abonnements & digest (SIG-10), avec le token de l'utilisateur courant ---

--- a/e2e/pom/admin.page.ts
+++ b/e2e/pom/admin.page.ts
@@ -163,6 +163,55 @@ export class AdminPage extends BasePage {
     await expect(this.page).not.toHaveURL(/\/administration/);
   }
 
+  // --- Impersonation (#1764) ---
+
+  private impersonationBanner = () => this.byTestId("impersonation-banner");
+
+  /** Impersonne l'utilisateur dont la LIGNE contient l'email (recharge l'app sous son identité). */
+  async impersonateUser(email: string): Promise<void> {
+    await this.expectUserRow(email);
+    const row = this.usersTable().locator("tr", { hasText: email });
+    const impersonated = this.page
+      .waitForResponse(
+        (r) =>
+          /\/users\/[^/]+\/impersonate$/.test(r.url()) &&
+          r.request().method() === "POST",
+        { timeout: 10_000 },
+      )
+      .catch(() => null);
+    await row.getByTestId("admin-user-impersonate-btn").first().click();
+    await impersonated;
+  }
+
+  /** Vérifie que le bandeau d'impersonation est affiché pour `email`. */
+  async expectImpersonationBanner(email: string): Promise<void> {
+    await expect(this.impersonationBanner()).toBeVisible();
+    await expect(this.impersonationBanner()).toContainText(email);
+  }
+
+  /** Vérifie qu'aucun bouton d'impersonation n'est proposé sur la ligne de `email` (ex. soi-même). */
+  async expectImpersonateUnavailable(email: string): Promise<void> {
+    await this.expectUserRow(email);
+    const row = this.usersTable().locator("tr", { hasText: email });
+    await expect(row.getByTestId("admin-user-impersonate-btn")).toHaveCount(0);
+  }
+
+  /** Recharge la page et vérifie que l'impersonation de `email` est toujours active. */
+  async expectImpersonationPersistsAfterReload(email: string): Promise<void> {
+    await this.page.reload();
+    await this.expectImpersonationBanner(email);
+  }
+
+  /** Arrête l'impersonation depuis le bandeau (recharge l'app sous l'identité admin). */
+  async stopImpersonation(): Promise<void> {
+    await this.byTestId("impersonation-stop-btn").click();
+  }
+
+  /** Vérifie que plus aucune impersonation n'est en cours. */
+  async expectNotImpersonating(): Promise<void> {
+    await expect(this.impersonationBanner()).toBeHidden();
+  }
+
   // --- Onglet « Organisations » (ADM-01 to ADM-04) ---
 
   private orgsTable = () => this.byTestId("admin-organizations-table");

--- a/e2e/tests/impersonation.spec.ts
+++ b/e2e/tests/impersonation.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect } from "../fixtures/test";
+import { DataFeature } from "../fixtures/datafeature";
+import { AdminPage, loginAs } from "../pom";
+import { captureStepScreenshot } from "../support/screenshots";
+
+const ADMIN_EMAIL = "admin@example.com";
+const USER_EMAIL = "user@example.com";
+
+/**
+ * Non-régression — Impersonation (#1764). Fonctionnalité **sensible** : un administrateur peut se
+ * faire passer pour un autre utilisateur. On couvre le cycle UI (impersonner, bascule d'identité,
+ * arrêt, persistance) ET les garde-fous serveur (réservé aux admins, pas de bot, pas de chaînage,
+ * traçabilité en base).
+ * Utilisateurs Keycloak : `admin` (ADMIN, `admin@example.com`) et `user` (READER, `user@example.com`),
+ * mot de passe `pass`. Page admin : `/administration`.
+ */
+test.describe("Impersonation", () => {
+  test.afterEach(async ({ page }, testInfo) => {
+    await captureStepScreenshot(page, testInfo);
+  });
+
+  test("IMP-01 - un admin impersonne un utilisateur puis arrête", async ({
+    page,
+  }) => {
+    await loginAs(page, "admin");
+    const admin = new AdminPage(page);
+    await admin.open();
+
+    // Démarre l'impersonation : l'app se recharge sous l'identité de l'utilisateur cible.
+    await admin.impersonateUser(USER_EMAIL);
+    await admin.expectImpersonationBanner(USER_EMAIL);
+
+    // Sous l'identité d'un lecteur, l'accès à l'administration est refusé : preuve que
+    // l'identité (et les droits) ont bien basculé côté serveur.
+    await admin.goToAdministration();
+    await admin.expectAccessDenied();
+
+    // Arrête l'impersonation : retour à l'identité administrateur.
+    await admin.stopImpersonation();
+    await admin.expectNotImpersonating();
+
+    // L'admin retrouve l'accès au panneau d'administration.
+    await admin.open();
+    await admin.expectLoaded();
+  });
+
+  test("IMP-02 - un admin ne peut pas s'impersonner lui-même", async ({
+    page,
+  }) => {
+    await loginAs(page, "admin");
+    const admin = new AdminPage(page);
+    await admin.open();
+
+    // La ligne de l'administrateur connecté n'expose pas le bouton « Se connecter en tant que ».
+    await admin.expectImpersonateUnavailable(ADMIN_EMAIL);
+  });
+
+  test("IMP-03 - l'impersonation survit à un rechargement", async ({
+    page,
+  }) => {
+    await loginAs(page, "admin");
+    const admin = new AdminPage(page);
+    await admin.open();
+
+    await admin.impersonateUser(USER_EMAIL);
+    await admin.expectImpersonationBanner(USER_EMAIL);
+
+    // Le bandeau reste affiché après un rechargement complet (état persisté).
+    await admin.expectImpersonationPersistsAfterReload(USER_EMAIL);
+
+    // Restauration : on arrête l'impersonation pour ne pas laisser d'état entre les tests.
+    await admin.stopImpersonation();
+    await admin.expectNotImpersonating();
+  });
+
+  test("IMP-04 - un non-admin ne peut pas impersonner (403)", async ({
+    browser,
+    data,
+  }) => {
+    const target = await data.getUser(USER_EMAIL);
+    test.skip(!target, "Utilisateur cible introuvable dans le jeu de données");
+
+    // Session Lecteur dans un contexte séparé (pas d'interférence avec la session admin).
+    const ctx = await browser.newContext();
+    try {
+      const userPage = await ctx.newPage();
+      await loginAs(userPage, "user");
+      const reader = await DataFeature.forPage(userPage);
+      expect(await reader.impersonateStatus(target!.id)).toBe(403);
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  test("IMP-05 - la session d'impersonation est tracée en base (audit)", async ({
+    page,
+    data,
+  }) => {
+    await loginAs(page, "admin");
+    const admin = new AdminPage(page);
+    await admin.open();
+
+    await admin.impersonateUser(USER_EMAIL);
+    await admin.expectImpersonationBanner(USER_EMAIL);
+
+    // À l'ouverture : une entrée d'audit existe, encore ouverte (endedAt null).
+    const opened = await data.latestImpersonationLog(USER_EMAIL);
+    expect(opened?.startedAt).toBeTruthy();
+    expect(opened?.endedAt).toBeNull();
+
+    await admin.stopImpersonation();
+    await admin.expectNotImpersonating();
+
+    // À l'arrêt : la même entrée est clôturée (endedAt renseigné).
+    const closed = await data.latestImpersonationLog(USER_EMAIL);
+    expect(closed?.endedAt).toBeTruthy();
+  });
+
+  test("IMP-06 - impossible d'impersonner un compte de service (400)", async ({
+    data,
+  }) => {
+    // On réutilise un bot existant, sinon on en crée un via l'API token (nettoyé en finally).
+    let botId = await data.findBotUserId();
+    let createdTokenId: string | null = null;
+    if (!botId) {
+      createdTokenId = await data.createServiceToken(
+        `e2e-imp-bot-${Date.now()}`,
+      );
+      botId = await data.findBotUserId();
+    }
+    test.skip(!botId, "Impossible d'obtenir un compte de service (bot)");
+
+    try {
+      expect(await data.impersonateStatus(botId!)).toBe(400);
+    } finally {
+      if (createdTokenId) await data.revokeToken(createdTokenId);
+    }
+  });
+
+  test("IMP-07 - pas d'impersonation en chaîne (403)", async ({ data }) => {
+    const reader = await data.getUser(USER_EMAIL);
+    const admin = await data.getUser(ADMIN_EMAIL);
+    test.skip(!reader || !admin, "Comptes admin/lecteur introuvables");
+
+    // Déjà en train d'impersonner le lecteur (header), tenter d'impersonner un autre compte :
+    // l'identité effective (lecteur) n'a pas le droit d'administration → refus.
+    expect(
+      await data.impersonateStatus(admin!.id, {
+        impersonateUserId: reader!.id,
+      }),
+    ).toBe(403);
+  });
+});

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -2515,7 +2515,7 @@ paths:
         identifie l'administrateur réel.
       parameters: []
       responses:
-        "200":
+        "204":
           description: Impersonation arrêtée
       tags: *a13
   /api/v2/users/{id}/impersonate:

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -2506,6 +2506,44 @@ paths:
         "403":
           description: Accès refusé - Privilège admin requis
       tags: *a13
+  /api/v2/users/impersonate/stop:
+    post:
+      operationId: UserController_stopImpersonation
+      summary: Arrêter l'impersonation en cours
+      description: Clôture la session d'impersonation active de l'administrateur. À
+        appeler en conservant le header d'impersonation pour que le serveur
+        identifie l'administrateur réel.
+      parameters: []
+      responses:
+        "200":
+          description: Impersonation arrêtée
+      tags: *a13
+  /api/v2/users/{id}/impersonate:
+    post:
+      operationId: UserController_impersonate
+      summary: Impersonner un utilisateur
+      description: "Démarre une session d'impersonation : l'administrateur se fait
+        passer pour l'utilisateur cible. Renvoie les informations de
+        l'utilisateur impersonné. Accès limité aux administrateurs."
+      parameters:
+        - name: id
+          required: true
+          in: path
+          description: ID de l'utilisateur à impersonner
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Session d'impersonation démarrée
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserWithPermissions"
+        "403":
+          description: Accès refusé - Privilège admin requis
+        "404":
+          description: Utilisateur non trouvé
+      tags: *a13
   /api/v2/users/{id}:
     patch:
       operationId: UserController_update

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -9,6 +9,7 @@ import { useRoute } from "vue-router";
 import { useUserStore } from "@/stores/userStore";
 import { configureClients } from "./api/init-clients";
 import SearchHeader from "./components/search/SearchHeader.vue";
+import ImpersonationBanner from "./components/ImpersonationBanner.vue";
 import AppToaster from "./components/AppToaster.vue";
 import { useScheme } from "@gouvminint/vue-dsfr";
 import ReloadPrompt from "./components/ReloadPrompt.vue";
@@ -184,6 +185,7 @@ function close() {
       { id: 'footer', text: 'Aller au pied de page' },
     ]"
   />
+  <ImpersonationBanner />
   <DsfrHeader
     :service-description="serviceDescription"
     :service-title="serviceTitle"

--- a/frontend/src/api/init-clients.ts
+++ b/frontend/src/api/init-clients.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { client } from "@/client/client.gen";
 import { USER_MANAGER } from "@/services/authentication";
+import { IMPERSONATE_HEADER, getImpersonatedUserId } from "@/services/impersonation";
 
 axios.defaults.baseURL = "/api/v2";
 axios.defaults.withCredentials = true;
@@ -14,6 +15,10 @@ const requestInterceptor: ReqInterceptor = async (req) => {
   const token = user?.access_token;
   if (token) {
     req.headers.set("Authorization", `Bearer ${token}`);
+  }
+  const impersonatedUserId = getImpersonatedUserId();
+  if (impersonatedUserId) {
+    req.headers.set(IMPERSONATE_HEADER, impersonatedUserId);
   }
   return req;
 };

--- a/frontend/src/components/ImpersonationBanner.vue
+++ b/frontend/src/components/ImpersonationBanner.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { useUserStore } from "@/stores/userStore";
+import { ref } from "vue";
+
+const userStore = useUserStore();
+const isStopping = ref(false);
+
+async function stop() {
+  isStopping.value = true;
+  try {
+    await userStore.stopImpersonation();
+  } finally {
+    isStopping.value = false;
+  }
+}
+</script>
+
+<template>
+  <div
+    v-if="userStore.isImpersonating && userStore.impersonation"
+    class="fr-notice fr-notice--warning impersonation-banner"
+    role="alert"
+    data-testid="impersonation-banner"
+  >
+    <div class="fr-container">
+      <div class="fr-notice__body impersonation-banner__body">
+        <p class="fr-notice__title impersonation-banner__text">
+          Vous êtes connecté en tant que <strong>{{ userStore.impersonation.userEmail }}</strong>
+          <span class="fr-notice__desc">·&nbsp;impersonation initiée par {{ userStore.impersonation.adminEmail }}</span>
+        </p>
+        <button
+          type="button"
+          class="fr-btn fr-btn--secondary fr-btn--sm fr-icon-logout-box-r-line fr-btn--icon-left impersonation-banner__stop"
+          :disabled="isStopping"
+          data-testid="impersonation-stop-btn"
+          @click="stop"
+        >
+          {{ isStopping ? "Arrêt…" : "Arrêter l'impersonation" }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* Bandeau collant en haut de page, au-dessus de l'en-tête. */
+.impersonation-banner {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
+.impersonation-banner__body {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.impersonation-banner__text {
+  margin-bottom: 0;
+}
+
+.impersonation-banner__stop {
+  flex-shrink: 0;
+}
+</style>

--- a/frontend/src/components/admin/UserActions.vue
+++ b/frontend/src/components/admin/UserActions.vue
@@ -9,6 +9,7 @@ import {
 } from "@/client/types.gen";
 import { Roles } from "@/client/types.gen";
 import { useToasterStore } from "@/stores/toasterStore";
+import { useUserStore } from "@/stores/userStore";
 import { RolesOptions, RolesScopes } from "@/utils/roles-utils";
 import type { DsfrCheckboxProps } from "@gouvminint/vue-dsfr";
 import { useMemoize } from "@vueuse/core";
@@ -22,6 +23,22 @@ const emit = defineEmits<{
 }>();
 
 const toaster = useToasterStore();
+const userStore = useUserStore();
+
+// On peut impersonner tout utilisateur humain, sauf soi-même.
+const canImpersonate = computed(() => props.user.type !== "bot" && props.user.id !== userStore.user?.id);
+const isImpersonating = ref(false);
+
+async function impersonate() {
+  isImpersonating.value = true;
+  try {
+    await userStore.startImpersonation(props.user);
+  } catch (err) {
+    toaster.addErrorMessage("Impossible d'impersonner cet utilisateur");
+    console.error(err);
+    isImpersonating.value = false;
+  }
+}
 
 const isEditModalOpen = ref(false);
 const isSaving = ref(false);
@@ -176,6 +193,17 @@ const isScopeDisabled = computed(() => {
         title="Modifier les permissions de l'utilisateur"
         aria-label="Modifier les permissions de l'utilisateur"
         @click="openEditModal"
+      />
+      <DsfrButton
+        v-if="canImpersonate"
+        :label="isImpersonating ? '...' : 'Se connecter en tant que'"
+        size="sm"
+        tertiary
+        :disabled="isImpersonating"
+        data-testid="admin-user-impersonate-btn"
+        title="Se connecter en tant que cet utilisateur"
+        aria-label="Se connecter en tant que cet utilisateur"
+        @click="impersonate"
       />
     </div>
 

--- a/frontend/src/services/impersonation.ts
+++ b/frontend/src/services/impersonation.ts
@@ -1,0 +1,41 @@
+// Gestion de l'état d'impersonation côté client.
+//
+// L'impersonation est pilotée par un header HTTP envoyé sur chaque requête. On
+// persiste l'identifiant de la cible (et quelques infos d'affichage) dans le
+// localStorage afin que la session survive à un rechargement de page.
+
+export const IMPERSONATE_HEADER = "x-impersonate-user-id";
+
+const USER_ID_KEY = "impersonatedUserId";
+const USER_EMAIL_KEY = "impersonatedUserEmail";
+const ADMIN_EMAIL_KEY = "impersonatorEmail";
+
+export interface ImpersonationState {
+  userId: string;
+  userEmail: string;
+  adminEmail: string;
+}
+
+export function getImpersonatedUserId(): string | null {
+  return localStorage.getItem(USER_ID_KEY);
+}
+
+export function getImpersonationState(): ImpersonationState | null {
+  const userId = localStorage.getItem(USER_ID_KEY);
+  const userEmail = localStorage.getItem(USER_EMAIL_KEY);
+  const adminEmail = localStorage.getItem(ADMIN_EMAIL_KEY);
+  if (!userId || !userEmail || !adminEmail) return null;
+  return { userId, userEmail, adminEmail };
+}
+
+export function setImpersonationState(state: ImpersonationState): void {
+  localStorage.setItem(USER_ID_KEY, state.userId);
+  localStorage.setItem(USER_EMAIL_KEY, state.userEmail);
+  localStorage.setItem(ADMIN_EMAIL_KEY, state.adminEmail);
+}
+
+export function clearImpersonationState(): void {
+  localStorage.removeItem(USER_ID_KEY);
+  localStorage.removeItem(USER_EMAIL_KEY);
+  localStorage.removeItem(ADMIN_EMAIL_KEY);
+}

--- a/frontend/src/stores/userStore.ts
+++ b/frontend/src/stores/userStore.ts
@@ -1,13 +1,17 @@
 import client from "@/api/index";
-import { Roles, type Permission, type UserFollowedApplicationDto, type UserWithPermissions } from "@/client/types.gen";
+import { Roles, type Permission, type UserEntity, type UserFollowedApplicationDto, type UserWithPermissions } from "@/client/types.gen";
 import type { APP_PERMISSIONS } from "@/models/Application";
 import { USER_MANAGER } from "@/services/authentication";
+import { clearImpersonationState, getImpersonationState, setImpersonationState, type ImpersonationState } from "@/services/impersonation";
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 
 export const useUserStore = defineStore("userStore", () => {
   const user = ref<UserWithPermissions>();
   const authenticated = ref(false);
+  // État d'impersonation restauré depuis le localStorage (survit au rechargement).
+  const impersonation = ref<ImpersonationState | null>(getImpersonationState());
+  const isImpersonating = computed(() => impersonation.value !== null);
 
   // Écoute les événements OIDC pour maintenir l'état d'authentification à jour
   USER_MANAGER.events.addUserLoaded(() => {
@@ -76,6 +80,39 @@ export const useUserStore = defineStore("userStore", () => {
     return user.value?.organization?.businessDivisionId ?? null;
   }
 
+  // Démarre une impersonation : l'admin se fait passer pour `target`. On recharge
+  // l'application à la racine pour repartir d'un état propre sous la nouvelle identité.
+  async function startImpersonation(target: UserEntity) {
+    const adminEmail = user.value?.email;
+    if (!adminEmail) return;
+
+    const response = await client.userControllerImpersonate({
+      path: { id: target.id },
+    });
+
+    if (response.data && response.response.ok) {
+      setImpersonationState({
+        userId: target.id,
+        userEmail: target.email,
+        adminEmail,
+      });
+      impersonation.value = getImpersonationState();
+      window.location.assign("/");
+    }
+  }
+
+  // Arrête l'impersonation. L'appel part avec le header encore présent pour que le
+  // serveur clôture la session côté audit, puis on nettoie l'état et on recharge.
+  async function stopImpersonation() {
+    try {
+      await client.userControllerStopImpersonation();
+    } finally {
+      clearImpersonationState();
+      impersonation.value = null;
+      window.location.assign("/");
+    }
+  }
+
   function hasPermissions(permissions: Permission[], userApplicationPerms?: APP_PERMISSIONS[]) {
     if (permissions.length === 0) return true;
     const userPermissions = new Set([
@@ -97,5 +134,9 @@ export const useUserStore = defineStore("userStore", () => {
     unsubscribeFromApp,
     getBusinessDivisionId,
     hasPermissions,
+    impersonation,
+    isImpersonating,
+    startImpersonation,
+    stopImpersonation,
   };
 });

--- a/krakend.json
+++ b/krakend.json
@@ -18,6 +18,7 @@
         "Accept-Language",
         "X-User-Id",
         "X-User-Email",
+        "X-Impersonate-User-Id",
         "Authorization",
         "Content-Type",
         "Origin"
@@ -72,6 +73,7 @@
         "Authorization",
         "X-User",
         "X-Role",
+        "X-Impersonate-User-Id",
         "ClientId",
         "X-Requested-With",
         "Content-Type",
@@ -93,6 +95,7 @@
         "Authorization",
         "X-User",
         "X-Role",
+        "X-Impersonate-User-Id",
         "ClientId",
         "X-Requested-With",
         "Content-Type",

--- a/qa/README.md
+++ b/qa/README.md
@@ -42,6 +42,7 @@ résultat du test, et au testeur de savoir d'un coup d'œil ce qui est déjà co
 | `CRU-`  | Actions CRUD de base (fiche)                | [`protocoles/actions-crud.md`](protocoles/actions-crud.md)                               |
 | `ADM-`  | Administration des référentiels             | [`protocoles/administration-referentiels.md`](protocoles/administration-referentiels.md) |
 | `PRF-`  | Profil utilisateur                          | [`protocoles/profil-utilisateur.md`](protocoles/profil-utilisateur.md)                   |
+| `IMP-`  | Impersonation                               | [`protocoles/impersonation.md`](protocoles/impersonation.md)                             |
 
 ## Cycle de vie d'une campagne (équivalent QASE « test run »)
 

--- a/qa/protocoles/impersonation.md
+++ b/qa/protocoles/impersonation.md
@@ -1,0 +1,65 @@
+# Protocole de non-régression — Impersonation (`IMP-`)
+
+> Un **administrateur** peut se faire passer pour un autre utilisateur (« se connecter en tant que »).
+> L'identité bascule côté serveur (header `x-impersonate-user-id`) : l'admin agit avec les droits de
+> la cible et perd ses propres droits admin le temps de la session. Un **bandeau** persistant rappelle
+> l'impersonation en cours et permet de l'arrêter. La session survit à un rechargement.
+> Page admin : `/administration` (`routeNames.ADMINPAGE`). Utilisateurs Keycloak : `admin` (ADMIN) et
+> `user` (READER, `user@example.com`), mot de passe `pass`. Ticket : #1764.
+
+| Légende           |                                                         |
+| :---------------- | :------------------------------------------------------ |
+| **Automatisé** ✅ | `e2e/tests/impersonation.spec.ts`                       |
+| **Statut**        | ✅ 100 % des cas automatisés (POM strict + datafeature) |
+
+---
+
+### IMP-01 — Un admin impersonne un utilisateur puis arrête ✅
+
+- **Datafeature** : utilisateur `admin` (ADMIN) ; cible `user@example.com` (Lecteur).
+- **Action** : onglet utilisateurs → ligne de la cible → `admin-user-impersonate-btn` ; observer le
+  bandeau ; tenter d'accéder à `/administration` ; cliquer `impersonation-stop-btn`.
+- **Résultat attendu** : le bandeau `impersonation-banner` affiche l'email de la cible ; l'accès à
+  l'administration est refusé (identité basculée) ; après arrêt, le bandeau disparaît et l'admin
+  retrouve l'accès au panneau d'administration.
+
+### IMP-02 — Un admin ne peut pas s'impersonner lui-même ✅
+
+- **Datafeature** : utilisateur `admin` (`admin@example.com`).
+- **Action** : onglet utilisateurs → repérer sa propre ligne.
+- **Résultat attendu** : aucun bouton `admin-user-impersonate-btn` n'est proposé sur la ligne de
+  l'administrateur connecté.
+
+### IMP-03 — L'impersonation survit à un rechargement ✅
+
+- **Datafeature** : utilisateur `admin` ; cible `user@example.com`.
+- **Action** : impersonner la cible → recharger la page → arrêter l'impersonation.
+- **Résultat attendu** : le bandeau `impersonation-banner` reste affiché après le rechargement (état
+  persisté) ; l'arrêt rétablit l'identité administrateur.
+
+### IMP-04 — Un non-admin ne peut pas impersonner ✅
+
+- **Datafeature** : utilisateur `user` (Lecteur) dans un contexte séparé ; cible `user@example.com`.
+- **Action** : en `user`, appeler `POST /users/{id}/impersonate`.
+- **Résultat attendu** : `403 Forbidden` (l'endpoint exige la permission `AdminPanelManage`).
+
+### IMP-05 — La session d'impersonation est tracée en base (audit) ✅
+
+- **Datafeature** : utilisateur `admin` ; cible `user@example.com`.
+- **Action** : impersonner la cible, lire `ImpersonationLog`, puis arrêter et relire.
+- **Résultat attendu** : à l'ouverture une entrée existe avec `startedAt` renseigné et `endedAt` nul ;
+  après arrêt, la même entrée porte un `endedAt` renseigné.
+
+### IMP-06 — Impossible d'impersonner un compte de service (bot) ✅
+
+- **Datafeature** : un compte `bot` (réutilisé ou créé via l'API token puis révoqué).
+- **Action** : en `admin`, appeler `POST /users/{botId}/impersonate`.
+- **Résultat attendu** : `400 Bad Request` (impersonation d'un compte de service refusée).
+
+### IMP-07 — Pas d'impersonation en chaîne ✅
+
+- **Datafeature** : utilisateur `admin` ; lecteur `user@example.com`.
+- **Action** : en `admin` déjà porteur du header d'impersonation du lecteur, appeler
+  `POST /users/{adminId}/impersonate`.
+- **Résultat attendu** : `403 Forbidden` — l'identité effective (lecteur) n'a pas le droit
+  d'administration, donc aucune impersonation imbriquée n'est possible.

--- a/qa/scripts/campaign.mjs
+++ b/qa/scripts/campaign.mjs
@@ -137,6 +137,13 @@ const DOMAINS = [
     template: "qa-profil-utilisateur.md",
     colorLabel: "qa:profil-utilisateur",
   },
+  {
+    domain: "impersonation",
+    prefix: "IMP",
+    label: "Impersonation",
+    template: "qa-impersonation.md",
+    colorLabel: "qa:impersonation",
+  },
 ];
 
 function required(key) {


### PR DESCRIPTION
Closes #1764.

## Contexte
Permettre à un **administrateur** de se faire passer pour un autre utilisateur (« se connecter en tant que »), pour reproduire un parcours/bug avec les droits de la cible.

Décisions produit retenues : **droits complets de la cible**, **n'importe quel utilisateur** (hors comptes de service), **table d'audit dédiée**.

## Mécanisme
Header `x-impersonate-user-id` envoyé par le front. Le middleware d'auth résout l'utilisateur réel via le JWT puis, si le header est présent **et que l'appelant est admin**, bascule `req.user` vers la cible (avec ses permissions) tout en conservant l'admin réel dans `req.impersonator`.

## Backend
- Table d'audit `ImpersonationLog` (admin, cible, `startedAt`/`endedAt`) + migration
- `auth.middleware.ts` : impersonation (admin-only, cible non-bot)
- Endpoints `POST /users/:id/impersonate` (admin) et `POST /users/impersonate/stop`
- Décorateur `@Impersonator()`, constante `IMPERSONATE_HEADER`

## Frontend
- Header injecté sur chaque requête, état persisté (localStorage, survit au rechargement)
- Bandeau **DSFR `fr-notice--warning`** persistant + bouton « Arrêter »
- Action « Se connecter en tant que » dans la liste admin (absente pour soi-même / les bots)

## Infra
- `krakend.json` : header autorisé (CORS) et propagé (`input_headers`) pour la prod

## Tests de non-régression (kit e2e, domaine `IMP`, 7 cas)
| Cas | Couverture |
| --- | --- |
| IMP-01 | Impersonne → bascule d'identité → arrêt → retour admin |
| IMP-02 | Auto-impersonation interdite |
| IMP-03 | Persistance au rechargement |
| IMP-04 | Non-admin → 403 |
| IMP-05 | Session tracée en base (audit start/end) |
| IMP-06 | Compte de service (bot) → 400 |
| IMP-07 | Pas d'impersonation en chaîne → 403 |

Raccordé au dispositif campagne (`qa/protocoles/impersonation.md`, template d'issue, `campaign.mjs`, `qa/README.md`).

## Vérifications
- `type-check` (backend/frontend/e2e) et ESLint au vert
- **21 exécutions** (7 cas × chromium/firefox/webkit) toutes vertes
- Bascule d'identité + bandeau validés visuellement en navigateur (modes clair/sombre)