### PR TITLE
feat: import Excel — onglets Applications et Hébergements (#752)

### DIFF
--- a/backend/src/applications/columnLabels/application-export.columnLabels.ts
+++ b/backend/src/applications/columnLabels/application-export.columnLabels.ts
@@ -25,6 +25,7 @@ export const columnLabels: Record<string, string> = {
   "labels.labelSource.source": "Source du label",
 
   hostings: "Hébergements",
+  "hostings.id": "ID Hébergement",
   "hostings.provider": "Fournisseur d’hébergement",
   "hostings.label": "Label d’hébergement",
   "hostings.region": "Région",

--- a/backend/src/applications/map/application-export.map.ts
+++ b/backend/src/applications/map/application-export.map.ts
@@ -55,6 +55,7 @@ export function mapHostings(app: ApplicationWithAllRelations) {
     app.hostings?.map((h) => ({
       applicationId: app.id,
       applicationLabel: app.label,
+      "hostings.id": h.id,
       "hostings.label": h.label || "",
       "hostings.provider": h.hostingOption?.provider || "",
       "hostings.site": h.hostingOption?.site || "",

--- a/backend/src/applications/usecases/application-export.usecase.ts
+++ b/backend/src/applications/usecases/application-export.usecase.ts
@@ -58,6 +58,7 @@ export class ExportApplicationsUseCase {
         columns: [
           col("applicationId", 30),
           col("applicationLabel", 30),
+          col("hostings.id", 36),
           col("hostings.label", 30),
           col("hostings.provider", 30),
           col("hostings.site", 25),

--- a/backend/src/import/excel-import.service.spec.ts
+++ b/backend/src/import/excel-import.service.spec.ts
@@ -7,7 +7,9 @@ jest.mock("src/metadatas/metadatas.service", () => ({
 import * as ExcelJS from "exceljs";
 import { sheetLabels } from "src/applications/constants/application-export.sheet-labels";
 import type { ActorsSheetProcessor } from "./processors/actors-sheet.processor";
+import type { ApplicationsSheetProcessor } from "./processors/applications-sheet.processor";
 import type { CompliancesSheetProcessor } from "./processors/compliances-sheet.processor";
+import type { HostingsSheetProcessor } from "./processors/hostings-sheet.processor";
 import { ExcelImportService } from "./excel-import.service";
 
 async function workbookBuffer(sheetNames: string[]): Promise<Buffer> {
@@ -16,20 +18,28 @@ async function workbookBuffer(sheetNames: string[]): Promise<Buffer> {
   return Buffer.from(await wb.xlsx.writeBuffer());
 }
 
+function makeProcessor(sheetName: string) {
+  return { sheetName, process: jest.fn().mockResolvedValue(undefined) };
+}
+
 function setup() {
-  const actorsProcessor = {
-    sheetName: sheetLabels.Actors,
-    process: jest.fn().mockResolvedValue(undefined),
-  };
-  const compliancesProcessor = {
-    sheetName: sheetLabels.Compliances,
-    process: jest.fn().mockResolvedValue(undefined),
-  };
+  const applicationsProcessor = makeProcessor(sheetLabels.Applications);
+  const hostingsProcessor = makeProcessor(sheetLabels.Hostings);
+  const actorsProcessor = makeProcessor(sheetLabels.Actors);
+  const compliancesProcessor = makeProcessor(sheetLabels.Compliances);
   const service = new ExcelImportService(
+    applicationsProcessor as unknown as ApplicationsSheetProcessor,
+    hostingsProcessor as unknown as HostingsSheetProcessor,
     actorsProcessor as unknown as ActorsSheetProcessor,
     compliancesProcessor as unknown as CompliancesSheetProcessor,
   );
-  return { service, actorsProcessor, compliancesProcessor };
+  return {
+    service,
+    applicationsProcessor,
+    hostingsProcessor,
+    actorsProcessor,
+    compliancesProcessor,
+  };
 }
 
 describe("ExcelImportService", () => {

--- a/backend/src/import/excel-import.service.ts
+++ b/backend/src/import/excel-import.service.ts
@@ -2,11 +2,15 @@ import { Injectable } from "@nestjs/common";
 import * as ExcelJS from "exceljs";
 import { createEmptyReport, ImportReportDto } from "./dto/import-report.dto";
 import { ActorsSheetProcessor } from "./processors/actors-sheet.processor";
+import { ApplicationsSheetProcessor } from "./processors/applications-sheet.processor";
 import { CompliancesSheetProcessor } from "./processors/compliances-sheet.processor";
+import { HostingsSheetProcessor } from "./processors/hostings-sheet.processor";
 
 @Injectable()
 export class ExcelImportService {
   constructor(
+    private readonly applicationsProcessor: ApplicationsSheetProcessor,
+    private readonly hostingsProcessor: HostingsSheetProcessor,
     private readonly actorsProcessor: ActorsSheetProcessor,
     private readonly compliancesProcessor: CompliancesSheetProcessor,
   ) {}
@@ -29,8 +33,13 @@ export class ExcelImportService {
     const report = createEmptyReport();
 
     // Onglets pris en charge, dans l'ordre de traitement.
-    // (L'onglet « Applications », traité en premier, relève de la phase 3.)
-    const processors = [this.actorsProcessor, this.compliancesProcessor];
+    // L'onglet « Applications » est toujours traité en premier (les autres s'y rattachent).
+    const processors = [
+      this.applicationsProcessor,
+      this.hostingsProcessor,
+      this.actorsProcessor,
+      this.compliancesProcessor,
+    ];
     const knownSheets = new Set(processors.map((p) => p.sheetName));
 
     for (const processor of processors) {

--- a/backend/src/import/import.controller.ts
+++ b/backend/src/import/import.controller.ts
@@ -35,10 +35,11 @@ export class ImportController {
   @ApiOperation({
     summary: "Importer des données depuis un fichier Excel",
     description: `Importe ou met à jour des données en masse à partir d'un fichier Excel
-au même format que l'export (un onglet par table). Les onglets pris en charge sont traités
-(actuellement : « Acteurs » et « Conformités ») ; les autres sont ignorés. Pour chaque ligne,
-la présence de l'identifiant déclenche une mise à jour, sinon une création. Les contrôles et
-les métadonnées sont identiques à ceux de l'API. Un rapport d'exécution est retourné.`,
+au même format que l'export (un onglet par table). L'onglet « Applications » est toujours traité
+en premier, puis les onglets pris en charge (« Hébergements », « Acteurs », « Conformités ») ;
+les autres sont ignorés. Pour chaque ligne, la présence de l'identifiant déclenche une mise à jour,
+sinon une création. Les contrôles et les métadonnées sont identiques à ceux de l'API. Un rapport
+d'exécution est retourné.`,
   })
   @ApiBody({
     schema: {

--- a/backend/src/import/import.module.ts
+++ b/backend/src/import/import.module.ts
@@ -1,18 +1,33 @@
 import { Module } from "@nestjs/common";
 import { ActorModule } from "src/actor/actor.module";
+import { ApplicationModule } from "src/applications/application.module";
 import { CommonModule } from "src/common/common.module";
 import { CompliancesModule } from "src/compliances/compliances.module";
+import { HostingsModule } from "src/hostings/hostings.module";
 import { PrismaModule } from "src/prisma/prisma.module";
+import { UserModule } from "src/user/user.module";
 import { ExcelImportService } from "./excel-import.service";
 import { ImportController } from "./import.controller";
 import { ActorsSheetProcessor } from "./processors/actors-sheet.processor";
+import { ApplicationsSheetProcessor } from "./processors/applications-sheet.processor";
 import { CompliancesSheetProcessor } from "./processors/compliances-sheet.processor";
+import { HostingsSheetProcessor } from "./processors/hostings-sheet.processor";
 
 @Module({
-  imports: [PrismaModule, ActorModule, CommonModule, CompliancesModule],
+  imports: [
+    PrismaModule,
+    ActorModule,
+    ApplicationModule,
+    HostingsModule,
+    UserModule,
+    CommonModule,
+    CompliancesModule,
+  ],
   controllers: [ImportController],
   providers: [
     ExcelImportService,
+    ApplicationsSheetProcessor,
+    HostingsSheetProcessor,
     ActorsSheetProcessor,
     CompliancesSheetProcessor,
   ],

--- a/backend/src/import/processors/applications-sheet.processor.spec.ts
+++ b/backend/src/import/processors/applications-sheet.processor.spec.ts
@@ -1,0 +1,185 @@
+// Neutralise une dépendance circulaire préexistante du graphe d'import
+// (base.service <-> metadatas.service) qui casse à l'évaluation sous ts-jest.
+jest.mock("src/metadatas/metadatas.service", () => ({
+  MetadatasService: class {},
+}));
+
+import * as ExcelJS from "exceljs";
+import type { ApplicationService } from "src/applications/application.service";
+import { sheetLabels } from "src/applications/constants/application-export.sheet-labels";
+import type { PrismaService } from "src/prisma/prisma.service";
+import type { UserService } from "src/user/user.service";
+import { createEmptyReport } from "../dto/import-report.dto";
+import { ApplicationsSheetProcessor } from "./applications-sheet.processor";
+
+function buildSheet(
+  headers: string[],
+  rows: (string | number)[][],
+): ExcelJS.Worksheet {
+  const wb = new ExcelJS.Workbook();
+  const sheet = wb.addWorksheet(sheetLabels.Applications);
+  sheet.addRow(headers);
+  for (const r of rows) sheet.addRow(r);
+  return sheet;
+}
+
+function setup() {
+  const prisma = {
+    application: {
+      findUnique: jest.fn(({ where }: { where: { id: string } }) =>
+        where.id === "ghost" ? null : { id: where.id },
+      ),
+    },
+  };
+  const applicationService = {
+    createApplication: jest.fn().mockResolvedValue({ id: "new-app" }),
+    update: jest.fn().mockResolvedValue({ id: "app-1" }),
+  };
+  const userService = {
+    findByIdWithRelations: jest
+      .fn()
+      .mockResolvedValue({ id: "user-1", role: "ADMIN" }),
+  };
+  const processor = new ApplicationsSheetProcessor(
+    prisma as unknown as PrismaService,
+    applicationService as unknown as ApplicationService,
+    userService as unknown as UserService,
+  );
+  return { processor, prisma, applicationService, userService };
+}
+
+describe("ApplicationsSheetProcessor", () => {
+  it("crée une application sans identifiant", async () => {
+    const { processor, applicationService } = setup();
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet(
+        ["Identifiant", "Libellé", "Description"],
+        [["", "Nouvelle App", "Une description"]],
+      ),
+      "user-1",
+      report,
+    );
+
+    expect(report.summary.created).toBe(1);
+    expect(report.summary.errors).toBe(0);
+    expect(applicationService.createApplication).toHaveBeenCalledWith(
+      "user-1",
+      // `tags` doit être un tableau (défaut []) : `createApplication` le passe à `findByNames`.
+      expect.objectContaining({ label: "Nouvelle App", tags: [] }),
+    );
+  });
+
+  it("met à jour une application avec identifiant", async () => {
+    const { processor, applicationService } = setup();
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet(
+        ["Identifiant", "Libellé", "Description"],
+        [["app-1", "App MAJ", "Desc"]],
+      ),
+      "user-1",
+      report,
+    );
+
+    expect(report.summary.updated).toBe(1);
+    expect(applicationService.update).toHaveBeenCalledWith(
+      expect.objectContaining({ applicationId: "app-1" }),
+    );
+  });
+
+  it("résout les listes (séparées par des virgules) et la priorité par libellé", async () => {
+    const { processor, applicationService } = setup();
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet(
+        [
+          "Identifiant",
+          "Libellé",
+          "Description",
+          "Tags",
+          "Priorité de redémarrage",
+        ],
+        [["", "App listes", "Desc", "a, b, c", "R0 - Immédiat (H24)"]],
+      ),
+      "user-1",
+      report,
+    );
+
+    expect(report.summary.created).toBe(1);
+    expect(applicationService.createApplication).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({
+        tags: ["a", "b", "c"],
+        priorityRestart: "R0",
+      }),
+    );
+  });
+
+  it("consigne une erreur quand l'application à mettre à jour est introuvable", async () => {
+    const { processor } = setup();
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet(
+        ["Identifiant", "Libellé", "Description"],
+        [["ghost", "Fantôme", "Desc"]],
+      ),
+      "user-1",
+      report,
+    );
+
+    expect(report.summary.errors).toBe(1);
+    expect(report.entries[0].message).toMatch(/Application introuvable/i);
+  });
+
+  it("erreur de validation si le libellé est trop court (création)", async () => {
+    const { processor, applicationService } = setup();
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet(
+        ["Identifiant", "Libellé", "Description"],
+        [["", "X", "Desc"]],
+      ),
+      "user-1",
+      report,
+    );
+
+    expect(report.summary.errors).toBe(1);
+    expect(report.entries[0].message).toMatch(/Validation/i);
+    expect(applicationService.createApplication).not.toHaveBeenCalled();
+  });
+
+  it("ne traite pas l'onglet sans la colonne Identifiant", async () => {
+    const { processor } = setup();
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet(["Libellé", "Description"], [["App", "Desc"]]),
+      "user-1",
+      report,
+    );
+
+    expect(report.summary.processedSheets).not.toContain(
+      sheetLabels.Applications,
+    );
+    expect(report.logs.join(" ")).toMatch(/colonnes manquantes/i);
+  });
+
+  it("ne traite pas l'onglet si l'utilisateur courant est introuvable", async () => {
+    const { processor, userService } = setup();
+    userService.findByIdWithRelations.mockResolvedValue(null);
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet(
+        ["Identifiant", "Libellé", "Description"],
+        [["", "App", "Desc"]],
+      ),
+      "user-1",
+      report,
+    );
+
+    expect(report.summary.processedSheets).not.toContain(
+      sheetLabels.Applications,
+    );
+    expect(report.logs.join(" ")).toMatch(/utilisateur courant introuvable/i);
+  });
+});

--- a/backend/src/import/processors/applications-sheet.processor.ts
+++ b/backend/src/import/processors/applications-sheet.processor.ts
@@ -1,0 +1,242 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { Status, priorityRestart } from "@prisma/client";
+import { plainToInstance } from "class-transformer";
+import { validate } from "class-validator";
+import * as ExcelJS from "exceljs";
+import { ApplicationService } from "src/applications/application.service";
+import { columnLabels } from "src/applications/columnLabels/application-export.columnLabels";
+import { sheetLabels } from "src/applications/constants/application-export.sheet-labels";
+import { PriorityRestartLabels } from "src/applications/constants/enum-label";
+import {
+  CreateApplicationDto,
+  PatchApplicationDto,
+} from "src/applications/dto/create-application.dto";
+import { roleToPermissions } from "src/permissions/role-to-permissions";
+import { PrismaService } from "src/prisma/prisma.service";
+import { Requestor } from "src/user/entities/user.entity";
+import { UserService } from "src/user/user.service";
+import {
+  ImportReportDto,
+  ImportReportEntryDto,
+} from "../dto/import-report.dto";
+import { buildHeaderIndex, makeCellReader } from "../utils/excel.utils";
+
+/** En-têtes (libellés) attendus dans l'onglet « Applications », alignés sur l'export. */
+const HEADERS = {
+  id: columnLabels.id,
+  label: columnLabels.label,
+  shortName: columnLabels.shortName,
+  logo: columnLabels.logo,
+  description: columnLabels.description,
+  tags: columnLabels.tags,
+  purposes: columnLabels.purposes,
+  targetPopulations: columnLabels.targetPopulations,
+  priorityRestart: columnLabels.priorityRestart,
+} as const;
+
+/** Colonnes sans lesquelles l'onglet ne peut pas être traité. */
+const REQUIRED_HEADERS = [HEADERS.id, HEADERS.label];
+
+/** Statut par défaut affecté à une application créée par import (équivalent création API). */
+const DEFAULT_CREATE_STATUS: Status = Status.under_construction;
+
+/** Libellé d'export d'une priorité de redémarrage → code enum (résolution de repli). */
+const PRIORITY_LABEL_TO_CODE: Record<string, priorityRestart> = Object.entries(
+  PriorityRestartLabels,
+).reduce(
+  (acc, [code, label]) => {
+    acc[label] = code as priorityRestart;
+    return acc;
+  },
+  {} as Record<string, priorityRestart>,
+);
+
+/** Découpe une cellule multi-valeurs de l'export (séparateur « , ») en tableau nettoyé. */
+function splitList(value: string): string[] {
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Traitement de l'onglet « Applications » (US #752, phase 3). Toujours traité en premier par
+ * l'orchestrateur. Une ligne avec un « Identifiant » met à jour l'application correspondante ;
+ * sinon une application est créée. Les contrôles et métadonnées sont identiques à l'API.
+ */
+@Injectable()
+export class ApplicationsSheetProcessor {
+  readonly sheetName = sheetLabels.Applications;
+  private readonly logger = new Logger(ApplicationsSheetProcessor.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly applicationService: ApplicationService,
+    private readonly userService: UserService,
+  ) {}
+
+  async process(
+    worksheet: ExcelJS.Worksheet,
+    requestorId: string,
+    report: ImportReportDto,
+  ): Promise<void> {
+    const headerIndex = buildHeaderIndex(worksheet);
+    const missing = REQUIRED_HEADERS.filter((h) => !(h in headerIndex));
+    if (missing.length > 0) {
+      const message = `Onglet « ${this.sheetName} » non traité : colonnes manquantes (${missing.join(", ")}).`;
+      report.logs.push(message);
+      this.logger.warn(message);
+      return;
+    }
+
+    // La mise à jour d'application requiert le `Requestor` complet (permissions) ; on le résout
+    // une fois pour tout l'onglet à partir de l'utilisateur courant.
+    const requestor = await this.resolveRequestor(requestorId);
+    if (!requestor) {
+      const message = `Onglet « ${this.sheetName} » non traité : utilisateur courant introuvable.`;
+      report.logs.push(message);
+      this.logger.warn(message);
+      return;
+    }
+
+    report.summary.processedSheets.push(this.sheetName);
+
+    for (let rowNumber = 2; rowNumber <= worksheet.rowCount; rowNumber++) {
+      const getCell = makeCellReader(headerIndex, worksheet.getRow(rowNumber));
+      const data = {
+        id: getCell(HEADERS.id),
+        label: getCell(HEADERS.label),
+        shortName: getCell(HEADERS.shortName),
+        logo: getCell(HEADERS.logo),
+        description: getCell(HEADERS.description),
+        tags: getCell(HEADERS.tags),
+        purposes: getCell(HEADERS.purposes),
+        targetPopulations: getCell(HEADERS.targetPopulations),
+        priorityRestart: getCell(HEADERS.priorityRestart),
+      };
+
+      // Ligne entièrement vide : ignorée silencieusement.
+      if (Object.values(data).every((v) => v === "")) continue;
+
+      try {
+        const entry = await this.processRow(rowNumber, data, requestor);
+        report.entries.push(entry);
+        if (entry.status === "created") report.summary.created++;
+        else if (entry.status === "updated") report.summary.updated++;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        report.entries.push({
+          sheet: this.sheetName,
+          row: rowNumber,
+          status: "error",
+          identifier: data.label || data.id || undefined,
+          message,
+        });
+        report.summary.errors++;
+        this.logger.warn(
+          `Ligne ${rowNumber} (${this.sheetName}) en erreur : ${message}`,
+        );
+      }
+    }
+  }
+
+  private async processRow(
+    row: number,
+    data: {
+      id: string;
+      label: string;
+      shortName: string;
+      logo: string;
+      description: string;
+      tags: string;
+      purposes: string;
+      targetPopulations: string;
+      priorityRestart: string;
+    },
+    requestor: Requestor,
+  ): Promise<ImportReportEntryDto> {
+    const identifier = data.label || data.id;
+
+    const baseFields = this.compact({
+      label: data.label || undefined,
+      shortName: data.shortName || undefined,
+      logo: data.logo || undefined,
+      description: data.description || undefined,
+      tags: data.tags ? splitList(data.tags) : undefined,
+      purposes: data.purposes ? splitList(data.purposes) : undefined,
+      targetPopulations: data.targetPopulations
+        ? splitList(data.targetPopulations)
+        : undefined,
+      priorityRestart: this.resolvePriority(data.priorityRestart),
+    });
+
+    if (data.id) {
+      const existing = await this.prisma.application.findUnique({
+        where: { id: data.id },
+        select: { id: true },
+      });
+      if (!existing) {
+        throw new Error(`Application introuvable (id=${data.id}).`);
+      }
+
+      const dto = plainToInstance(PatchApplicationDto, baseFields);
+      await this.validateDto(dto);
+      await this.applicationService.update({
+        applicationId: data.id,
+        data: dto,
+        requestor,
+      });
+      return { sheet: this.sheetName, row, status: "updated", identifier };
+    }
+
+    const dto = plainToInstance(CreateApplicationDto, {
+      ...baseFields,
+      // `createApplication` transmet `tags` tel quel à `findByNames` (sans défaut) : on garantit
+      // un tableau à la création pour ne pas déréférencer `undefined`.
+      tags: baseFields.tags ?? [],
+      status: { status: DEFAULT_CREATE_STATUS },
+    });
+    await this.validateDto(dto);
+    await this.applicationService.createApplication(requestor.id, dto);
+    return { sheet: this.sheetName, row, status: "created", identifier };
+  }
+
+  /** Reconstitue le `Requestor` (avec permissions) de l'utilisateur courant. */
+  private async resolveRequestor(
+    requestorId: string,
+  ): Promise<Requestor | null> {
+    const user = await this.userService.findByIdWithRelations(requestorId);
+    if (!user) return null;
+    return { ...user, permissions: roleToPermissions(user.role) };
+  }
+
+  /** Résout la priorité de redémarrage par code (« R0 ») puis par libellé d'export. */
+  private resolvePriority(value: string): priorityRestart | undefined {
+    if (!value) return undefined;
+    if (value in priorityRestart) return value as priorityRestart;
+    return PRIORITY_LABEL_TO_CODE[value];
+  }
+
+  /** Retire les clés `undefined` pour ne pas remonter de valeurs vides à la validation. */
+  private compact<T extends Record<string, unknown>>(obj: T): Partial<T> {
+    return Object.fromEntries(
+      Object.entries(obj).filter(([, v]) => v !== undefined),
+    ) as Partial<T>;
+  }
+
+  private async validateDto(
+    dto: CreateApplicationDto | PatchApplicationDto,
+  ): Promise<void> {
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: false,
+    });
+    if (errors.length > 0) {
+      const details = errors
+        .map((e) => Object.values(e.constraints ?? {}).join(", "))
+        .filter(Boolean)
+        .join(" ; ");
+      throw new Error(`Validation échouée : ${details}`);
+    }
+  }
+}

--- a/backend/src/import/processors/hostings-sheet.processor.spec.ts
+++ b/backend/src/import/processors/hostings-sheet.processor.spec.ts
@@ -1,0 +1,169 @@
+// Neutralise une dépendance circulaire préexistante du graphe d'import
+// (base.service <-> metadatas.service) qui casse à l'évaluation sous ts-jest.
+jest.mock("src/metadatas/metadatas.service", () => ({
+  MetadatasService: class {},
+}));
+
+import * as ExcelJS from "exceljs";
+import { sheetLabels } from "src/applications/constants/application-export.sheet-labels";
+import type { HostingsService } from "src/hostings/hostings.service";
+import type { PrismaService } from "src/prisma/prisma.service";
+import { createEmptyReport } from "../dto/import-report.dto";
+import { HostingsSheetProcessor } from "./hostings-sheet.processor";
+
+/** Les ID d'application sont des UUID en base (cf. schema) → requis par CreateHostingDto. */
+const APP_UUID = "11111111-1111-4111-8111-111111111111";
+
+function buildSheet(
+  headers: string[],
+  rows: (string | number)[][],
+): ExcelJS.Worksheet {
+  const wb = new ExcelJS.Workbook();
+  const sheet = wb.addWorksheet(sheetLabels.Hostings);
+  sheet.addRow(headers);
+  for (const r of rows) sheet.addRow(r);
+  return sheet;
+}
+
+function setup() {
+  const prisma = {
+    application: {
+      findUnique: jest.fn(({ where }: { where: { id: string } }) =>
+        where.id === APP_UUID ? { id: APP_UUID } : null,
+      ),
+    },
+    hosting: {
+      findUnique: jest.fn(({ where }: { where: { id: string } }) =>
+        where.id === "host-1" ? { id: "host-1" } : null,
+      ),
+    },
+    hostingOption: {
+      findFirst: jest.fn().mockResolvedValue(null),
+      create: jest.fn().mockResolvedValue({ id: "opt-1" }),
+    },
+  };
+  const hostingsService = {
+    createHosting: jest.fn().mockResolvedValue({ id: "new-host" }),
+    updateHosting: jest.fn().mockResolvedValue({ id: "host-1" }),
+  };
+  const processor = new HostingsSheetProcessor(
+    prisma as unknown as PrismaService,
+    hostingsService as unknown as HostingsService,
+  );
+  return { processor, prisma, hostingsService };
+}
+
+const HEADERS = [
+  "ID Hébergement",
+  "ID Application",
+  "Label d’hébergement",
+  "Fournisseur d’hébergement",
+  "Site",
+  "Plateforme",
+];
+
+describe("HostingsSheetProcessor", () => {
+  it("crée un hébergement en créant l'option d'hébergement absente", async () => {
+    const { processor, prisma, hostingsService } = setup();
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet(HEADERS, [
+        ["", APP_UUID, "Prod", "DTNUM", "RENNES", "PHYSIQUE"],
+      ]),
+      "user-1",
+      report,
+    );
+
+    expect(report.summary.created).toBe(1);
+    expect(report.summary.errors).toBe(0);
+    expect(prisma.hostingOption.create).toHaveBeenCalledTimes(1);
+    expect(hostingsService.createHosting).toHaveBeenCalledWith(
+      expect.objectContaining({
+        applicationId: APP_UUID,
+        hostingOptionId: "opt-1",
+      }),
+      "user-1",
+    );
+  });
+
+  it("réutilise une option d'hébergement existante (pas de création)", async () => {
+    const { processor, prisma } = setup();
+    prisma.hostingOption.findFirst.mockResolvedValue({ id: "opt-existing" });
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet(HEADERS, [
+        ["", APP_UUID, "Prod", "DTNUM", "RENNES", "PHYSIQUE"],
+      ]),
+      "user-1",
+      report,
+    );
+
+    expect(report.summary.created).toBe(1);
+    expect(prisma.hostingOption.create).not.toHaveBeenCalled();
+  });
+
+  it("met à jour un hébergement existant", async () => {
+    const { processor, hostingsService } = setup();
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet(HEADERS, [
+        ["host-1", APP_UUID, "Prod", "DTNUM", "RENNES", "PHYSIQUE"],
+      ]),
+      "user-1",
+      report,
+    );
+
+    expect(report.summary.updated).toBe(1);
+    expect(hostingsService.updateHosting).toHaveBeenCalledWith(
+      "host-1",
+      expect.objectContaining({ applicationId: APP_UUID }),
+      "user-1",
+    );
+  });
+
+  it("consigne une erreur quand l'application est introuvable", async () => {
+    const { processor } = setup();
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet(HEADERS, [
+        ["", "ghost", "Prod", "DTNUM", "RENNES", "PHYSIQUE"],
+      ]),
+      "user-1",
+      report,
+    );
+
+    expect(report.summary.errors).toBe(1);
+    expect(report.entries[0].message).toMatch(/Application introuvable/i);
+  });
+
+  it("consigne une erreur quand l'hébergement à mettre à jour est introuvable", async () => {
+    const { processor } = setup();
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet(HEADERS, [
+        ["ghost-host", APP_UUID, "Prod", "DTNUM", "RENNES", "PHYSIQUE"],
+      ]),
+      "user-1",
+      report,
+    );
+
+    expect(report.summary.errors).toBe(1);
+    expect(report.entries[0].message).toMatch(/Hébergement introuvable/i);
+  });
+
+  it("ne traite pas l'onglet sans la colonne ID Hébergement", async () => {
+    const { processor } = setup();
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet(
+        ["ID Application", "Fournisseur d’hébergement"],
+        [[APP_UUID, "DTNUM"]],
+      ),
+      "user-1",
+      report,
+    );
+
+    expect(report.summary.processedSheets).not.toContain(sheetLabels.Hostings);
+    expect(report.logs.join(" ")).toMatch(/colonnes manquantes/i);
+  });
+});

--- a/backend/src/import/processors/hostings-sheet.processor.ts
+++ b/backend/src/import/processors/hostings-sheet.processor.ts
@@ -1,0 +1,234 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { plainToInstance } from "class-transformer";
+import { validate } from "class-validator";
+import * as ExcelJS from "exceljs";
+import { columnLabels } from "src/applications/columnLabels/application-export.columnLabels";
+import { sheetLabels } from "src/applications/constants/application-export.sheet-labels";
+import { CreateHostingOptionDto } from "src/hosting-option/dto/hosting-option.dto";
+import {
+  CreateHostingDto,
+  UpdateHostingDto,
+} from "src/hostings/dto/hosting.dto";
+import { HostingsService } from "src/hostings/hostings.service";
+import { PrismaService } from "src/prisma/prisma.service";
+import {
+  ImportReportDto,
+  ImportReportEntryDto,
+} from "../dto/import-report.dto";
+import { buildHeaderIndex, makeCellReader } from "../utils/excel.utils";
+
+/** En-têtes (libellés) attendus dans l'onglet « Hébergements », alignés sur l'export. */
+const HEADERS = {
+  id: columnLabels["hostings.id"],
+  applicationId: columnLabels.applicationId,
+  label: columnLabels["hostings.label"],
+  provider: columnLabels["hostings.provider"],
+  site: columnLabels["hostings.site"],
+  platform: columnLabels["hostings.platform"],
+  building: columnLabels["hostings.building"],
+  room: columnLabels["hostings.room"],
+} as const;
+
+/** Colonnes sans lesquelles l'onglet ne peut pas être traité. */
+const REQUIRED_HEADERS = [HEADERS.id, HEADERS.applicationId];
+
+/**
+ * Traitement de l'onglet « Hébergements » (US #752, phase 3). Une ligne avec un « ID Hébergement »
+ * met à jour l'hébergement correspondant ; sinon il est créé. L'option d'hébergement
+ * (fournisseur/site/plateforme/bâtiment/salle) est résolue par correspondance, et créée si besoin,
+ * comme via l'API.
+ */
+@Injectable()
+export class HostingsSheetProcessor {
+  readonly sheetName = sheetLabels.Hostings;
+  private readonly logger = new Logger(HostingsSheetProcessor.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly hostingsService: HostingsService,
+  ) {}
+
+  async process(
+    worksheet: ExcelJS.Worksheet,
+    requestorId: string,
+    report: ImportReportDto,
+  ): Promise<void> {
+    const headerIndex = buildHeaderIndex(worksheet);
+    const missing = REQUIRED_HEADERS.filter((h) => !(h in headerIndex));
+    if (missing.length > 0) {
+      const message = `Onglet « ${this.sheetName} » non traité : colonnes manquantes (${missing.join(", ")}).`;
+      report.logs.push(message);
+      this.logger.warn(message);
+      return;
+    }
+
+    report.summary.processedSheets.push(this.sheetName);
+
+    for (let rowNumber = 2; rowNumber <= worksheet.rowCount; rowNumber++) {
+      const getCell = makeCellReader(headerIndex, worksheet.getRow(rowNumber));
+      const data = {
+        id: getCell(HEADERS.id),
+        applicationId: getCell(HEADERS.applicationId),
+        label: getCell(HEADERS.label),
+        provider: getCell(HEADERS.provider),
+        site: getCell(HEADERS.site),
+        platform: getCell(HEADERS.platform),
+        building: getCell(HEADERS.building),
+        room: getCell(HEADERS.room),
+      };
+
+      // Ligne entièrement vide : ignorée silencieusement.
+      if (Object.values(data).every((v) => v === "")) continue;
+
+      try {
+        const entry = await this.processRow(rowNumber, data, requestorId);
+        report.entries.push(entry);
+        if (entry.status === "created") report.summary.created++;
+        else if (entry.status === "updated") report.summary.updated++;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        report.entries.push({
+          sheet: this.sheetName,
+          row: rowNumber,
+          status: "error",
+          identifier: this.identifierOf(data),
+          message,
+        });
+        report.summary.errors++;
+        this.logger.warn(
+          `Ligne ${rowNumber} (${this.sheetName}) en erreur : ${message}`,
+        );
+      }
+    }
+  }
+
+  private async processRow(
+    row: number,
+    data: {
+      id: string;
+      applicationId: string;
+      label: string;
+      provider: string;
+      site: string;
+      platform: string;
+      building: string;
+      room: string;
+    },
+    requestorId: string,
+  ): Promise<ImportReportEntryDto> {
+    if (!data.applicationId) {
+      throw new Error("Colonne « ID Application » vide.");
+    }
+
+    const application = await this.prisma.application.findUnique({
+      where: { id: data.applicationId },
+      select: { id: true },
+    });
+    if (!application) {
+      throw new Error(`Application introuvable (id=${data.applicationId}).`);
+    }
+
+    const hostingOptionId = await this.resolveHostingOptionId(data);
+    const identifier = this.identifierOf(data);
+
+    if (data.id) {
+      const existing = await this.prisma.hosting.findUnique({
+        where: { id: data.id },
+        select: { id: true },
+      });
+      if (!existing) {
+        throw new Error(`Hébergement introuvable (id=${data.id}).`);
+      }
+
+      const dto = plainToInstance(UpdateHostingDto, {
+        label: data.label || undefined,
+        applicationId: data.applicationId,
+        ...(hostingOptionId && { hostingOptionId }),
+      });
+      await this.validateDto(dto);
+      await this.hostingsService.updateHosting(data.id, dto, requestorId);
+      return { sheet: this.sheetName, row, status: "updated", identifier };
+    }
+
+    const dto = plainToInstance(CreateHostingDto, {
+      label: data.label || undefined,
+      applicationId: data.applicationId,
+      ...(hostingOptionId && { hostingOptionId }),
+      isActive: null,
+    });
+    await this.validateDto(dto);
+    await this.hostingsService.createHosting(dto, requestorId);
+    return { sheet: this.sheetName, row, status: "created", identifier };
+  }
+
+  /**
+   * Résout l'option d'hébergement par correspondance exacte (fournisseur/site/plateforme/bâtiment/
+   * salle) ; la crée si absente lorsque les champs obligatoires sont renseignés. Retourne
+   * `undefined` si aucun champ d'option n'est fourni (hébergement sans option).
+   */
+  private async resolveHostingOptionId(data: {
+    provider: string;
+    site: string;
+    platform: string;
+    building: string;
+    room: string;
+  }): Promise<string | undefined> {
+    const provider = data.provider;
+    const site = data.site;
+    const platform = data.platform;
+    const building = data.building || null;
+    const room = data.room || null;
+
+    if (!provider && !site && !platform && !building && !room) {
+      return undefined;
+    }
+
+    const existing = await this.prisma.hostingOption.findFirst({
+      where: { provider, site, platform, building, room },
+      select: { id: true },
+    });
+    if (existing) return existing.id;
+
+    // Création d'une option : mêmes contrôles que l'API (site/plateforme/fournisseur requis).
+    const optionDto = plainToInstance(CreateHostingOptionDto, {
+      provider,
+      site,
+      platform,
+      ...(building && { building }),
+      ...(room && { room }),
+    });
+    await this.validateDto(optionDto);
+    const created = await this.prisma.hostingOption.create({
+      data: { provider, site, platform, building, room },
+      select: { id: true },
+    });
+    return created.id;
+  }
+
+  private identifierOf(data: {
+    id: string;
+    label: string;
+    provider: string;
+    site: string;
+  }): string | undefined {
+    if (data.label) return data.label;
+    if (data.provider && data.site) return `${data.provider} (${data.site})`;
+    return data.provider || data.site || data.id || undefined;
+  }
+
+  private async validateDto(
+    dto: CreateHostingDto | UpdateHostingDto | CreateHostingOptionDto,
+  ): Promise<void> {
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: false,
+    });
+    if (errors.length > 0) {
+      const details = errors
+        .map((e) => Object.values(e.constraints ?? {}).join(", "))
+        .filter(Boolean)
+        .join(" ; ");
+      throw new Error(`Validation échouée : ${details}`);
+    }
+  }
+}

--- a/e2e/tests/administration-referentiels.spec.ts
+++ b/e2e/tests/administration-referentiels.spec.ts
@@ -416,4 +416,123 @@ test.describe("Administration des référentiels", () => {
       await deleteThrowawayApp(appId);
     }
   });
+
+  test("ADM-13 - importer une application via un fichier Excel (mise à jour)", async ({
+    page,
+  }) => {
+    const ts = Date.now();
+    const newLabel = `E2E-ADM13-MAJ-${ts}`;
+    const appId = await createThrowawayApp(`E2E ADM13 ${ts}`);
+
+    try {
+      const workbook = await buildSheetWorkbook(
+        "Applications",
+        ["Identifiant", "Libellé", "Description"],
+        [[appId, newLabel, "Mise à jour par import"]],
+      );
+
+      const admin = new AdminPage(page);
+      await admin.open();
+      await admin.openBatchDataTab();
+      await admin.importExcel({
+        name: `import-adm13-${ts}.xlsx`,
+        mimeType: XLSX_MIME,
+        buffer: workbook,
+      });
+
+      await admin.expectImportReportSummary(/1 mis à jour/);
+      await admin.expectImportReportSummary(/0 en erreur/);
+
+      // Non-régression : le nouveau libellé est appliqué à l'application existante.
+      const rows = await dbQuery<{ label: string }>(
+        `SELECT label FROM "Application" WHERE id = $1`,
+        [appId],
+      );
+      expect(rows[0]?.label).toBe(newLabel);
+    } finally {
+      await deleteThrowawayApp(appId);
+    }
+  });
+
+  test("ADM-14 - importer une application via un fichier Excel (création)", async ({
+    page,
+  }) => {
+    const ts = Date.now();
+    const label = `E2E-ADM14-${ts}`;
+    let createdId: string | undefined;
+
+    try {
+      const workbook = await buildSheetWorkbook(
+        "Applications",
+        ["Identifiant", "Libellé", "Description"],
+        [["", label, "Créée par import Excel"]],
+      );
+
+      const admin = new AdminPage(page);
+      await admin.open();
+      await admin.openBatchDataTab();
+      await admin.importExcel({
+        name: `import-adm14-${ts}.xlsx`,
+        mimeType: XLSX_MIME,
+        buffer: workbook,
+      });
+
+      await admin.expectImportReportSummary(/1 créé\(s\)/);
+      await admin.expectImportReportSummary(/0 en erreur/);
+
+      // Non-régression : une application au libellé fourni existe désormais en base.
+      const rows = await dbQuery<{ id: string }>(
+        `SELECT id FROM "Application" WHERE label = $1`,
+        [label],
+      );
+      expect(rows.length).toBe(1);
+      createdId = rows[0]?.id;
+    } finally {
+      if (createdId) await deleteThrowawayApp(createdId);
+    }
+  });
+
+  test("ADM-15 - importer un hébergement via un fichier Excel (création)", async ({
+    page,
+  }) => {
+    const ts = Date.now();
+    const appId = await createThrowawayApp(`E2E ADM15 ${ts}`);
+
+    try {
+      const workbook = await buildSheetWorkbook(
+        "Hébergements",
+        [
+          "ID Hébergement",
+          "ID Application",
+          "Label d’hébergement",
+          "Fournisseur d’hébergement",
+          "Site",
+          "Plateforme",
+        ],
+        [["", appId, `E2E-ADM15-HOST-${ts}`, "DTNUM", "RENNES", "PHYSIQUE"]],
+      );
+
+      const admin = new AdminPage(page);
+      await admin.open();
+      await admin.openBatchDataTab();
+      await admin.importExcel({
+        name: `import-adm15-${ts}.xlsx`,
+        mimeType: XLSX_MIME,
+        buffer: workbook,
+      });
+
+      await admin.expectImportReportSummary(/1 créé\(s\)/);
+      await admin.expectImportReportSummary(/0 en erreur/);
+
+      // Non-régression : l'application possède désormais un hébergement.
+      const rows = await dbQuery<{ id: string }>(
+        `SELECT id FROM "Hosting" WHERE "applicationId" = $1`,
+        [appId],
+      );
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      // La suppression de l'application supprime ses hébergements en cascade.
+      await deleteThrowawayApp(appId);
+    }
+  });
 });

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -3187,17 +3187,19 @@ paths:
       description: >-
         Importe ou met à jour des données en masse à partir d'un fichier Excel
 
-        au même format que l'export (un onglet par table). Les onglets pris en
-        charge sont traités
+        au même format que l'export (un onglet par table). L'onglet «
+        Applications » est toujours traité
 
-        (actuellement : « Acteurs » et « Conformités ») ; les autres sont
-        ignorés. Pour chaque ligne,
+        en premier, puis les onglets pris en charge (« Hébergements », « Acteurs
+        », « Conformités ») ;
 
-        la présence de l'identifiant déclenche une mise à jour, sinon une
-        création. Les contrôles et
+        les autres sont ignorés. Pour chaque ligne, la présence de l'identifiant
+        déclenche une mise à jour,
 
-        les métadonnées sont identiques à ceux de l'API. Un rapport d'exécution
-        est retourné.
+        sinon une création. Les contrôles et les métadonnées sont identiques à
+        ceux de l'API. Un rapport
+
+        d'exécution est retourné.
       parameters: []
       requestBody:
         required: true

--- a/frontend/src/components/admin/AdminBatchData.vue
+++ b/frontend/src/components/admin/AdminBatchData.vue
@@ -141,11 +141,11 @@ async function runMaiaActorSync() {
       </div>
     </div>
     <div class="section-card--mt">
-      <h2 class="fr-h2">Import Excel (acteurs, conformités)</h2>
+      <h2 class="fr-h2">Import Excel (applications, hébergements, acteurs, conformités)</h2>
       <p class="fr-hint-text">
-        Importez ou mettez à jour des données en masse à partir d'un fichier Excel au même format que l'export (un onglet par table). Les
-        onglets pris en charge sont traités (« Acteurs », « Conformités ») ; les autres sont ignorés. Une ligne avec un identifiant met à
-        jour l'enregistrement ; sans identifiant, il est créé.
+        Importez ou mettez à jour des données en masse à partir d'un fichier Excel au même format que l'export (un onglet par table).
+        L'onglet « Applications » est traité en premier, puis les onglets pris en charge (« Hébergements », « Acteurs », « Conformités ») ;
+        les autres sont ignorés. Une ligne avec un identifiant met à jour l'enregistrement ; sans identifiant, il est créé.
       </p>
       <div class="import-actor-container">
         <div class="fr-upload-group">

--- a/qa/protocoles/administration-referentiels.md
+++ b/qa/protocoles/administration-referentiels.md
@@ -8,7 +8,7 @@
 | Légende           |                                                                              |
 | :---------------- | :--------------------------------------------------------------------------- |
 | **Automatisé** ✅ | tests Playwright dédiés dans `e2e/tests/administration-referentiels.spec.ts` |
-| **Statut**        | 🟢 automatisé — 12 cas couverts par la CI                                    |
+| **Statut**        | 🟢 automatisé — 15 cas couverts par la CI                                    |
 
 ---
 
@@ -107,3 +107,30 @@
   fichier « Conformités » modifiant l'impact métier.
 - **Résultat attendu** : le rapport indique « 1 mis à jour » et « 0 en erreur » ; la conformité
   existante (même application) reflète la nouvelle valeur.
+
+### ADM-13 — Importer une application via un fichier Excel (mise à jour) ✅
+
+- **Datafeature** : une application jetable créée en base ; le classeur reprend son « Identifiant »
+  (onglet « Applications ») avec un libellé modifié.
+- **Action** : administration → onglet Batch de données → section « Import Excel » → importer le
+  fichier contenant l'identifiant de l'application.
+- **Résultat attendu** : le rapport indique « 1 mis à jour » et « 0 en erreur » ; le nouveau libellé
+  est appliqué à l'application existante en base.
+
+### ADM-14 — Importer une application via un fichier Excel (création) ✅
+
+- **Datafeature** : aucune (l'application est créée par l'import) ; le classeur contient une ligne
+  « Applications » sans identifiant (libellé + description).
+- **Action** : administration → onglet Batch de données → section « Import Excel » → importer le
+  fichier.
+- **Résultat attendu** : le rapport indique « 1 créé(s) » et « 0 en erreur » ; une application au
+  libellé fourni existe désormais en base (nettoyée en fin de test).
+
+### ADM-15 — Importer un hébergement via un fichier Excel (création) ✅
+
+- **Datafeature** : une application jetable créée en base ; le classeur contient une ligne
+  « Hébergements » rattachée à son « ID Application » (fournisseur/site/plateforme).
+- **Action** : administration → onglet Batch de données → section « Import Excel » → importer le
+  fichier.
+- **Résultat attendu** : le rapport indique « 1 créé(s) » et « 0 en erreur » ; l'application possède
+  désormais un hébergement (l'option d'hébergement est résolue ou créée comme via l'API).


### PR DESCRIPTION
Closes #752 (phase 3 — Applications & Hébergements). Suite de la phase 1 (Acteurs, #1876) et de la phase 2 (Conformités, #1881, déjà mergée dans `main`).

## Ce que ça ajoute

L'import générique `POST /import/excel` prend désormais en charge les onglets **Applications** et **Hébergements**, en plus d'Acteurs et Conformités.

### Backend (`src/import/processors/`)
- **`ApplicationsSheetProcessor`** — l'onglet « Applications » est **toujours traité en premier**. Une ligne avec un « Identifiant » met à jour l'application ; sinon elle est créée (statut par défaut `under_construction`). Mêmes contrôles et métadonnées que l'API ; le `Requestor` de l'utilisateur courant est reconstitué (permissions) pour autoriser la mise à jour. Résolution des listes (tags/finalités/populations) et de la priorité de redémarrage (par code ou libellé d'export).
- **`HostingsSheetProcessor`** — création/mise à jour d'hébergements. L'option d'hébergement (fournisseur/site/plateforme/bâtiment/salle) est résolue par correspondance, ou créée si absente, comme via l'API.
- **Orchestrateur** : ordre de traitement `Applications → Hébergements → Acteurs → Conformités`.
- **Prérequis export** : ajout de la colonne **PK « ID Hébergement »** à l'onglet Hébergements (nécessaire pour cibler une mise à jour à l'import).

### Frontend / API
- UI admin « Import Excel » et description Swagger de l'endpoint mises à jour pour mentionner tous les onglets pris en charge (aucun nouvel endpoint).

## Tests
- **Unitaires** : specs des deux nouveaux processeurs + spec orchestrateur mis à jour — **37 tests verts** (`src/import`).
- **e2e non-régression** (protocole `qa/protocoles/administration-referentiels.md`) : **ADM-13** (application — mise à jour), **ADM-14** (application — création), **ADM-15** (hébergement — création).

## Vérifications locales
`nest build` ✅ · 37 tests unitaires d'import ✅ · `vue-tsc` (frontend) ✅ · eslint ✅ · prettier ✅