### PR TITLE
feat: import des acteurs depuis un fichier Excel (#751)

### DIFF
--- a/.github/ISSUE_TEMPLATE/qa-administration-referentiels.md
+++ b/.github/ISSUE_TEMPLATE/qa-administration-referentiels.md
@@ -21,7 +21,7 @@ labels: ["qa", "non-regression", "qa:administration-referentiels"]
 
 | Total | ✅ Passés | ❌ Échecs | ⏭️ Non testés |
 | ----- | --------- | --------- | ------------- |
-| 9     |           |           |               |
+| 10    |           |           |               |
 
 ## Protocole
 

--- a/.github/ISSUE_TEMPLATE/qa-administration-referentiels.md
+++ b/.github/ISSUE_TEMPLATE/qa-administration-referentiels.md
@@ -21,7 +21,7 @@ labels: ["qa", "non-regression", "qa:administration-referentiels"]
 
 | Total | ✅ Passés | ❌ Échecs | ⏭️ Non testés |
 | ----- | --------- | --------- | ------------- |
-| 7     |           |           |               |
+| 9     |           |           |               |
 
 ## Protocole
 

--- a/backend/src/actor/actor-import.service.spec.ts
+++ b/backend/src/actor/actor-import.service.spec.ts
@@ -1,0 +1,320 @@
+// Neutralise une dépendance circulaire préexistante du graphe d'import
+// (base.service <-> metadatas.service) qui casse à l'évaluation sous ts-jest.
+// Sans incidence ici : ActorService est entièrement mocké.
+jest.mock("src/metadatas/metadatas.service", () => ({
+  MetadatasService: class {},
+}));
+
+import * as ExcelJS from "exceljs";
+import { columnLabels } from "src/applications/columnLabels/application-export.columnLabels";
+import { sheetLabels } from "src/applications/constants/application-export.sheet-labels";
+import type { PrismaService } from "src/prisma/prisma.service";
+import { ActorImportService } from "./actor-import.service";
+import type { ActorService } from "./actor.service";
+
+interface Row {
+  id?: string;
+  applicationId?: string;
+  firstname?: string;
+  lastname?: string;
+  role?: string;
+  type?: string;
+  email?: string;
+}
+
+const DEFAULT_HEADERS = [
+  columnLabels.applicationId,
+  columnLabels.applicationLabel,
+  columnLabels["actors.id"],
+  columnLabels["actors.firstname"],
+  columnLabels["actors.lastname"],
+  columnLabels["actors.role"],
+  columnLabels["actors.type"],
+  columnLabels["actors.email"],
+];
+
+async function buildWorkbook(
+  rows: Row[],
+  opts?: { sheetName?: string; headers?: string[]; extraSheet?: string },
+): Promise<Buffer> {
+  const wb = new ExcelJS.Workbook();
+  const sheet = wb.addWorksheet(opts?.sheetName ?? sheetLabels.Actors);
+  sheet.addRow(opts?.headers ?? DEFAULT_HEADERS);
+  for (const r of rows) {
+    sheet.addRow([
+      r.applicationId ?? "",
+      "",
+      r.id ?? "",
+      r.firstname ?? "",
+      r.lastname ?? "",
+      r.role ?? "",
+      r.type ?? "",
+      r.email ?? "",
+    ]);
+  }
+  if (opts?.extraSheet) wb.addWorksheet(opts.extraSheet);
+  return Buffer.from(await wb.xlsx.writeBuffer());
+}
+
+function setup() {
+  const prisma = {
+    application: { findUnique: jest.fn().mockResolvedValue({ id: "app-1" }) },
+    actor: { findUnique: jest.fn().mockResolvedValue({ id: "actor-1" }) },
+    actorType: { findFirst: jest.fn().mockResolvedValue({ id: "type-1" }) },
+  };
+  const actorService = {
+    create: jest.fn().mockResolvedValue({ id: "new-actor" }),
+    update: jest.fn().mockResolvedValue({ id: "actor-1" }),
+  };
+  const service = new ActorImportService(
+    prisma as unknown as PrismaService,
+    actorService as unknown as ActorService,
+  );
+  return { service, prisma, actorService };
+}
+
+describe("ActorImportService", () => {
+  it("crée un acteur quand l'ID Acteur est absent", async () => {
+    const { service, actorService } = setup();
+    const buffer = await buildWorkbook([
+      {
+        applicationId: "app-1",
+        firstname: "Jean",
+        lastname: "Dupont",
+        role: "MOA",
+        email: "jean@example.com",
+      },
+    ]);
+
+    const report = await service.importFromExcel(buffer, "user-1");
+
+    expect(report.summary.created).toBe(1);
+    expect(report.summary.errors).toBe(0);
+    expect(report.summary.processedSheets).toContain(sheetLabels.Actors);
+    expect(actorService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorTypeId: "type-1",
+        applicationId: "app-1",
+      }),
+      "app-1",
+      "user-1",
+    );
+    expect(report.entries[0].status).toBe("created");
+  });
+
+  it("met à jour un acteur quand l'ID Acteur est présent", async () => {
+    const { service, actorService } = setup();
+    const buffer = await buildWorkbook([
+      { id: "actor-1", applicationId: "app-1", lastname: "Modif", role: "MOA" },
+    ]);
+
+    const report = await service.importFromExcel(buffer, "user-1");
+
+    expect(report.summary.updated).toBe(1);
+    expect(report.summary.errors).toBe(0);
+    expect(actorService.update).toHaveBeenCalledWith(
+      "actor-1",
+      expect.any(Object),
+      "app-1",
+      "user-1",
+    );
+  });
+
+  it("consigne une erreur si l'acteur à mettre à jour est introuvable", async () => {
+    const { service, prisma, actorService } = setup();
+    prisma.actor.findUnique.mockResolvedValue(null);
+    const buffer = await buildWorkbook([
+      { id: "missing", applicationId: "app-1", role: "MOA" },
+    ]);
+
+    const report = await service.importFromExcel(buffer, "user-1");
+
+    expect(report.summary.errors).toBe(1);
+    expect(actorService.update).not.toHaveBeenCalled();
+    expect(report.entries[0]).toMatchObject({ status: "error" });
+    expect(report.entries[0].message).toMatch(/introuvable/i);
+  });
+
+  it("consigne une erreur si l'application est introuvable", async () => {
+    const { service, prisma } = setup();
+    prisma.application.findUnique.mockResolvedValue(null);
+    const buffer = await buildWorkbook([
+      { applicationId: "ghost", role: "MOA", email: "a@b.com" },
+    ]);
+
+    const report = await service.importFromExcel(buffer, "user-1");
+
+    expect(report.summary.errors).toBe(1);
+    expect(report.entries[0].message).toMatch(/Application introuvable/i);
+  });
+
+  it("consigne une erreur si le type d'acteur (rôle) est introuvable", async () => {
+    const { service, prisma } = setup();
+    prisma.actorType.findFirst.mockResolvedValue(null);
+    const buffer = await buildWorkbook([
+      { applicationId: "app-1", role: "INCONNU", email: "a@b.com" },
+    ]);
+
+    const report = await service.importFromExcel(buffer, "user-1");
+
+    expect(report.summary.errors).toBe(1);
+    expect(report.entries[0].message).toMatch(/Type d'acteur introuvable/i);
+  });
+
+  it("résout le type d'acteur par libellé (colonne Type) si le rôle est vide", async () => {
+    const { service, prisma, actorService } = setup();
+    // Rôle vide → le lookup par code est sauté ; seule la résolution par libellé est tentée.
+    prisma.actorType.findFirst.mockResolvedValue({ id: "type-by-label" });
+    const buffer = await buildWorkbook([
+      { applicationId: "app-1", type: "Maîtrise d'ouvrage", email: "a@b.com" },
+    ]);
+
+    const report = await service.importFromExcel(buffer, "user-1");
+
+    expect(report.summary.created).toBe(1);
+    expect(actorService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ actorTypeId: "type-by-label" }),
+      "app-1",
+      "user-1",
+    );
+  });
+
+  it("consigne une erreur de validation pour un email invalide", async () => {
+    const { service, actorService } = setup();
+    const buffer = await buildWorkbook([
+      { applicationId: "app-1", role: "MOA", email: "pas-un-email" },
+    ]);
+
+    const report = await service.importFromExcel(buffer, "user-1");
+
+    expect(report.summary.errors).toBe(1);
+    expect(report.entries[0].message).toMatch(/Validation/i);
+    expect(actorService.create).not.toHaveBeenCalled();
+  });
+
+  it("poursuit le traitement après une ligne fautive", async () => {
+    const { service, prisma } = setup();
+    // 1ʳᵉ ligne : type résolu ; 2ᵉ ligne : non résolu (code + libellé).
+    prisma.actorType.findFirst
+      .mockResolvedValueOnce({ id: "type-1" })
+      .mockResolvedValue(null);
+    const buffer = await buildWorkbook([
+      { applicationId: "app-1", role: "MOA", email: "ok@example.com" },
+      { applicationId: "app-1", role: "INCONNU", email: "ko@example.com" },
+    ]);
+
+    const report = await service.importFromExcel(buffer, "user-1");
+
+    expect(report.summary.created).toBe(1);
+    expect(report.summary.errors).toBe(1);
+    expect(report.entries).toHaveLength(2);
+  });
+
+  it("ignore les lignes entièrement vides", async () => {
+    const { service } = setup();
+    const buffer = await buildWorkbook([
+      {},
+      { applicationId: "app-1", role: "MOA", email: "a@b.com" },
+    ]);
+
+    const report = await service.importFromExcel(buffer, "user-1");
+
+    expect(report.entries).toHaveLength(1);
+    expect(report.summary.created).toBe(1);
+  });
+
+  it("ne traite pas l'onglet si une colonne nécessaire manque", async () => {
+    const { service } = setup();
+    const buffer = await buildWorkbook(
+      [{ applicationId: "app-1", role: "MOA" }],
+      {
+        // En-têtes sans « ID Acteur » (colonne requise).
+        headers: [
+          columnLabels.applicationId,
+          columnLabels["actors.firstname"],
+          columnLabels["actors.role"],
+        ],
+      },
+    );
+
+    const report = await service.importFromExcel(buffer, "user-1");
+
+    expect(report.summary.processedSheets).not.toContain(sheetLabels.Actors);
+    expect(report.summary.created).toBe(0);
+    expect(report.logs.join(" ")).toMatch(/colonnes manquantes/i);
+  });
+
+  it("ignore l'onglet Acteurs absent et les onglets inconnus", async () => {
+    const { service } = setup();
+    const wb = new ExcelJS.Workbook();
+    wb.addWorksheet("Feuille inconnue");
+    const buffer = Buffer.from(await wb.xlsx.writeBuffer());
+
+    const report = await service.importFromExcel(buffer, "user-1");
+
+    expect(report.summary.ignoredSheets).toContain(sheetLabels.Actors);
+    expect(report.summary.ignoredSheets).toContain("Feuille inconnue");
+  });
+
+  it("référence l'onglet inconnu en plus de l'onglet Acteurs traité", async () => {
+    const { service } = setup();
+    const buffer = await buildWorkbook(
+      [{ applicationId: "app-1", role: "MOA", email: "a@b.com" }],
+      { extraSheet: "Autre" },
+    );
+
+    const report = await service.importFromExcel(buffer, "user-1");
+
+    expect(report.summary.processedSheets).toContain(sheetLabels.Actors);
+    expect(report.summary.ignoredSheets).toContain("Autre");
+  });
+
+  it("consigne une erreur si la colonne ID Application est vide", async () => {
+    const { service } = setup();
+    const buffer = await buildWorkbook([
+      { role: "MOA", email: "a@b.com" }, // applicationId absent
+    ]);
+
+    const report = await service.importFromExcel(buffer, "user-1");
+
+    expect(report.summary.errors).toBe(1);
+    expect(report.entries[0].message).toMatch(/ID Application/i);
+  });
+
+  it("coerce les cellules non textuelles (nombre, date, richText, hyperlien)", async () => {
+    const { service, actorService } = setup();
+    const wb = new ExcelJS.Workbook();
+    const sheet = wb.addWorksheet(sheetLabels.Actors);
+    sheet.addRow(DEFAULT_HEADERS);
+    const row = sheet.addRow([]);
+    row.getCell(1).value = "app-1"; // ID Application
+    row.getCell(4).value = { richText: [{ text: "Jean" }, { text: "-Luc" }] };
+    row.getCell(5).value = new Date("2020-01-02T00:00:00.000Z"); // Nom (date)
+    row.getCell(6).value = "MOA"; // Rôle
+    row.getCell(7).value = 7; // Type (nombre, lu mais non utilisé ici)
+    row.getCell(8).value = {
+      text: "rich@example.com",
+      hyperlink: "mailto:rich@example.com",
+    };
+    const buffer = Buffer.from(await wb.xlsx.writeBuffer());
+
+    const report = await service.importFromExcel(buffer, "user-1");
+
+    expect(report.summary.created).toBe(1);
+    expect(actorService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        firstname: "Jean-Luc",
+        email: "rich@example.com",
+      }),
+      "app-1",
+      "user-1",
+    );
+  });
+
+  it("rejette un fichier non Excel", async () => {
+    const { service } = setup();
+    await expect(
+      service.importFromExcel(Buffer.from("pas un xlsx"), "user-1"),
+    ).rejects.toThrow(/Excel/i);
+  });
+});

--- a/backend/src/actor/actor-import.service.ts
+++ b/backend/src/actor/actor-import.service.ts
@@ -1,0 +1,306 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { plainToInstance } from "class-transformer";
+import { validate } from "class-validator";
+import * as ExcelJS from "exceljs";
+import { columnLabels } from "src/applications/columnLabels/application-export.columnLabels";
+import { sheetLabels } from "src/applications/constants/application-export.sheet-labels";
+import { PrismaService } from "src/prisma/prisma.service";
+import { ActorService } from "./actor.service";
+import { CreateActorDto, UpdateActorDto } from "./dto/actor.dto";
+import { ImportReportDto, ImportReportEntryDto } from "./dto/import-report.dto";
+
+/** En-têtes (libellés) attendus dans l'onglet « Acteurs », alignés sur l'export. */
+const HEADERS = {
+  id: columnLabels["actors.id"],
+  applicationId: columnLabels.applicationId,
+  firstname: columnLabels["actors.firstname"],
+  lastname: columnLabels["actors.lastname"],
+  role: columnLabels["actors.role"],
+  type: columnLabels["actors.type"],
+  email: columnLabels["actors.email"],
+} as const;
+
+/** Colonnes sans lesquelles l'onglet ne peut pas être traité. */
+const REQUIRED_HEADERS = [HEADERS.id, HEADERS.applicationId, HEADERS.role];
+
+@Injectable()
+export class ActorImportService {
+  private readonly logger = new Logger(ActorImportService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly actorService: ActorService,
+  ) {}
+
+  async importFromExcel(
+    buffer: Buffer,
+    requestorId: string,
+  ): Promise<ImportReportDto> {
+    const report: ImportReportDto = {
+      summary: {
+        processedSheets: [],
+        ignoredSheets: [],
+        created: 0,
+        updated: 0,
+        errors: 0,
+      },
+      entries: [],
+      logs: [],
+    };
+
+    const workbook = new ExcelJS.Workbook();
+    try {
+      // exceljs déclare son propre `interface Buffer extends ArrayBuffer`,
+      // incompatible avec le Buffer générique de Node bien que correct au runtime.
+      await workbook.xlsx.load(
+        buffer as unknown as Parameters<typeof workbook.xlsx.load>[0],
+      );
+    } catch {
+      report.logs.push("Le fichier fourni n'est pas un classeur Excel valide.");
+      throw new Error("Le fichier fourni n'est pas un classeur Excel valide.");
+    }
+
+    // L'onglet « Applications » est toujours traité en premier (phases ultérieures).
+    // Phase 1 : seul l'onglet « Acteurs » est traité ici.
+    await this.processActorsSheet(workbook, requestorId, report);
+
+    // Onglets présents mais non pris en charge en phase 1.
+    for (const sheet of workbook.worksheets) {
+      if (
+        sheet.name !== sheetLabels.Actors &&
+        !report.summary.ignoredSheets.includes(sheet.name)
+      ) {
+        report.summary.ignoredSheets.push(sheet.name);
+      }
+    }
+
+    return report;
+  }
+
+  private async processActorsSheet(
+    workbook: ExcelJS.Workbook,
+    requestorId: string,
+    report: ImportReportDto,
+  ): Promise<void> {
+    const sheetName = sheetLabels.Actors;
+    const worksheet = workbook.getWorksheet(sheetName);
+
+    if (!worksheet) {
+      report.summary.ignoredSheets.push(sheetName);
+      report.logs.push(`Onglet « ${sheetName} » absent : ignoré.`);
+      return;
+    }
+
+    const headerIndex = this.buildHeaderIndex(worksheet);
+    const missing = REQUIRED_HEADERS.filter((h) => !(h in headerIndex));
+    if (missing.length > 0) {
+      const message = `Onglet « ${sheetName} » non traité : colonnes manquantes (${missing.join(", ")}).`;
+      report.logs.push(message);
+      this.logger.warn(message);
+      return;
+    }
+
+    report.summary.processedSheets.push(sheetName);
+
+    const getCell = (row: ExcelJS.Row, header: string): string => {
+      const col = headerIndex[header];
+      if (!col) return "";
+      return this.cellToString(row.getCell(col).value);
+    };
+
+    for (let rowNumber = 2; rowNumber <= worksheet.rowCount; rowNumber++) {
+      const row = worksheet.getRow(rowNumber);
+
+      const data = {
+        id: getCell(row, HEADERS.id),
+        applicationId: getCell(row, HEADERS.applicationId),
+        firstname: getCell(row, HEADERS.firstname),
+        lastname: getCell(row, HEADERS.lastname),
+        role: getCell(row, HEADERS.role),
+        type: getCell(row, HEADERS.type),
+        email: getCell(row, HEADERS.email),
+      };
+
+      // Ligne entièrement vide : ignorée silencieusement.
+      if (Object.values(data).every((v) => v === "")) continue;
+
+      try {
+        const entry = await this.processActorRow(
+          sheetName,
+          rowNumber,
+          data,
+          requestorId,
+        );
+        report.entries.push(entry);
+        if (entry.status === "created") report.summary.created++;
+        else if (entry.status === "updated") report.summary.updated++;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        report.entries.push({
+          sheet: sheetName,
+          row: rowNumber,
+          status: "error",
+          identifier: data.id || data.email || undefined,
+          message,
+        });
+        report.summary.errors++;
+        this.logger.warn(
+          `Ligne ${rowNumber} (${sheetName}) en erreur : ${message}`,
+        );
+      }
+    }
+  }
+
+  private async processActorRow(
+    sheet: string,
+    row: number,
+    data: {
+      id: string;
+      applicationId: string;
+      firstname: string;
+      lastname: string;
+      role: string;
+      type: string;
+      email: string;
+    },
+    requestorId: string,
+  ): Promise<ImportReportEntryDto> {
+    if (!data.applicationId) {
+      throw new Error("Colonne « ID Application » vide.");
+    }
+
+    const application = await this.prisma.application.findUnique({
+      where: { id: data.applicationId },
+      select: { id: true },
+    });
+    if (!application) {
+      throw new Error(`Application introuvable (id=${data.applicationId}).`);
+    }
+
+    const actorTypeId = await this.resolveActorTypeId(data.role, data.type);
+    if (!actorTypeId) {
+      throw new Error(
+        `Type d'acteur introuvable pour le rôle « ${data.role} ».`,
+      );
+    }
+
+    const baseFields = {
+      firstname: data.firstname || undefined,
+      lastname: data.lastname || undefined,
+      email: data.email || undefined,
+      actorTypeId,
+      applicationId: data.applicationId,
+    };
+
+    const identifier =
+      data.email || `${data.firstname} ${data.lastname}`.trim();
+
+    if (data.id) {
+      const existing = await this.prisma.actor.findUnique({
+        where: { id: data.id },
+        select: { id: true },
+      });
+      if (!existing) {
+        throw new Error(`Acteur introuvable (id=${data.id}).`);
+      }
+
+      const dto = plainToInstance(UpdateActorDto, baseFields);
+      await this.validateDto(dto);
+      await this.actorService.update(
+        data.id,
+        dto,
+        data.applicationId,
+        requestorId,
+      );
+
+      return { sheet, row, status: "updated", identifier };
+    }
+
+    const dto = plainToInstance(CreateActorDto, {
+      ...baseFields,
+      isGroup: false,
+    });
+    await this.validateDto(dto);
+    await this.actorService.create(dto, data.applicationId, requestorId);
+
+    return { sheet, row, status: "created", identifier };
+  }
+
+  /** Résout l'ActorType par code (colonne « Rôle ») puis par libellé (colonne « Type »). */
+  private async resolveActorTypeId(
+    role: string,
+    type: string,
+  ): Promise<string | null> {
+    if (role) {
+      const byCode = await this.prisma.actorType.findFirst({
+        where: { code: role },
+        select: { id: true },
+      });
+      if (byCode) return byCode.id;
+    }
+    if (type) {
+      const byLabel = await this.prisma.actorType.findFirst({
+        where: { label: type },
+        select: { id: true },
+      });
+      if (byLabel) return byLabel.id;
+    }
+    return null;
+  }
+
+  private async validateDto(
+    dto: CreateActorDto | UpdateActorDto,
+  ): Promise<void> {
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: false,
+    });
+    if (errors.length > 0) {
+      const details = errors
+        .map((e) => Object.values(e.constraints ?? {}).join(", "))
+        .filter(Boolean)
+        .join(" ; ");
+      throw new Error(`Validation échouée : ${details}`);
+    }
+  }
+
+  private buildHeaderIndex(
+    worksheet: ExcelJS.Worksheet,
+  ): Record<string, number> {
+    const headerRow = worksheet.getRow(1);
+    const index: Record<string, number> = {};
+    headerRow.eachCell((cell, colNumber) => {
+      const label = this.cellToString(cell.value);
+      if (label) index[label] = colNumber;
+    });
+    return index;
+  }
+
+  private cellToString(value: ExcelJS.CellValue): string {
+    if (value === null || value === undefined) return "";
+    if (typeof value === "string") return value.trim();
+    if (typeof value === "number" || typeof value === "boolean") {
+      return String(value);
+    }
+    if (value instanceof Date) return value.toISOString();
+    if (typeof value === "object") {
+      const obj = value as {
+        text?: string;
+        hyperlink?: string;
+        result?: unknown;
+        richText?: { text: string }[];
+      };
+      if (typeof obj.text === "string") return obj.text.trim();
+      if (Array.isArray(obj.richText)) {
+        return obj.richText
+          .map((part) => part.text)
+          .join("")
+          .trim();
+      }
+      if (obj.result !== undefined && obj.result !== null) {
+        return String(obj.result).trim();
+      }
+    }
+    return "";
+  }
+}

--- a/backend/src/actor/actor.controller.spec.ts
+++ b/backend/src/actor/actor.controller.spec.ts
@@ -1,0 +1,82 @@
+// Neutralise une dépendance circulaire préexistante du graphe d'import
+// (base.service <-> metadatas.service) qui casse à l'évaluation sous ts-jest.
+jest.mock("src/metadatas/metadatas.service", () => ({
+  MetadatasService: class {},
+}));
+
+import { BadRequestException } from "@nestjs/common";
+import { ActorController } from "./actor.controller";
+import type { ActorImportService } from "./actor-import.service";
+import type { ActorService } from "./actor.service";
+import type { ImportReportDto } from "./dto/import-report.dto";
+
+const REPORT: ImportReportDto = {
+  summary: {
+    processedSheets: ["Acteurs"],
+    ignoredSheets: [],
+    created: 1,
+    updated: 0,
+    errors: 0,
+  },
+  entries: [],
+  logs: [],
+};
+
+function setup(importImpl?: jest.Mock) {
+  const importService = {
+    importFromExcel: importImpl ?? jest.fn().mockResolvedValue(REPORT),
+  };
+  const controller = new ActorController(
+    {} as unknown as ActorService,
+    importService as unknown as ActorImportService,
+  );
+  return { controller, importService };
+}
+
+const xlsxFile = {
+  buffer: Buffer.from("x"),
+  originalname: "import.xlsx",
+  mimetype: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+};
+
+describe("ActorController.importExcel", () => {
+  it("rejette quand aucun fichier n'est fourni", async () => {
+    const { controller } = setup();
+    await expect(controller.importExcel(undefined, "user-1")).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it("rejette un fichier qui n'est pas un .xlsx", async () => {
+    const { controller } = setup();
+    await expect(
+      controller.importExcel(
+        {
+          buffer: Buffer.from("x"),
+          originalname: "x.txt",
+          mimetype: "text/plain",
+        },
+        "user-1",
+      ),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it("traite un .xlsx et renvoie le rapport", async () => {
+    const { controller, importService } = setup();
+    const result = await controller.importExcel(xlsxFile, "user-1");
+    expect(importService.importFromExcel).toHaveBeenCalledWith(
+      xlsxFile.buffer,
+      "user-1",
+    );
+    expect(result.summary.created).toBe(1);
+  });
+
+  it("convertit une erreur du service en BadRequest", async () => {
+    const { controller } = setup(
+      jest.fn().mockRejectedValue(new Error("fichier illisible")),
+    );
+    await expect(controller.importExcel(xlsxFile, "user-1")).rejects.toThrow(
+      /fichier illisible/,
+    );
+  });
+});

--- a/backend/src/actor/actor.controller.ts
+++ b/backend/src/actor/actor.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -9,10 +10,14 @@ import {
   Patch,
   Post,
   Query,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
 } from "@nestjs/common";
+import { FileInterceptor } from "@nestjs/platform-express";
 import {
   ApiBody,
+  ApiConsumes,
   ApiCreatedResponse,
   ApiNoContentResponse,
   ApiOkResponse,
@@ -23,6 +28,7 @@ import {
 import { Actor, Permission } from "@prisma/client";
 import { PaginatedResponseDto } from "src/common/dto/paginated-response.dto";
 import { UserId } from "../common/decorators/user-id.decorator";
+import { ActorImportService } from "./actor-import.service";
 import { ActorService } from "./actor.service";
 import {
   ActorDto,
@@ -30,6 +36,7 @@ import {
   CreateActorDto,
   UpdateActorDto,
 } from "./dto/actor.dto";
+import { ImportReportDto } from "./dto/import-report.dto";
 import { PermissionGuard } from "src/common/guards/permission.guard";
 import { RequiredPermissions } from "src/common/decorators/required-permissions.decorator";
 
@@ -37,7 +44,67 @@ import { RequiredPermissions } from "src/common/decorators/required-permissions.
 @UseGuards(PermissionGuard)
 @Controller("actors")
 export class ActorController {
-  constructor(private readonly actorService: ActorService) {}
+  constructor(
+    private readonly actorService: ActorService,
+    private readonly actorImportService: ActorImportService,
+  ) {}
+
+  @Post("import/excel")
+  @RequiredPermissions([Permission.AdminPanelManage])
+  @UseInterceptors(FileInterceptor("file"))
+  @ApiConsumes("multipart/form-data")
+  @ApiOperation({
+    summary: "Importer des acteurs depuis un fichier Excel",
+    description: `Importe ou met à jour des acteurs en masse à partir d'un fichier Excel
+au même format que l'export (un onglet par table). Seul l'onglet « Acteurs » est traité.
+Chaque ligne dont la colonne « ID Acteur » est renseignée met à jour l'acteur correspondant ;
+sinon un nouvel acteur est créé. Les contrôles et métadonnées sont identiques à ceux de l'API.
+Un rapport d'exécution est retourné.`,
+  })
+  @ApiBody({
+    schema: {
+      type: "object",
+      properties: {
+        file: { type: "string", format: "binary" },
+      },
+      required: ["file"],
+    },
+  })
+  @ApiOkResponse({
+    description: "Rapport d'exécution de l'import",
+    type: ImportReportDto,
+  })
+  public async importExcel(
+    @UploadedFile()
+    file:
+      | { buffer: Buffer; originalname: string; mimetype: string }
+      | undefined,
+    @UserId() userId: string,
+  ): Promise<ImportReportDto> {
+    if (!file) {
+      throw new BadRequestException("Aucun fichier fourni.");
+    }
+    const isXlsx =
+      file.originalname?.toLowerCase().endsWith(".xlsx") ||
+      file.mimetype ===
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    if (!isXlsx) {
+      throw new BadRequestException(
+        "Le fichier doit être un classeur Excel (.xlsx).",
+      );
+    }
+    Logger.log({
+      message: "Début de l'import Excel des acteurs",
+      userId,
+      action: "import",
+    });
+    try {
+      return await this.actorImportService.importFromExcel(file.buffer, userId);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new BadRequestException(message);
+    }
+  }
 
   @Get("count")
   @ApiOperation({

--- a/backend/src/actor/actor.module.ts
+++ b/backend/src/actor/actor.module.ts
@@ -9,6 +9,7 @@ import {
   ActorController,
   ApplicationActorsController,
 } from "./actor.controller";
+import { ActorImportService } from "./actor-import.service";
 import { ActorService } from "./actor.service";
 
 @Module({
@@ -21,7 +22,7 @@ import { ActorService } from "./actor.service";
     OrganizationMaiaReferencesModule,
   ],
   controllers: [ApplicationActorsController, ActorController],
-  providers: [ActorService],
+  providers: [ActorService, ActorImportService],
   exports: [ActorService],
 })
 export class ActorModule {}

--- a/backend/src/actor/dto/import-report.dto.ts
+++ b/backend/src/actor/dto/import-report.dto.ts
@@ -1,0 +1,72 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export type ImportRowStatus = "created" | "updated" | "error";
+
+export class ImportReportEntryDto {
+  @ApiProperty({
+    description: "Nom de l'onglet traité",
+    example: "Acteurs",
+  })
+  sheet: string;
+
+  @ApiProperty({
+    description: "Numéro de la ligne dans l'onglet (1 = en-tête)",
+    example: 4,
+  })
+  row: number;
+
+  @ApiProperty({
+    description: "Résultat du traitement de la ligne",
+    enum: ["created", "updated", "error"],
+    example: "updated",
+  })
+  status: ImportRowStatus;
+
+  @ApiProperty({
+    description: "Identifiant lisible de l'enregistrement concerné",
+    required: false,
+    example: "MOA : jean.dupont@example.com",
+  })
+  identifier?: string;
+
+  @ApiProperty({
+    description: "Détail (motif d'erreur ou information)",
+    required: false,
+    example: "Type d'acteur introuvable pour le rôle « XYZ »",
+  })
+  message?: string;
+}
+
+export class ImportReportSummaryDto {
+  @ApiProperty({ description: "Onglets effectivement traités", type: [String] })
+  processedSheets: string[];
+
+  @ApiProperty({
+    description: "Onglets ignorés (absents ou non reconnus)",
+    type: [String],
+  })
+  ignoredSheets: string[];
+
+  @ApiProperty({ description: "Nombre d'enregistrements créés" })
+  created: number;
+
+  @ApiProperty({ description: "Nombre d'enregistrements mis à jour" })
+  updated: number;
+
+  @ApiProperty({ description: "Nombre de lignes en erreur" })
+  errors: number;
+}
+
+export class ImportReportDto {
+  @ApiProperty({ type: ImportReportSummaryDto })
+  summary: ImportReportSummaryDto;
+
+  @ApiProperty({ type: [ImportReportEntryDto] })
+  entries: ImportReportEntryDto[];
+
+  @ApiProperty({
+    description: "Journal d'exécution (erreurs au niveau onglet, etc.)",
+    type: [String],
+  })
+  logs: string[];
+}

--- a/backend/src/applications/columnLabels/application-export.columnLabels.ts
+++ b/backend/src/applications/columnLabels/application-export.columnLabels.ts
@@ -38,6 +38,7 @@ export const columnLabels: Record<string, string> = {
   "compliances.type": "Type de conformité",
 
   actors: "Acteurs",
+  "actors.id": "ID Acteur",
   "actors.firstname": "Prénom de l’acteur",
   "actors.lastname": "Nom de l’acteur",
   "actors.role": "Rôle",

--- a/backend/src/applications/map/application-export.map.ts
+++ b/backend/src/applications/map/application-export.map.ts
@@ -70,6 +70,7 @@ export function mapActors(app: ApplicationWithAllRelations) {
     app.actors?.map((a) => ({
       applicationId: app.id,
       applicationLabel: app.label,
+      "actors.id": a.id,
       "actors.firstname": a.firstname,
       "actors.lastname": a.lastname,
       "actors.role": a.actorType?.code || "",

--- a/backend/src/applications/usecases/application-export.usecase.ts
+++ b/backend/src/applications/usecases/application-export.usecase.ts
@@ -72,6 +72,7 @@ export class ExportApplicationsUseCase {
         columns: [
           col("applicationId", 30),
           col("applicationLabel", 30),
+          col("actors.id", 36),
           col("actors.firstname", 25),
           col("actors.lastname", 25),
           col("actors.role", 30),

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -16,6 +16,7 @@
     "@playwright/test": "^1.58.2",
     "@types/node": "^22.10.0",
     "@types/pg": "^8.20.0",
+    "exceljs": "^4.4.0",
     "pg": "^8.21.0",
     "typescript": "^5.7.2"
   }

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
+      exceljs:
+        specifier: ^4.4.0
+        version: 4.4.0
       pg:
         specifier: ^8.21.0
         version: 8.21.0
@@ -26,10 +29,19 @@ importers:
 
 packages:
 
+  '@fast-csv/format@4.3.5':
+    resolution: {integrity: sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==}
+
+  '@fast-csv/parse@4.3.6':
+    resolution: {integrity: sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==}
+
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@types/node@14.18.63':
+    resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
 
   '@types/node@22.19.20':
     resolution: {integrity: sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==}
@@ -37,10 +49,218 @@ packages:
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
+  archiver-utils@2.1.0:
+    resolution: {integrity: sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==}
+    engines: {node: '>= 6'}
+
+  archiver-utils@3.0.4:
+    resolution: {integrity: sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==}
+    engines: {node: '>= 10'}
+
+  archiver@5.3.2:
+    resolution: {integrity: sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==}
+    engines: {node: '>= 10'}
+
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  big-integer@1.6.52:
+    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
+    engines: {node: '>=0.6'}
+
+  binary@0.3.0:
+    resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bluebird@3.4.7:
+    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
+
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-indexof-polyfill@1.0.2:
+    resolution: {integrity: sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==}
+    engines: {node: '>=0.10'}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffers@0.1.1:
+    resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
+    engines: {node: '>=0.2.0'}
+
+  chainsaw@0.1.0:
+    resolution: {integrity: sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==}
+
+  compress-commons@4.1.2:
+    resolution: {integrity: sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==}
+    engines: {node: '>= 10'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@4.0.3:
+    resolution: {integrity: sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==}
+    engines: {node: '>= 10'}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
+  duplexer2@0.1.4:
+    resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  exceljs@4.4.0:
+    resolution: {integrity: sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==}
+    engines: {node: '>=8.3.0'}
+
+  fast-csv@4.3.6:
+    resolution: {integrity: sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==}
+    engines: {node: '>=10.0.0'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  fstream@1.0.12:
+    resolution: {integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==}
+    engines: {node: '>=0.6'}
+    deprecated: This package is no longer supported.
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
+  listenercount@1.0.1:
+    resolution: {integrity: sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.difference@4.5.0:
+    resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.flatten@4.4.0:
+    resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+
+  lodash.groupby@4.6.0:
+    resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
+  lodash.isfunction@3.0.9:
+    resolution: {integrity: sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==}
+
+  lodash.isnil@4.0.0:
+    resolution: {integrity: sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isundefined@3.0.1:
+    resolution: {integrity: sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==}
+
+  lodash.union@4.6.0:
+    resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}
+
+  lodash.uniq@4.5.0:
+    resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   pg-cloudflare@1.4.0:
     resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
@@ -102,9 +322,57 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
+
+  rimraf@2.7.1:
+    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  saxes@5.0.1:
+    resolution: {integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==}
+    engines: {node: '>=10'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
+    engines: {node: '>=14.14'}
+
+  traverse@0.3.9:
+    resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -114,15 +382,57 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unzipper@0.10.14:
+    resolution: {integrity: sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  zip-stream@4.1.1:
+    resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
+    engines: {node: '>= 10'}
+
 snapshots:
+
+  '@fast-csv/format@4.3.5':
+    dependencies:
+      '@types/node': 14.18.63
+      lodash.escaperegexp: 4.1.2
+      lodash.isboolean: 3.0.3
+      lodash.isequal: 4.5.0
+      lodash.isfunction: 3.0.9
+      lodash.isnil: 4.0.0
+
+  '@fast-csv/parse@4.3.6':
+    dependencies:
+      '@types/node': 14.18.63
+      lodash.escaperegexp: 4.1.2
+      lodash.groupby: 4.6.0
+      lodash.isfunction: 3.0.9
+      lodash.isnil: 4.0.0
+      lodash.isundefined: 3.0.1
+      lodash.uniq: 4.5.0
 
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
+
+  '@types/node@14.18.63': {}
 
   '@types/node@22.19.20':
     dependencies:
@@ -134,8 +444,236 @@ snapshots:
       pg-protocol: 1.14.0
       pg-types: 2.2.0
 
+  archiver-utils@2.1.0:
+    dependencies:
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      lazystream: 1.0.1
+      lodash.defaults: 4.2.0
+      lodash.difference: 4.5.0
+      lodash.flatten: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.union: 4.6.0
+      normalize-path: 3.0.0
+      readable-stream: 2.3.8
+
+  archiver-utils@3.0.4:
+    dependencies:
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      lazystream: 1.0.1
+      lodash.defaults: 4.2.0
+      lodash.difference: 4.5.0
+      lodash.flatten: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.union: 4.6.0
+      normalize-path: 3.0.0
+      readable-stream: 3.6.2
+
+  archiver@5.3.2:
+    dependencies:
+      archiver-utils: 2.1.0
+      async: 3.2.6
+      buffer-crc32: 0.2.13
+      readable-stream: 3.6.2
+      readdir-glob: 1.1.3
+      tar-stream: 2.2.0
+      zip-stream: 4.1.1
+
+  async@3.2.6: {}
+
+  balanced-match@1.0.2: {}
+
+  base64-js@1.5.1: {}
+
+  big-integer@1.6.52: {}
+
+  binary@0.3.0:
+    dependencies:
+      buffers: 0.1.1
+      chainsaw: 0.1.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  bluebird@3.4.7: {}
+
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.1.1:
+    dependencies:
+      balanced-match: 1.0.2
+
+  buffer-crc32@0.2.13: {}
+
+  buffer-indexof-polyfill@1.0.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buffers@0.1.1: {}
+
+  chainsaw@0.1.0:
+    dependencies:
+      traverse: 0.3.9
+
+  compress-commons@4.1.2:
+    dependencies:
+      buffer-crc32: 0.2.13
+      crc32-stream: 4.0.3
+      normalize-path: 3.0.0
+      readable-stream: 3.6.2
+
+  concat-map@0.0.1: {}
+
+  core-util-is@1.0.3: {}
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@4.0.3:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 3.6.2
+
+  dayjs@1.11.21: {}
+
+  duplexer2@0.1.4:
+    dependencies:
+      readable-stream: 2.3.8
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  exceljs@4.4.0:
+    dependencies:
+      archiver: 5.3.2
+      dayjs: 1.11.21
+      fast-csv: 4.3.6
+      jszip: 3.10.1
+      readable-stream: 3.6.2
+      saxes: 5.0.1
+      tmp: 0.2.7
+      unzipper: 0.10.14
+      uuid: 8.3.2
+
+  fast-csv@4.3.6:
+    dependencies:
+      '@fast-csv/format': 4.3.5
+      '@fast-csv/parse': 4.3.6
+
+  fs-constants@1.0.0: {}
+
+  fs.realpath@1.0.0: {}
+
   fsevents@2.3.2:
     optional: true
+
+  fstream@1.0.12:
+    dependencies:
+      graceful-fs: 4.2.11
+      inherits: 2.0.4
+      mkdirp: 0.5.6
+      rimraf: 2.7.1
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  graceful-fs@4.2.11: {}
+
+  ieee754@1.2.1: {}
+
+  immediate@3.0.6: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  isarray@1.0.0: {}
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
+
+  listenercount@1.0.1: {}
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.difference@4.5.0: {}
+
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.flatten@4.4.0: {}
+
+  lodash.groupby@4.6.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isequal@4.5.0: {}
+
+  lodash.isfunction@3.0.9: {}
+
+  lodash.isnil@4.0.0: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isundefined@3.0.1: {}
+
+  lodash.union@4.6.0: {}
+
+  lodash.uniq@4.5.0: {}
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
+
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
+  minimist@1.2.8: {}
+
+  mkdirp@0.5.6:
+    dependencies:
+      minimist: 1.2.8
+
+  normalize-path@3.0.0: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  pako@1.0.11: {}
+
+  path-is-absolute@1.0.1: {}
 
   pg-cloudflare@1.4.0:
     optional: true
@@ -190,10 +728,93 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  process-nextick-args@2.0.1: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.9
+
+  rimraf@2.7.1:
+    dependencies:
+      glob: 7.2.3
+
+  safe-buffer@5.1.2: {}
+
+  safe-buffer@5.2.1: {}
+
+  saxes@5.0.1:
+    dependencies:
+      xmlchars: 2.2.0
+
+  setimmediate@1.0.5: {}
+
   split2@4.2.0: {}
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  tmp@0.2.7: {}
+
+  traverse@0.3.9: {}
 
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
 
+  unzipper@0.10.14:
+    dependencies:
+      big-integer: 1.6.52
+      binary: 0.3.0
+      bluebird: 3.4.7
+      buffer-indexof-polyfill: 1.0.2
+      duplexer2: 0.1.4
+      fstream: 1.0.12
+      graceful-fs: 4.2.11
+      listenercount: 1.0.1
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
+  util-deprecate@1.0.2: {}
+
+  uuid@8.3.2: {}
+
+  wrappy@1.0.2: {}
+
+  xmlchars@2.2.0: {}
+
   xtend@4.0.2: {}
+
+  zip-stream@4.1.1:
+    dependencies:
+      archiver-utils: 3.0.4
+      compress-commons: 4.1.2
+      readable-stream: 3.6.2

--- a/e2e/pom/admin.page.ts
+++ b/e2e/pom/admin.page.ts
@@ -504,4 +504,9 @@ export class AdminPage extends BasePage {
   async expectImportReportDownloadable(): Promise<void> {
     await expect(this.byTestId("admin-import-report-download")).toBeVisible();
   }
+
+  /** Vérifie que le détail du rapport (par ligne) contient un texte (ex. motif d'erreur). */
+  async expectImportReportContains(text: string | RegExp): Promise<void> {
+    await expect(this.byTestId("admin-import-report")).toContainText(text);
+  }
 }

--- a/e2e/pom/admin.page.ts
+++ b/e2e/pom/admin.page.ts
@@ -475,4 +475,33 @@ export class AdminPage extends BasePage {
     await this.byTestId("admin-actor-maia-batch-btn").click();
     await this.expectToaster(/Batch MAIA lancé en tâche de fond/i);
   }
+
+  // --- Onglet « Batch de données » : import Excel des acteurs (#751, ADM-08/09) ---
+
+  /** Sélectionne le classeur Excel et lance l'import, puis attend l'affichage du rapport. */
+  async importActorsFromExcel(file: {
+    name: string;
+    mimeType: string;
+    buffer: Buffer;
+  }): Promise<void> {
+    await this.byTestId("admin-import-actors-file").setInputFiles({
+      name: file.name,
+      mimeType: file.mimeType,
+      buffer: file.buffer,
+    });
+    await this.byTestId("admin-import-actors-submit").click();
+    await expect(this.byTestId("admin-import-report")).toBeVisible();
+  }
+
+  /** Vérifie le résumé du rapport d'exécution (créés / mis à jour / erreurs). */
+  async expectImportReportSummary(text: string | RegExp): Promise<void> {
+    await expect(this.byTestId("admin-import-report-summary")).toContainText(
+      text,
+    );
+  }
+
+  /** Vérifie que le rapport d'exécution est téléchargeable. */
+  async expectImportReportDownloadable(): Promise<void> {
+    await expect(this.byTestId("admin-import-report-download")).toBeVisible();
+  }
 }

--- a/e2e/support/actor-import-xlsx.ts
+++ b/e2e/support/actor-import-xlsx.ts
@@ -1,0 +1,59 @@
+import ExcelJS from "exceljs";
+
+/**
+ * Génère un classeur Excel au format de l'export RefApp pour l'import d'acteurs.
+ *
+ * Les en-têtes reproduisent **à l'identique** les libellés de l'onglet « Acteurs » de l'export
+ * (cf. `backend/src/applications/columnLabels/application-export.columnLabels.ts`). Le service
+ * d'import retrouve les colonnes par ces libellés ; une ligne avec « ID Acteur » met à jour
+ * l'acteur correspondant, sinon un acteur est créé.
+ */
+export interface ActorImportRow {
+  /** « ID Acteur » — vide pour une création, renseigné pour une mise à jour. */
+  id?: string;
+  /** « ID Application » — application de rattachement (obligatoire). */
+  applicationId: string;
+  firstname?: string;
+  lastname?: string;
+  /** « Rôle » — code du type d'acteur (ex. « MOA »). */
+  role?: string;
+  /** « Type » — libellé du type d'acteur (résolution de repli si le code est absent). */
+  type?: string;
+  email?: string;
+}
+
+const ACTORS_SHEET = "Acteurs";
+const HEADERS = [
+  "ID Application",
+  "Application",
+  "ID Acteur",
+  "Prénom de l’acteur",
+  "Nom de l’acteur",
+  "Rôle",
+  "Type",
+  "Email",
+] as const;
+
+export async function buildActorImportWorkbook(
+  rows: ActorImportRow[],
+): Promise<Buffer> {
+  const workbook = new ExcelJS.Workbook();
+  const sheet = workbook.addWorksheet(ACTORS_SHEET);
+  sheet.addRow([...HEADERS]);
+
+  for (const row of rows) {
+    sheet.addRow([
+      row.applicationId,
+      "",
+      row.id ?? "",
+      row.firstname ?? "",
+      row.lastname ?? "",
+      row.role ?? "",
+      row.type ?? "",
+      row.email ?? "",
+    ]);
+  }
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  return Buffer.from(buffer);
+}

--- a/e2e/tests/administration-referentiels.spec.ts
+++ b/e2e/tests/administration-referentiels.spec.ts
@@ -237,4 +237,66 @@ test.describe("Administration des référentiels", () => {
       if (seeded) await data.deleteActor(app!.id, seeded.id).catch(() => {});
     }
   });
+
+  test("ADM-10 - import Excel : ligne fautive consignée, traitement poursuivi", async ({
+    page,
+    data,
+  }) => {
+    const ts = Date.now();
+    const okEmail = `e2e-adm10-ok-${ts}@example.com`;
+    const koEmail = `e2e-adm10-ko-${ts}@example.com`;
+    const okLastname = `IMPORT-OK-${ts}`;
+    const app = await data.firstApplication();
+    const actorType = await firstActorType();
+    test.skip(!app, "Aucune application disponible");
+    test.skip(!actorType, "Aucun type d'acteur disponible");
+
+    try {
+      // Une ligne valide (création) + une ligne fautive (rôle inexistant → non résolu).
+      const workbook = await buildActorImportWorkbook([
+        {
+          applicationId: app!.id,
+          firstname: "Acteur",
+          lastname: okLastname,
+          role: actorType!.code,
+          email: okEmail,
+        },
+        {
+          applicationId: app!.id,
+          firstname: "Acteur",
+          lastname: `IMPORT-KO-${ts}`,
+          role: `ROLE_INEXISTANT_${ts}`,
+          email: koEmail,
+        },
+      ]);
+
+      const admin = new AdminPage(page);
+      await admin.open();
+      await admin.openBatchDataTab();
+      await admin.importActorsFromExcel({
+        name: `import-adm10-${ts}.xlsx`,
+        mimeType: XLSX_MIME,
+        buffer: workbook,
+      });
+
+      // Le traitement continue malgré l'erreur : 1 création + 1 ligne en erreur.
+      await admin.expectImportReportSummary(/1 créé\(s\)/);
+      await admin.expectImportReportSummary(/1 en erreur/);
+      await admin.expectImportReportContains(/introuvable/i);
+
+      // La ligne valide est bien créée, la fautive ne l'est pas.
+      const ok = await dbQuery(`SELECT id FROM "Actor" WHERE email = $1`, [
+        okEmail,
+      ]);
+      const ko = await dbQuery(`SELECT id FROM "Actor" WHERE email = $1`, [
+        koEmail,
+      ]);
+      expect(ok.length).toBe(1);
+      expect(ko.length).toBe(0);
+    } finally {
+      await dbQuery(`DELETE FROM "Actor" WHERE email = ANY($1)`, [
+        [okEmail, koEmail],
+      ]).catch(() => {});
+    }
+  });
 });

--- a/e2e/tests/administration-referentiels.spec.ts
+++ b/e2e/tests/administration-referentiels.spec.ts
@@ -1,5 +1,21 @@
-import { test } from "../fixtures/test";
+import { expect, test } from "../fixtures/test";
 import { AdminPage } from "../pom";
+import { buildActorImportWorkbook } from "../support/actor-import-xlsx";
+import { dbQuery } from "../support/db";
+
+const XLSX_MIME =
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+/**
+ * Résout un type d'acteur directement en base. L'API `/actorTypes` n'est pas exposée par le
+ * résolveur e2e courant ; le type d'acteur est un prérequis non inscriptible pour ce protocole.
+ */
+async function firstActorType(): Promise<{ id: string; code: string } | null> {
+  const rows = await dbQuery<{ id: string; code: string }>(
+    `SELECT id, code FROM "ActorType" WHERE code IS NOT NULL ORDER BY code LIMIT 1`,
+  );
+  return rows[0] ?? null;
+}
 
 test.describe("Administration des référentiels", () => {
   // L'administration requiert une session admin. Certains cas n'utilisent que `page` : on consomme
@@ -115,5 +131,110 @@ test.describe("Administration des référentiels", () => {
     await admin.createCampaign(year, "Campagne E2E ADM-07");
     await admin.expectCampaignRow(year);
     await admin.deleteCampaign(year);
+  });
+
+  test("ADM-08 - importer un acteur via un fichier Excel (création)", async ({
+    page,
+    data,
+  }) => {
+    const ts = Date.now();
+    const lastname = `IMPORT-CREATE-${ts}`;
+    const email = `e2e-adm08-${ts}@example.com`;
+    const app = await data.firstApplication();
+    const actorType = await firstActorType();
+    test.skip(!app, "Aucune application disponible");
+    test.skip(!actorType, "Aucun type d'acteur disponible");
+
+    try {
+      const workbook = await buildActorImportWorkbook([
+        {
+          applicationId: app!.id,
+          firstname: "Acteur",
+          lastname,
+          role: actorType!.code,
+          email,
+        },
+      ]);
+
+      const admin = new AdminPage(page);
+      await admin.open();
+      await admin.openBatchDataTab();
+      await admin.importActorsFromExcel({
+        name: `import-adm08-${ts}.xlsx`,
+        mimeType: XLSX_MIME,
+        buffer: workbook,
+      });
+
+      await admin.expectImportReportSummary(/1 créé\(s\)/);
+      await admin.expectImportReportSummary(/0 en erreur/);
+      await admin.expectImportReportDownloadable();
+
+      // Non-régression : l'acteur a bien été créé en base par l'import.
+      const created = await dbQuery<{ lastname: string }>(
+        `SELECT lastname FROM "Actor" WHERE email = $1`,
+        [email],
+      );
+      expect(created.some((a) => a.lastname === lastname)).toBe(true);
+    } finally {
+      await dbQuery(`DELETE FROM "Actor" WHERE email = $1`, [email]).catch(
+        () => {},
+      );
+    }
+  });
+
+  test("ADM-09 - importer un acteur via un fichier Excel (mise à jour)", async ({
+    page,
+    data,
+  }) => {
+    const ts = Date.now();
+    const newLastname = `IMPORT-UPDATE-${ts}`;
+    const email = `e2e-adm09-${ts}@example.com`;
+    const app = await data.firstApplication();
+    const actorType = await firstActorType();
+    test.skip(!app, "Aucune application disponible");
+    test.skip(!actorType, "Aucun type d'acteur disponible");
+
+    const seeded = await data.createActor(app!.id, {
+      firstname: "Acteur",
+      lastname: `SEED-${ts}`,
+      email,
+      actorTypeId: actorType!.id,
+      isGroup: false,
+    });
+    test.skip(!seeded, "Impossible de créer l'acteur de test");
+
+    try {
+      const workbook = await buildActorImportWorkbook([
+        {
+          id: seeded!.id,
+          applicationId: app!.id,
+          firstname: "Acteur",
+          lastname: newLastname,
+          role: actorType!.code,
+          email,
+        },
+      ]);
+
+      const admin = new AdminPage(page);
+      await admin.open();
+      await admin.openBatchDataTab();
+      await admin.importActorsFromExcel({
+        name: `import-adm09-${ts}.xlsx`,
+        mimeType: XLSX_MIME,
+        buffer: workbook,
+      });
+
+      await admin.expectImportReportSummary(/1 mis à jour/);
+      await admin.expectImportReportSummary(/0 en erreur/);
+
+      // Non-régression : la mise à jour est bien appliquée en base.
+      const updated = await dbQuery<{ lastname: string }>(
+        `SELECT lastname FROM "Actor" WHERE id = $1`,
+        [seeded!.id],
+      );
+      expect(updated[0]?.lastname).toBe(newLastname);
+    } finally {
+      if (seeded) await data.deleteActor(app!.id, seeded.id).catch(() => {});
+    }
   });
 });

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -2856,6 +2856,51 @@ paths:
         "204":
           description: Acteur supprimé avec succès
       tags: *a14
+  /api/v2/actors/import/excel:
+    post:
+      operationId: ActorController_importExcel
+      summary: Importer des acteurs depuis un fichier Excel
+      description: >-
+        Importe ou met à jour des acteurs en masse à partir d'un fichier Excel
+
+        au même format que l'export (un onglet par table). Seul l'onglet «
+        Acteurs » est traité.
+
+        Chaque ligne dont la colonne « ID Acteur » est renseignée met à jour
+        l'acteur correspondant ;
+
+        sinon un nouvel acteur est créé. Les contrôles et métadonnées sont
+        identiques à ceux de l'API.
+
+        Un rapport d'exécution est retourné.
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+              required:
+                - file
+      responses:
+        "200":
+          description: Rapport d'exécution de l'import
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportReportDto"
+        "201":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportReportDto"
+      tags: &a15
+        - Actors
   /api/v2/actors/count:
     get:
       operationId: ActorController_countAllActors
@@ -2868,8 +2913,7 @@ paths:
             application/json:
               schema:
                 type: number
-      tags: &a15
-        - Actors
+      tags: *a15
   /api/v2/actors/sync-maia:
     post:
       operationId: ActorController_syncFromMaia
@@ -6623,6 +6667,83 @@ components:
         isGroup:
           type: boolean
           description: Indique si l'acteur est un groupe d'acteurs ou non
+    ImportReportSummaryDto:
+      type: object
+      properties:
+        processedSheets:
+          description: Onglets effectivement traités
+          type: array
+          items:
+            type: string
+        ignoredSheets:
+          description: Onglets ignorés (absents ou non reconnus)
+          type: array
+          items:
+            type: string
+        created:
+          type: number
+          description: Nombre d'enregistrements créés
+        updated:
+          type: number
+          description: Nombre d'enregistrements mis à jour
+        errors:
+          type: number
+          description: Nombre de lignes en erreur
+      required:
+        - processedSheets
+        - ignoredSheets
+        - created
+        - updated
+        - errors
+    ImportReportEntryDto:
+      type: object
+      properties:
+        sheet:
+          type: string
+          description: Nom de l'onglet traité
+          example: Acteurs
+        row:
+          type: number
+          description: Numéro de la ligne dans l'onglet (1 = en-tête)
+          example: 4
+        status:
+          type: string
+          description: Résultat du traitement de la ligne
+          enum:
+            - created
+            - updated
+            - error
+          example: updated
+        identifier:
+          type: string
+          description: Identifiant lisible de l'enregistrement concerné
+          example: "MOA : jean.dupont@example.com"
+        message:
+          type: string
+          description: Détail (motif d'erreur ou information)
+          example: Type d'acteur introuvable pour le rôle « XYZ »
+      required:
+        - sheet
+        - row
+        - status
+    ImportReportDto:
+      type: object
+      properties:
+        summary:
+          $ref: "#/components/schemas/ImportReportSummaryDto"
+        entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/ImportReportEntryDto"
+        logs:
+          description: Journal d'exécution (erreurs au niveau onglet, etc.)
+          type: array
+          items:
+            type: string
+      required:
+        - summary
+        - entries
+        - logs
     CreateActorTypeDto:
       type: object
       properties:

--- a/frontend/src/components/admin/AdminBatchData.vue
+++ b/frontend/src/components/admin/AdminBatchData.vue
@@ -1,12 +1,64 @@
 <script setup lang="ts">
 import api from "@/api";
-import type { UserControllerSyncOrganizationsFromMaiaData } from "@/client";
+import type { ImportReportDto, UserControllerSyncOrganizationsFromMaiaData } from "@/client";
 import { useToasterStore } from "@/stores/toasterStore";
 
 const props = defineProps<{ loading: boolean }>();
 const emit = defineEmits<(e: "recomputeQuality") => void>();
 const toaster = useToasterStore();
 const isBatchLoading = ref(false);
+
+const selectedFile = ref<File | null>(null);
+const isImporting = ref(false);
+const importReport = ref<ImportReportDto | null>(null);
+
+function onImportFileChange(event: Event) {
+  const input = event.target as HTMLInputElement;
+  selectedFile.value = input.files?.[0] ?? null;
+  importReport.value = null;
+}
+
+async function runActorImport() {
+  if (!selectedFile.value) return;
+  isImporting.value = true;
+  try {
+    const response = await api.actorControllerImportExcel({ body: { file: selectedFile.value } });
+    if (!response.data) {
+      throw new Error("Réponse d'import vide.");
+    }
+    importReport.value = response.data;
+    const { created, updated, errors } = response.data.summary;
+    const summary = `${created} créé(s), ${updated} mis à jour, ${errors} en erreur.`;
+    if (errors > 0) {
+      toaster.addErrorMessage(`Import terminé avec des erreurs : ${summary}`);
+    } else {
+      toaster.addSuccessMessage(`Import terminé : ${summary}`);
+    }
+  } catch (error) {
+    toaster.addErrorMessage("Erreur lors de l'import du fichier Excel.");
+    console.error(error);
+  } finally {
+    isImporting.value = false;
+  }
+}
+
+function downloadImportReport() {
+  if (!importReport.value) return;
+  const header = ["Onglet", "Ligne", "Statut", "Identifiant", "Détail"].join(";");
+  const rows = importReport.value.entries.map((entry) =>
+    [entry.sheet, String(entry.row), entry.status, entry.identifier ?? "", (entry.message ?? "").replace(/[\r\n;]+/g, " ")].join(";"),
+  );
+  const csv = [header, ...rows, "", ...importReport.value.logs].join("\n");
+  const blob = new Blob([`\uFEFF${csv}`], { type: "text/csv;charset=utf-8" });
+  const link = document.createElement("a");
+  link.href = URL.createObjectURL(blob);
+  const date = new Date().toISOString().split("T")[0];
+  link.download = `rapport_import_acteurs_${date}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
+}
 
 async function runMaiaBatch(body: NonNullable<UserControllerSyncOrganizationsFromMaiaData["body"]> = { onlyMissing: true }) {
   isBatchLoading.value = true;
@@ -88,6 +140,67 @@ async function runMaiaActorSync() {
         />
       </div>
     </div>
+    <div class="section-card--mt">
+      <h2 class="fr-h2">Import Excel des acteurs</h2>
+      <p class="fr-hint-text">
+        Importez ou mettez à jour des acteurs en masse à partir d'un fichier Excel au même format que l'export (un onglet « Acteurs »). Une
+        ligne avec un « ID Acteur » met à jour l'acteur ; sans identifiant, un acteur est créé.
+      </p>
+      <div class="import-actor-container">
+        <div class="fr-upload-group">
+          <label class="fr-label" for="admin-import-actors-file">Fichier Excel (.xlsx)</label>
+          <input
+            id="admin-import-actors-file"
+            class="fr-upload"
+            type="file"
+            accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            data-testid="admin-import-actors-file"
+            @change="onImportFileChange"
+          />
+        </div>
+        <DsfrButton
+          :label="isImporting ? 'Import en cours...' : 'Importer les acteurs'"
+          :disabled="isImporting || !selectedFile"
+          :icon="{ name: 'ri-upload-2-line', animation: isImporting ? 'spin' : undefined }"
+          data-testid="admin-import-actors-submit"
+          @click="runActorImport()"
+        />
+      </div>
+
+      <div v-if="importReport" class="import-report" data-testid="admin-import-report">
+        <p>
+          <strong>Rapport d'exécution :</strong>
+          <span data-testid="admin-import-report-summary">
+            {{ importReport.summary.created }} créé(s), {{ importReport.summary.updated }} mis à jour, {{ importReport.summary.errors }} en
+            erreur.
+          </span>
+        </p>
+        <DsfrTable
+          v-if="importReport.entries.length > 0"
+          title="Détail par ligne"
+          :headers="['Onglet', 'Ligne', 'Statut', 'Identifiant', 'Détail']"
+        >
+          <tr v-for="(entry, idx) in importReport.entries" :key="idx">
+            <td>{{ entry.sheet }}</td>
+            <td>{{ entry.row }}</td>
+            <td>
+              <span v-if="entry.status === 'created'" class="fr-badge fr-badge--success fr-badge--sm">Créé</span>
+              <span v-else-if="entry.status === 'updated'" class="fr-badge fr-badge--info fr-badge--sm">Mis à jour</span>
+              <span v-else class="fr-badge fr-badge--error fr-badge--sm">Erreur</span>
+            </td>
+            <td>{{ entry.identifier }}</td>
+            <td>{{ entry.message }}</td>
+          </tr>
+        </DsfrTable>
+        <DsfrButton
+          label="Télécharger le rapport"
+          secondary
+          icon="ri-download-2-line"
+          data-testid="admin-import-report-download"
+          @click="downloadImportReport()"
+        />
+      </div>
+    </div>
   </div>
 </template>
 
@@ -110,6 +223,21 @@ async function runMaiaActorSync() {
   display: flex;
   flex-direction: column;
   justify-content: center;
+  gap: 1rem;
+}
+
+.import-actor-container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.import-report {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 1rem;
 }
 

--- a/qa/protocoles/administration-referentiels.md
+++ b/qa/protocoles/administration-referentiels.md
@@ -8,7 +8,7 @@
 | Légende           |                                                                              |
 | :---------------- | :--------------------------------------------------------------------------- |
 | **Automatisé** ✅ | tests Playwright dédiés dans `e2e/tests/administration-referentiels.spec.ts` |
-| **Statut**        | 🟢 automatisé — 9 cas couverts par la CI                                     |
+| **Statut**        | 🟢 automatisé — 10 cas couverts par la CI                                    |
 
 ---
 
@@ -81,3 +81,12 @@
   importer le fichier contenant l'identifiant de l'acteur.
 - **Résultat attendu** : le rapport indique « 1 mis à jour » et « 0 en erreur » ; la modification du
   nom est appliquée à l'acteur existant (même identifiant).
+
+### ADM-10 — Import Excel : ligne fautive consignée, traitement poursuivi ✅
+
+- **Datafeature** : une application existante et un type d'acteur (résolu en base) ; le classeur
+  contient deux lignes — une valide (création) et une fautive (rôle inexistant, non résolu).
+- **Action** : administration → onglet Batch de données → section « Import Excel des acteurs » →
+  importer le fichier multi-lignes.
+- **Résultat attendu** : le traitement continue malgré l'erreur ; le rapport indique « 1 créé(s) » et
+  « 1 en erreur » avec le motif (« introuvable »). La ligne valide est créée, la fautive ne l'est pas.

--- a/qa/protocoles/administration-referentiels.md
+++ b/qa/protocoles/administration-referentiels.md
@@ -8,7 +8,7 @@
 | Légende           |                                                                              |
 | :---------------- | :--------------------------------------------------------------------------- |
 | **Automatisé** ✅ | tests Playwright dédiés dans `e2e/tests/administration-referentiels.spec.ts` |
-| **Statut**        | 🟢 automatisé — 7 cas couverts par la CI                                     |
+| **Statut**        | 🟢 automatisé — 9 cas couverts par la CI                                     |
 
 ---
 
@@ -63,3 +63,21 @@
   `admin-campaign-delete-btn` pour la supprimer.
 - **Résultat attendu** : la campagne créée apparaît dans le tableau ; sa suppression la retire ; les
   actions admin sont réservées au privilège `AdminPanelManage`.
+
+### ADM-08 — Importer un acteur via un fichier Excel (création) ✅
+
+- **Datafeature** : une application existante (lecture API) et un type d'acteur (résolu en base) ;
+  le classeur Excel est généré à la volée au format de l'export (onglet « Acteurs »).
+- **Action** : administration → onglet Batch de données → section « Import Excel des acteurs » →
+  sélectionner le fichier (`admin-import-actors-file`) → `admin-import-actors-submit`.
+- **Résultat attendu** : le rapport d'exécution (`admin-import-report`) indique « 1 créé(s) » et
+  « 0 en erreur », est téléchargeable (`admin-import-report-download`), et l'acteur est bien créé.
+
+### ADM-09 — Importer un acteur via un fichier Excel (mise à jour) ✅
+
+- **Datafeature** : un acteur de test créé via l'API (nettoyé en fin de test) ; le classeur Excel
+  reprend son « ID Acteur » avec un nom modifié.
+- **Action** : administration → onglet Batch de données → section « Import Excel des acteurs » →
+  importer le fichier contenant l'identifiant de l'acteur.
+- **Résultat attendu** : le rapport indique « 1 mis à jour » et « 0 en erreur » ; la modification du
+  nom est appliquée à l'acteur existant (même identifiant).


### PR DESCRIPTION
Closes #751 (phase 1 — Acteurs).

## Contexte
Permettre l'import/modification en masse d'acteurs à partir d'un fichier Excel au format de l'export (un onglet par table). Cette phase ne traite que l'onglet **Acteurs**.

## Backend
- **Prérequis** : ajout de la colonne **« ID Acteur »** (PK) à l'onglet Acteurs de l'export (`columnLabels`, `mapActors`, usecase export).
- `ActorImportService` : lecture du classeur (exceljs), traitement de l'onglet `Acteurs`.
  - Vérifie la présence des colonnes nécessaires ; sinon l'onglet n'est pas traité (consigné dans le journal).
  - Lignes traitées individuellement : « ID Acteur » présent → **mise à jour**, sinon → **création**, via `ActorService` (mêmes contrôles et mêmes métadonnées que l'API). Erreur sur une ligne → consignée (n° + motif) et on continue.
  - Onglets inconnus / absents ignorés.
- Endpoint `POST /actors/import/excel` (multipart, `AdminPanelManage`) renvoyant un **rapport d'exécution** (`ImportReportDto`).

## Frontend
- Section **« Import Excel des acteurs »** dans l'onglet admin *Batch de données* : upload `.xlsx`, lancement, affichage du résumé + détail par ligne, et **téléchargement du rapport** (CSV).

## Tests de non-régression (POM strict)
- `ADM-08` : import → création d'un acteur.
- `ADM-09` : import → mise à jour d'un acteur existant (par « ID Acteur »).
- Verts sur chromium/firefox/webkit ; protocole et template de campagne mis à jour (7 → 9).

## Note (hors périmètre)
Deux helpers e2e (`api.actorTypes()` route erronée, `api.actors()` non-déballage de la pagination) sont latents et masquent CRU-01/02/03 (le formulaire acteur exige une organisation). Laissés inchangés ici pour ne pas démasquer des échecs UI non liés ; à traiter séparément.