### PR TITLE
feat: import Excel — droits par application et refus consignés (#1890)

### DIFF
--- a/backend/src/import/PERMISSIONS.md
+++ b/backend/src/import/PERMISSIONS.md
@@ -1,0 +1,51 @@
+# Import Excel — droits et permissions (US #1890)
+
+L'endpoint `POST /import/excel` est réservé aux administrateurs (permission **globale**
+`AdminPanelManage`). Mais cela ne suffit pas : RefApp distingue deux familles de permissions et les
+opérations d'écriture sur les données métier sont des **permissions applicatives**, calculées **par
+application** (la portée / _scope_ de l'utilisateur est prise en compte). Voir
+`src/permissions/role-to-permissions.ts` (`roleToPermissions` vs `roleToAppPermissions`) et
+`src/common/service/check-permissions.service.ts`.
+
+## Politique
+
+L'import applique, **ligne par ligne**, exactement les **mêmes permissions et la même portée** que
+l'API correspondante (via `CheckPermissions.can(permission, requestor, applicationId)`). Conséquences :
+
+- un **administrateur global** (rôle `ADMIN` sans `scopeOrganization`) peut tout importer ;
+- un **administrateur scopé** (rôle `ADMIN` avec une `scopeOrganization`) ne peut créer/modifier que
+  les données des applications **de son périmètre** ; les lignes hors périmètre sont **refusées** ;
+- toute ligne refusée est **consignée dans le rapport d'exécution** avec un motif explicite
+  (`Droits insuffisants : permission « … » requise [sur l'application …].`) et le traitement
+  **continue** avec les lignes suivantes.
+
+## Matrice « qui a le droit de faire quoi »
+
+| Onglet           | Opération              | Permission requise  | Type        | Portée                                  |
+| :--------------- | :--------------------- | :------------------ | :---------- | :-------------------------------------- |
+| **Applications** | création (sans id)     | `CreateApplication` | globale     | —                                       |
+| **Applications** | mise à jour (id)       | `AppWrite`          | applicative | sur l'application ciblée (scope inclus) |
+| **Hébergements** | création / mise à jour | `HostingWrite`      | applicative | sur l'application de rattachement       |
+| **Acteurs**      | création / mise à jour | `ActorWrite`        | applicative | sur l'application de rattachement       |
+| **Conformités**  | création / mise à jour | `ComplianceWrite`   | applicative | sur l'application de rattachement       |
+
+> Note `priorityRestart` (Applications) : la protection fine du champ priorité de redémarrage
+> (`AppWritePriority`) reste assurée par `ApplicationService.update`. Le contrôle `AppWrite` effectué
+> en amont par le processeur renseigne `requestor.appPerms` pour l'application ciblée, ce dont
+> dépend cette protection.
+
+## Où c'est implémenté
+
+- Contrôle par ligne : dans chaque processeur `src/import/processors/*-sheet.processor.ts`
+  (`checkPermissions.can([...], requestor, applicationId)` avant l'appel au service métier).
+- Message de refus : `insufficientRightsMessage()` dans `src/import/utils/excel.utils.ts`.
+- Le `Requestor` complet (permissions de rôle + `additionalPermissions` + portée) circule depuis le
+  contrôleur (`@User()`) jusqu'aux processeurs.
+
+## Tests
+
+- **Unitaires** : pour chaque processeur, un cas « refus de droits » vérifie qu'une ligne est
+  consignée en erreur avec le motif attendu et que le service métier n'est **pas** appelé
+  (`*-sheet.processor.spec.ts`).
+- **e2e (non-régression)** : un administrateur scopé importe une donnée hors de son périmètre et
+  obtient un rapport « en erreur » avec le motif « Droits insuffisants » (cf. protocole QA).

--- a/backend/src/import/excel-import.service.spec.ts
+++ b/backend/src/import/excel-import.service.spec.ts
@@ -11,6 +11,9 @@ import type { ApplicationsSheetProcessor } from "./processors/applications-sheet
 import type { CompliancesSheetProcessor } from "./processors/compliances-sheet.processor";
 import type { HostingsSheetProcessor } from "./processors/hostings-sheet.processor";
 import { ExcelImportService } from "./excel-import.service";
+import type { Requestor } from "src/user/entities/user.entity";
+
+const requestor = { id: "user-1" } as unknown as Requestor;
 
 async function workbookBuffer(sheetNames: string[]): Promise<Buffer> {
   const wb = new ExcelJS.Workbook();
@@ -51,7 +54,7 @@ describe("ExcelImportService", () => {
       "Feuille inconnue",
     ]);
 
-    const report = await service.importFromExcel(buffer, "user-1");
+    const report = await service.importFromExcel(buffer, requestor);
 
     expect(actorsProcessor.process).toHaveBeenCalledTimes(1);
     expect(compliancesProcessor.process).toHaveBeenCalledTimes(1);
@@ -63,7 +66,7 @@ describe("ExcelImportService", () => {
     const { service, actorsProcessor, compliancesProcessor } = setup();
     const buffer = await workbookBuffer(["Autre"]);
 
-    const report = await service.importFromExcel(buffer, "user-1");
+    const report = await service.importFromExcel(buffer, requestor);
 
     expect(actorsProcessor.process).not.toHaveBeenCalled();
     expect(compliancesProcessor.process).not.toHaveBeenCalled();
@@ -79,7 +82,7 @@ describe("ExcelImportService", () => {
   it("rejette un fichier non Excel", async () => {
     const { service } = setup();
     await expect(
-      service.importFromExcel(Buffer.from("pas un xlsx"), "user-1"),
+      service.importFromExcel(Buffer.from("pas un xlsx"), requestor),
     ).rejects.toThrow(/Excel/i);
   });
 });

--- a/backend/src/import/excel-import.service.ts
+++ b/backend/src/import/excel-import.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import * as ExcelJS from "exceljs";
+import { Requestor } from "src/user/entities/user.entity";
 import { createEmptyReport, ImportReportDto } from "./dto/import-report.dto";
 import { ActorsSheetProcessor } from "./processors/actors-sheet.processor";
 import { ApplicationsSheetProcessor } from "./processors/applications-sheet.processor";
@@ -17,7 +18,7 @@ export class ExcelImportService {
 
   async importFromExcel(
     buffer: Buffer,
-    requestorId: string,
+    requestor: Requestor,
   ): Promise<ImportReportDto> {
     const workbook = new ExcelJS.Workbook();
     try {
@@ -49,7 +50,7 @@ export class ExcelImportService {
         report.logs.push(`Onglet « ${processor.sheetName} » absent : ignoré.`);
         continue;
       }
-      await processor.process(worksheet, requestorId, report);
+      await processor.process(worksheet, requestor, report);
     }
 
     // Onglets non reconnus présents dans le fichier : ignorés.

--- a/backend/src/import/import.controller.spec.ts
+++ b/backend/src/import/import.controller.spec.ts
@@ -5,9 +5,12 @@ jest.mock("src/metadatas/metadatas.service", () => ({
 }));
 
 import { BadRequestException } from "@nestjs/common";
+import type { Requestor } from "src/user/entities/user.entity";
 import type { ExcelImportService } from "./excel-import.service";
 import { ImportController } from "./import.controller";
 import { createEmptyReport, ImportReportDto } from "./dto/import-report.dto";
+
+const requestor = { id: "user-1" } as unknown as Requestor;
 
 const REPORT: ImportReportDto = {
   ...createEmptyReport(),
@@ -39,7 +42,7 @@ const xlsxFile = {
 describe("ImportController.importExcel", () => {
   it("rejette quand aucun fichier n'est fourni", async () => {
     const { controller } = setup();
-    await expect(controller.importExcel(undefined, "user-1")).rejects.toThrow(
+    await expect(controller.importExcel(undefined, requestor)).rejects.toThrow(
       BadRequestException,
     );
   });
@@ -53,17 +56,17 @@ describe("ImportController.importExcel", () => {
           originalname: "x.txt",
           mimetype: "text/plain",
         },
-        "user-1",
+        requestor,
       ),
     ).rejects.toThrow(BadRequestException);
   });
 
   it("traite un .xlsx et renvoie le rapport", async () => {
     const { controller, importService } = setup();
-    const result = await controller.importExcel(xlsxFile, "user-1");
+    const result = await controller.importExcel(xlsxFile, requestor);
     expect(importService.importFromExcel).toHaveBeenCalledWith(
       xlsxFile.buffer,
-      "user-1",
+      requestor,
     );
     expect(result.summary.created).toBe(1);
   });
@@ -72,7 +75,7 @@ describe("ImportController.importExcel", () => {
     const { controller } = setup(
       jest.fn().mockRejectedValue(new Error("fichier illisible")),
     );
-    await expect(controller.importExcel(xlsxFile, "user-1")).rejects.toThrow(
+    await expect(controller.importExcel(xlsxFile, requestor)).rejects.toThrow(
       /fichier illisible/,
     );
   });

--- a/backend/src/import/import.controller.ts
+++ b/backend/src/import/import.controller.ts
@@ -18,7 +18,8 @@ import {
 import { Permission } from "@prisma/client";
 import { RequiredPermissions } from "src/common/decorators/required-permissions.decorator";
 import { PermissionGuard } from "src/common/guards/permission.guard";
-import { UserId } from "src/common/decorators/user-id.decorator";
+import { User } from "src/common/decorators/user.decorator";
+import { Requestor } from "src/user/entities/user.entity";
 import { ImportReportDto } from "./dto/import-report.dto";
 import { ExcelImportService } from "./excel-import.service";
 
@@ -59,7 +60,7 @@ d'exécution est retourné.`,
     file:
       | { buffer: Buffer; originalname: string; mimetype: string }
       | undefined,
-    @UserId() userId: string,
+    @User() requestor: Requestor,
   ): Promise<ImportReportDto> {
     if (!file) {
       throw new BadRequestException("Aucun fichier fourni.");
@@ -75,11 +76,14 @@ d'exécution est retourné.`,
     }
     Logger.log({
       message: "Début de l'import Excel",
-      userId,
+      userId: requestor.id,
       action: "import",
     });
     try {
-      return await this.excelImportService.importFromExcel(file.buffer, userId);
+      return await this.excelImportService.importFromExcel(
+        file.buffer,
+        requestor,
+      );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new BadRequestException(message);

--- a/backend/src/import/import.module.ts
+++ b/backend/src/import/import.module.ts
@@ -5,7 +5,6 @@ import { CommonModule } from "src/common/common.module";
 import { CompliancesModule } from "src/compliances/compliances.module";
 import { HostingsModule } from "src/hostings/hostings.module";
 import { PrismaModule } from "src/prisma/prisma.module";
-import { UserModule } from "src/user/user.module";
 import { ExcelImportService } from "./excel-import.service";
 import { ImportController } from "./import.controller";
 import { ActorsSheetProcessor } from "./processors/actors-sheet.processor";
@@ -19,7 +18,6 @@ import { HostingsSheetProcessor } from "./processors/hostings-sheet.processor";
     ActorModule,
     ApplicationModule,
     HostingsModule,
-    UserModule,
     CommonModule,
     CompliancesModule,
   ],

--- a/backend/src/import/processors/actors-sheet.processor.spec.ts
+++ b/backend/src/import/processors/actors-sheet.processor.spec.ts
@@ -8,9 +8,13 @@ import * as ExcelJS from "exceljs";
 import { columnLabels } from "src/applications/columnLabels/application-export.columnLabels";
 import { sheetLabels } from "src/applications/constants/application-export.sheet-labels";
 import type { ActorService } from "src/actor/actor.service";
+import type { CheckPermissions } from "src/common/service/check-permissions.service";
 import type { PrismaService } from "src/prisma/prisma.service";
+import type { Requestor } from "src/user/entities/user.entity";
 import { createEmptyReport } from "../dto/import-report.dto";
 import { ActorsSheetProcessor } from "./actors-sheet.processor";
+
+const requestor = { id: "user-1" } as unknown as Requestor;
 
 interface Row {
   id?: string;
@@ -65,11 +69,13 @@ function setup() {
     create: jest.fn().mockResolvedValue({ id: "new-actor" }),
     update: jest.fn().mockResolvedValue({ id: "actor-1" }),
   };
+  const checkPermissions = { can: jest.fn().mockResolvedValue(true) };
   const processor = new ActorsSheetProcessor(
     prisma as unknown as PrismaService,
     actorService as unknown as ActorService,
+    checkPermissions as unknown as CheckPermissions,
   );
-  return { processor, prisma, actorService };
+  return { processor, prisma, actorService, checkPermissions };
 }
 
 describe("ActorsSheetProcessor", () => {
@@ -85,7 +91,7 @@ describe("ActorsSheetProcessor", () => {
           email: "a@b.com",
         },
       ]),
-      "user-1",
+      requestor,
       report,
     );
     expect(report.summary.created).toBe(1);
@@ -99,7 +105,7 @@ describe("ActorsSheetProcessor", () => {
     const report = createEmptyReport();
     await processor.process(
       buildSheet([{ id: "actor-1", applicationId: "app-1", role: "MOA" }]),
-      "user-1",
+      requestor,
       report,
     );
     expect(report.summary.updated).toBe(1);
@@ -112,7 +118,7 @@ describe("ActorsSheetProcessor", () => {
     const report = createEmptyReport();
     await processor.process(
       buildSheet([{ id: "missing", applicationId: "app-1", role: "MOA" }]),
-      "user-1",
+      requestor,
       report,
     );
     expect(report.summary.errors).toBe(1);
@@ -125,7 +131,7 @@ describe("ActorsSheetProcessor", () => {
     const report = createEmptyReport();
     await processor.process(
       buildSheet([{ applicationId: "ghost", role: "MOA", email: "a@b.com" }]),
-      "user-1",
+      requestor,
       report,
     );
     expect(report.summary.errors).toBe(1);
@@ -138,7 +144,7 @@ describe("ActorsSheetProcessor", () => {
     const report = createEmptyReport();
     await processor.process(
       buildSheet([{ applicationId: "app-1", role: "X", email: "a@b.com" }]),
-      "user-1",
+      requestor,
       report,
     );
     expect(report.summary.errors).toBe(1);
@@ -153,7 +159,7 @@ describe("ActorsSheetProcessor", () => {
       buildSheet([
         { applicationId: "app-1", type: "Libellé", email: "a@b.com" },
       ]),
-      "user-1",
+      requestor,
       report,
     );
     expect(report.summary.created).toBe(1);
@@ -169,7 +175,7 @@ describe("ActorsSheetProcessor", () => {
     const report = createEmptyReport();
     await processor.process(
       buildSheet([{ applicationId: "app-1", role: "MOA", email: "bad" }]),
-      "user-1",
+      requestor,
       report,
     );
     expect(report.summary.errors).toBe(1);
@@ -188,7 +194,7 @@ describe("ActorsSheetProcessor", () => {
         {},
         { applicationId: "app-1", role: "X", email: "ko@b.com" },
       ]),
-      "user-1",
+      requestor,
       report,
     );
     expect(report.summary.created).toBe(1);
@@ -204,7 +210,7 @@ describe("ActorsSheetProcessor", () => {
         [{ applicationId: "app-1", role: "MOA" }],
         [columnLabels.applicationId, columnLabels["actors.role"]],
       ),
-      "user-1",
+      requestor,
       report,
     );
     expect(report.summary.processedSheets).not.toContain(sheetLabels.Actors);
@@ -227,7 +233,7 @@ describe("ActorsSheetProcessor", () => {
     };
     const report = createEmptyReport();
 
-    await processor.process(sheet, "user-1", report);
+    await processor.process(sheet, requestor, report);
 
     expect(report.summary.created).toBe(1);
     expect(actorService.create).toHaveBeenCalledWith(
@@ -238,5 +244,21 @@ describe("ActorsSheetProcessor", () => {
       "app-1",
       "user-1",
     );
+  });
+
+  it("refuse la ligne et consigne le motif sans droits ActorWrite sur l'application", async () => {
+    const { processor, checkPermissions, actorService } = setup();
+    checkPermissions.can.mockResolvedValue(false);
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet([{ applicationId: "app-1", role: "MOA", email: "a@b.com" }]),
+      requestor,
+      report,
+    );
+    expect(report.summary.errors).toBe(1);
+    expect(report.entries[0].message).toMatch(
+      /Droits insuffisants.*ActorWrite/i,
+    );
+    expect(actorService.create).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/import/processors/actors-sheet.processor.ts
+++ b/backend/src/import/processors/actors-sheet.processor.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from "@nestjs/common";
+import { Permission } from "@prisma/client";
 import { plainToInstance } from "class-transformer";
 import { validate } from "class-validator";
 import * as ExcelJS from "exceljs";
@@ -6,12 +7,18 @@ import { ActorService } from "src/actor/actor.service";
 import { CreateActorDto, UpdateActorDto } from "src/actor/dto/actor.dto";
 import { columnLabels } from "src/applications/columnLabels/application-export.columnLabels";
 import { sheetLabels } from "src/applications/constants/application-export.sheet-labels";
+import { CheckPermissions } from "src/common/service/check-permissions.service";
 import { PrismaService } from "src/prisma/prisma.service";
+import { Requestor } from "src/user/entities/user.entity";
 import {
   ImportReportDto,
   ImportReportEntryDto,
 } from "../dto/import-report.dto";
-import { buildHeaderIndex, makeCellReader } from "../utils/excel.utils";
+import {
+  buildHeaderIndex,
+  insufficientRightsMessage,
+  makeCellReader,
+} from "../utils/excel.utils";
 
 /** En-têtes (libellés) attendus dans l'onglet « Acteurs », alignés sur l'export. */
 const HEADERS = {
@@ -35,11 +42,12 @@ export class ActorsSheetProcessor {
   constructor(
     private readonly prisma: PrismaService,
     private readonly actorService: ActorService,
+    private readonly checkPermissions: CheckPermissions,
   ) {}
 
   async process(
     worksheet: ExcelJS.Worksheet,
-    requestorId: string,
+    requestor: Requestor,
     report: ImportReportDto,
   ): Promise<void> {
     const headerIndex = buildHeaderIndex(worksheet);
@@ -69,7 +77,7 @@ export class ActorsSheetProcessor {
       if (Object.values(data).every((v) => v === "")) continue;
 
       try {
-        const entry = await this.processRow(rowNumber, data, requestorId);
+        const entry = await this.processRow(rowNumber, data, requestor);
         report.entries.push(entry);
         if (entry.status === "created") report.summary.created++;
         else if (entry.status === "updated") report.summary.updated++;
@@ -101,7 +109,7 @@ export class ActorsSheetProcessor {
       type: string;
       email: string;
     },
-    requestorId: string,
+    requestor: Requestor,
   ): Promise<ImportReportEntryDto> {
     if (!data.applicationId) {
       throw new Error("Colonne « ID Application » vide.");
@@ -113,6 +121,18 @@ export class ActorsSheetProcessor {
     });
     if (!application) {
       throw new Error(`Application introuvable (id=${data.applicationId}).`);
+    }
+
+    // Droits applicatifs (portée incluse) sur CETTE application, comme l'API acteurs.
+    const allowed = await this.checkPermissions.can(
+      [Permission.ActorWrite],
+      requestor,
+      data.applicationId,
+    );
+    if (!allowed) {
+      throw new Error(
+        insufficientRightsMessage("ActorWrite", data.applicationId),
+      );
     }
 
     const actorTypeId = await this.resolveActorTypeId(data.role, data.type);
@@ -148,7 +168,7 @@ export class ActorsSheetProcessor {
         data.id,
         dto,
         data.applicationId,
-        requestorId,
+        requestor.id,
       );
 
       return { sheet: this.sheetName, row, status: "updated", identifier };
@@ -159,7 +179,7 @@ export class ActorsSheetProcessor {
       isGroup: false,
     });
     await this.validateDto(dto);
-    await this.actorService.create(dto, data.applicationId, requestorId);
+    await this.actorService.create(dto, data.applicationId, requestor.id);
 
     return { sheet: this.sheetName, row, status: "created", identifier };
   }

--- a/backend/src/import/processors/applications-sheet.processor.spec.ts
+++ b/backend/src/import/processors/applications-sheet.processor.spec.ts
@@ -7,10 +7,13 @@ jest.mock("src/metadatas/metadatas.service", () => ({
 import * as ExcelJS from "exceljs";
 import type { ApplicationService } from "src/applications/application.service";
 import { sheetLabels } from "src/applications/constants/application-export.sheet-labels";
+import type { CheckPermissions } from "src/common/service/check-permissions.service";
 import type { PrismaService } from "src/prisma/prisma.service";
-import type { UserService } from "src/user/user.service";
+import type { Requestor } from "src/user/entities/user.entity";
 import { createEmptyReport } from "../dto/import-report.dto";
 import { ApplicationsSheetProcessor } from "./applications-sheet.processor";
+
+const requestor = { id: "user-1" } as unknown as Requestor;
 
 function buildSheet(
   headers: string[],
@@ -35,17 +38,13 @@ function setup() {
     createApplication: jest.fn().mockResolvedValue({ id: "new-app" }),
     update: jest.fn().mockResolvedValue({ id: "app-1" }),
   };
-  const userService = {
-    findByIdWithRelations: jest
-      .fn()
-      .mockResolvedValue({ id: "user-1", role: "ADMIN" }),
-  };
+  const checkPermissions = { can: jest.fn().mockResolvedValue(true) };
   const processor = new ApplicationsSheetProcessor(
     prisma as unknown as PrismaService,
     applicationService as unknown as ApplicationService,
-    userService as unknown as UserService,
+    checkPermissions as unknown as CheckPermissions,
   );
-  return { processor, prisma, applicationService, userService };
+  return { processor, prisma, applicationService, checkPermissions };
 }
 
 describe("ApplicationsSheetProcessor", () => {
@@ -57,7 +56,7 @@ describe("ApplicationsSheetProcessor", () => {
         ["Identifiant", "Libellé", "Description"],
         [["", "Nouvelle App", "Une description"]],
       ),
-      "user-1",
+      requestor,
       report,
     );
 
@@ -78,7 +77,7 @@ describe("ApplicationsSheetProcessor", () => {
         ["Identifiant", "Libellé", "Description"],
         [["app-1", "App MAJ", "Desc"]],
       ),
-      "user-1",
+      requestor,
       report,
     );
 
@@ -102,7 +101,7 @@ describe("ApplicationsSheetProcessor", () => {
         ],
         [["", "App listes", "Desc", "a, b, c", "R0 - Immédiat (H24)"]],
       ),
-      "user-1",
+      requestor,
       report,
     );
 
@@ -124,7 +123,7 @@ describe("ApplicationsSheetProcessor", () => {
         ["Identifiant", "Libellé", "Description"],
         [["ghost", "Fantôme", "Desc"]],
       ),
-      "user-1",
+      requestor,
       report,
     );
 
@@ -140,7 +139,7 @@ describe("ApplicationsSheetProcessor", () => {
         ["Identifiant", "Libellé", "Description"],
         [["", "X", "Desc"]],
       ),
-      "user-1",
+      requestor,
       report,
     );
 
@@ -154,7 +153,7 @@ describe("ApplicationsSheetProcessor", () => {
     const report = createEmptyReport();
     await processor.process(
       buildSheet(["Libellé", "Description"], [["App", "Desc"]]),
-      "user-1",
+      requestor,
       report,
     );
 
@@ -164,22 +163,41 @@ describe("ApplicationsSheetProcessor", () => {
     expect(report.logs.join(" ")).toMatch(/colonnes manquantes/i);
   });
 
-  it("ne traite pas l'onglet si l'utilisateur courant est introuvable", async () => {
-    const { processor, userService } = setup();
-    userService.findByIdWithRelations.mockResolvedValue(null);
+  it("refuse la création sans la permission globale CreateApplication", async () => {
+    const { processor, checkPermissions, applicationService } = setup();
+    checkPermissions.can.mockResolvedValue(false);
     const report = createEmptyReport();
     await processor.process(
       buildSheet(
         ["Identifiant", "Libellé", "Description"],
-        [["", "App", "Desc"]],
+        [["", "Nouvelle App", "Desc"]],
       ),
-      "user-1",
+      requestor,
       report,
     );
 
-    expect(report.summary.processedSheets).not.toContain(
-      sheetLabels.Applications,
+    expect(report.summary.errors).toBe(1);
+    expect(report.entries[0].message).toMatch(
+      /Droits insuffisants.*CreateApplication/i,
     );
-    expect(report.logs.join(" ")).toMatch(/utilisateur courant introuvable/i);
+    expect(applicationService.createApplication).not.toHaveBeenCalled();
+  });
+
+  it("refuse la mise à jour sans droits AppWrite sur l'application", async () => {
+    const { processor, checkPermissions, applicationService } = setup();
+    checkPermissions.can.mockResolvedValue(false);
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet(
+        ["Identifiant", "Libellé", "Description"],
+        [["app-1", "App MAJ", "Desc"]],
+      ),
+      requestor,
+      report,
+    );
+
+    expect(report.summary.errors).toBe(1);
+    expect(report.entries[0].message).toMatch(/Droits insuffisants.*AppWrite/i);
+    expect(applicationService.update).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/import/processors/applications-sheet.processor.ts
+++ b/backend/src/import/processors/applications-sheet.processor.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from "@nestjs/common";
-import { Status, priorityRestart } from "@prisma/client";
+import { Permission, Status, priorityRestart } from "@prisma/client";
 import { plainToInstance } from "class-transformer";
 import { validate } from "class-validator";
 import * as ExcelJS from "exceljs";
@@ -11,15 +11,18 @@ import {
   CreateApplicationDto,
   PatchApplicationDto,
 } from "src/applications/dto/create-application.dto";
-import { roleToPermissions } from "src/permissions/role-to-permissions";
+import { CheckPermissions } from "src/common/service/check-permissions.service";
 import { PrismaService } from "src/prisma/prisma.service";
 import { Requestor } from "src/user/entities/user.entity";
-import { UserService } from "src/user/user.service";
 import {
   ImportReportDto,
   ImportReportEntryDto,
 } from "../dto/import-report.dto";
-import { buildHeaderIndex, makeCellReader } from "../utils/excel.utils";
+import {
+  buildHeaderIndex,
+  insufficientRightsMessage,
+  makeCellReader,
+} from "../utils/excel.utils";
 
 /** En-têtes (libellés) attendus dans l'onglet « Applications », alignés sur l'export. */
 const HEADERS = {
@@ -72,28 +75,18 @@ export class ApplicationsSheetProcessor {
   constructor(
     private readonly prisma: PrismaService,
     private readonly applicationService: ApplicationService,
-    private readonly userService: UserService,
+    private readonly checkPermissions: CheckPermissions,
   ) {}
 
   async process(
     worksheet: ExcelJS.Worksheet,
-    requestorId: string,
+    requestor: Requestor,
     report: ImportReportDto,
   ): Promise<void> {
     const headerIndex = buildHeaderIndex(worksheet);
     const missing = REQUIRED_HEADERS.filter((h) => !(h in headerIndex));
     if (missing.length > 0) {
       const message = `Onglet « ${this.sheetName} » non traité : colonnes manquantes (${missing.join(", ")}).`;
-      report.logs.push(message);
-      this.logger.warn(message);
-      return;
-    }
-
-    // La mise à jour d'application requiert le `Requestor` complet (permissions) ; on le résout
-    // une fois pour tout l'onglet à partir de l'utilisateur courant.
-    const requestor = await this.resolveRequestor(requestorId);
-    if (!requestor) {
-      const message = `Onglet « ${this.sheetName} » non traité : utilisateur courant introuvable.`;
       report.logs.push(message);
       this.logger.warn(message);
       return;
@@ -179,6 +172,18 @@ export class ApplicationsSheetProcessor {
         throw new Error(`Application introuvable (id=${data.id}).`);
       }
 
+      // Droits applicatifs (portée incluse) sur CETTE application, comme l'API `PATCH`.
+      // L'appel renseigne aussi `requestor.appPerms`, que `update` réutilise pour la protection
+      // des champs (ex. priorité de redémarrage).
+      const allowed = await this.checkPermissions.can(
+        [Permission.AppWrite],
+        requestor,
+        data.id,
+      );
+      if (!allowed) {
+        throw new Error(insufficientRightsMessage("AppWrite", data.id));
+      }
+
       const dto = plainToInstance(PatchApplicationDto, baseFields);
       await this.validateDto(dto);
       await this.applicationService.update({
@@ -187,6 +192,15 @@ export class ApplicationsSheetProcessor {
         requestor,
       });
       return { sheet: this.sheetName, row, status: "updated", identifier };
+    }
+
+    // Création : permission globale `CreateApplication`, comme l'API `POST /applications`.
+    const allowed = await this.checkPermissions.can(
+      [Permission.CreateApplication],
+      requestor,
+    );
+    if (!allowed) {
+      throw new Error(insufficientRightsMessage("CreateApplication"));
     }
 
     const dto = plainToInstance(CreateApplicationDto, {
@@ -199,15 +213,6 @@ export class ApplicationsSheetProcessor {
     await this.validateDto(dto);
     await this.applicationService.createApplication(requestor.id, dto);
     return { sheet: this.sheetName, row, status: "created", identifier };
-  }
-
-  /** Reconstitue le `Requestor` (avec permissions) de l'utilisateur courant. */
-  private async resolveRequestor(
-    requestorId: string,
-  ): Promise<Requestor | null> {
-    const user = await this.userService.findByIdWithRelations(requestorId);
-    if (!user) return null;
-    return { ...user, permissions: roleToPermissions(user.role) };
   }
 
   /** Résout la priorité de redémarrage par code (« R0 ») puis par libellé d'export. */

--- a/backend/src/import/processors/compliances-sheet.processor.spec.ts
+++ b/backend/src/import/processors/compliances-sheet.processor.spec.ts
@@ -6,10 +6,14 @@ jest.mock("src/metadatas/metadatas.service", () => ({
 
 import * as ExcelJS from "exceljs";
 import { sheetLabels } from "src/applications/constants/application-export.sheet-labels";
+import type { CheckPermissions } from "src/common/service/check-permissions.service";
 import type { CompliancesService } from "src/compliances/compliances.service";
 import type { PrismaService } from "src/prisma/prisma.service";
+import type { Requestor } from "src/user/entities/user.entity";
 import { createEmptyReport } from "../dto/import-report.dto";
 import { CompliancesSheetProcessor } from "./compliances-sheet.processor";
+
+const requestor = { id: "user-1" } as unknown as Requestor;
 
 function buildSheet(
   headers: string[],
@@ -30,11 +34,13 @@ function setup() {
     findByApplicationId: jest.fn().mockResolvedValue(null),
     createOrUpdateByApplicationId: jest.fn().mockResolvedValue({ id: "c-1" }),
   };
+  const checkPermissions = { can: jest.fn().mockResolvedValue(true) };
   const processor = new CompliancesSheetProcessor(
     prisma as unknown as PrismaService,
     compliancesService as unknown as CompliancesService,
+    checkPermissions as unknown as CheckPermissions,
   );
-  return { processor, prisma, compliancesService };
+  return { processor, prisma, compliancesService, checkPermissions };
 }
 
 describe("CompliancesSheetProcessor", () => {
@@ -51,7 +57,7 @@ describe("CompliancesSheetProcessor", () => {
         ],
         [["app-1", 5, "Oui", "Non"]],
       ),
-      "user-1",
+      requestor,
       report,
     );
 
@@ -76,7 +82,7 @@ describe("CompliancesSheetProcessor", () => {
     const report = createEmptyReport();
     await processor.process(
       buildSheet(["ID Application", "DIMA Impact métier"], [["app-1", "X"]]),
-      "user-1",
+      requestor,
       report,
     );
     expect(report.summary.updated).toBe(1);
@@ -89,7 +95,7 @@ describe("CompliancesSheetProcessor", () => {
     const report = createEmptyReport();
     await processor.process(
       buildSheet(["ID Application", "DIMA Impact métier"], [["ghost", "X"]]),
-      "user-1",
+      requestor,
       report,
     );
     expect(report.summary.errors).toBe(1);
@@ -104,7 +110,7 @@ describe("CompliancesSheetProcessor", () => {
         ["ID Application", "DIMA Résultat test"],
         [["app-1", "PEUT_ETRE"]],
       ),
-      "user-1",
+      requestor,
       report,
     );
     expect(report.summary.errors).toBe(1);
@@ -119,7 +125,7 @@ describe("CompliancesSheetProcessor", () => {
     const report = createEmptyReport();
     await processor.process(
       buildSheet(["ID Application", "DIMA Impact métier"], [["", "X"]]),
-      "user-1",
+      requestor,
       report,
     );
     expect(report.summary.errors).toBe(1);
@@ -137,7 +143,7 @@ describe("CompliancesSheetProcessor", () => {
           ["app-1", "X"],
         ],
       ),
-      "user-1",
+      requestor,
       report,
     );
     expect(report.entries).toHaveLength(1);
@@ -149,12 +155,30 @@ describe("CompliancesSheetProcessor", () => {
     const report = createEmptyReport();
     await processor.process(
       buildSheet(["DIMA Impact métier"], [["X"]]),
-      "user-1",
+      requestor,
       report,
     );
     expect(report.summary.processedSheets).not.toContain(
       sheetLabels.Compliances,
     );
     expect(report.logs.join(" ")).toMatch(/colonnes manquantes/i);
+  });
+
+  it("refuse la ligne et consigne le motif sans droits ComplianceWrite sur l'application", async () => {
+    const { processor, checkPermissions, compliancesService } = setup();
+    checkPermissions.can.mockResolvedValue(false);
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet(["ID Application", "DIMA Impact métier"], [["app-1", "X"]]),
+      requestor,
+      report,
+    );
+    expect(report.summary.errors).toBe(1);
+    expect(report.entries[0].message).toMatch(
+      /Droits insuffisants.*ComplianceWrite/i,
+    );
+    expect(
+      compliancesService.createOrUpdateByApplicationId,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/import/processors/compliances-sheet.processor.ts
+++ b/backend/src/import/processors/compliances-sheet.processor.ts
@@ -1,14 +1,17 @@
 import { Injectable, Logger } from "@nestjs/common";
+import { Permission } from "@prisma/client";
 import { plainToInstance } from "class-transformer";
 import { validate } from "class-validator";
 import * as ExcelJS from "exceljs";
 import { columnLabels } from "src/applications/columnLabels/application-export.columnLabels";
 import { sheetLabels } from "src/applications/constants/application-export.sheet-labels";
+import { CheckPermissions } from "src/common/service/check-permissions.service";
 import { COMPLIANCE_METADATA_FIELDS } from "src/compliances/constants/compliance-metadata.constants";
 import { CreateComplianceDto } from "src/compliances/dto/create-compliance.dto";
 import { CompliancesService } from "src/compliances/compliances.service";
 import { detectCompliances } from "src/compliances/utils/compliance.utils";
 import { PrismaService } from "src/prisma/prisma.service";
+import { Requestor } from "src/user/entities/user.entity";
 import {
   ImportReportDto,
   ImportReportEntryDto,
@@ -18,6 +21,7 @@ import {
   coerceDate,
   coerceNumber,
   coerceOuiNon,
+  insufficientRightsMessage,
   makeCellReader,
 } from "../utils/excel.utils";
 
@@ -57,11 +61,12 @@ export class CompliancesSheetProcessor {
   constructor(
     private readonly prisma: PrismaService,
     private readonly compliancesService: CompliancesService,
+    private readonly checkPermissions: CheckPermissions,
   ) {}
 
   async process(
     worksheet: ExcelJS.Worksheet,
-    requestorId: string,
+    requestor: Requestor,
     report: ImportReportDto,
   ): Promise<void> {
     const headerIndex = buildHeaderIndex(worksheet);
@@ -87,7 +92,7 @@ export class CompliancesSheetProcessor {
           rowNumber,
           applicationId,
           values,
-          requestorId,
+          requestor,
         );
         report.entries.push(entry);
         if (entry.status === "created") report.summary.created++;
@@ -134,7 +139,7 @@ export class CompliancesSheetProcessor {
     row: number,
     applicationId: string,
     values: Record<string, string | number | boolean>,
-    requestorId: string,
+    requestor: Requestor,
   ): Promise<ImportReportEntryDto> {
     if (!applicationId) {
       throw new Error("Colonne « ID Application » vide.");
@@ -146,6 +151,18 @@ export class CompliancesSheetProcessor {
     });
     if (!application) {
       throw new Error(`Application introuvable (id=${applicationId}).`);
+    }
+
+    // Droits applicatifs (portée incluse) sur CETTE application, comme l'API conformités.
+    const allowed = await this.checkPermissions.can(
+      [Permission.ComplianceWrite],
+      requestor,
+      applicationId,
+    );
+    if (!allowed) {
+      throw new Error(
+        insufficientRightsMessage("ComplianceWrite", applicationId),
+      );
     }
 
     const dto = plainToInstance(CreateComplianceDto, values);
@@ -163,7 +180,7 @@ export class CompliancesSheetProcessor {
       {
         applicationId,
         metadata: {
-          userId: requestorId,
+          userId: requestor.id,
           gender: "de la conformité",
           getColumn: () => sectionSuffix,
           entity: "complianceId",

--- a/backend/src/import/processors/hostings-sheet.processor.spec.ts
+++ b/backend/src/import/processors/hostings-sheet.processor.spec.ts
@@ -6,13 +6,16 @@ jest.mock("src/metadatas/metadatas.service", () => ({
 
 import * as ExcelJS from "exceljs";
 import { sheetLabels } from "src/applications/constants/application-export.sheet-labels";
+import type { CheckPermissions } from "src/common/service/check-permissions.service";
 import type { HostingsService } from "src/hostings/hostings.service";
 import type { PrismaService } from "src/prisma/prisma.service";
+import type { Requestor } from "src/user/entities/user.entity";
 import { createEmptyReport } from "../dto/import-report.dto";
 import { HostingsSheetProcessor } from "./hostings-sheet.processor";
 
 /** Les ID d'application sont des UUID en base (cf. schema) → requis par CreateHostingDto. */
 const APP_UUID = "11111111-1111-4111-8111-111111111111";
+const requestor = { id: "user-1" } as unknown as Requestor;
 
 function buildSheet(
   headers: string[],
@@ -46,11 +49,13 @@ function setup() {
     createHosting: jest.fn().mockResolvedValue({ id: "new-host" }),
     updateHosting: jest.fn().mockResolvedValue({ id: "host-1" }),
   };
+  const checkPermissions = { can: jest.fn().mockResolvedValue(true) };
   const processor = new HostingsSheetProcessor(
     prisma as unknown as PrismaService,
     hostingsService as unknown as HostingsService,
+    checkPermissions as unknown as CheckPermissions,
   );
-  return { processor, prisma, hostingsService };
+  return { processor, prisma, hostingsService, checkPermissions };
 }
 
 const HEADERS = [
@@ -70,7 +75,7 @@ describe("HostingsSheetProcessor", () => {
       buildSheet(HEADERS, [
         ["", APP_UUID, "Prod", "DTNUM", "RENNES", "PHYSIQUE"],
       ]),
-      "user-1",
+      requestor,
       report,
     );
 
@@ -94,7 +99,7 @@ describe("HostingsSheetProcessor", () => {
       buildSheet(HEADERS, [
         ["", APP_UUID, "Prod", "DTNUM", "RENNES", "PHYSIQUE"],
       ]),
-      "user-1",
+      requestor,
       report,
     );
 
@@ -109,7 +114,7 @@ describe("HostingsSheetProcessor", () => {
       buildSheet(HEADERS, [
         ["host-1", APP_UUID, "Prod", "DTNUM", "RENNES", "PHYSIQUE"],
       ]),
-      "user-1",
+      requestor,
       report,
     );
 
@@ -128,7 +133,7 @@ describe("HostingsSheetProcessor", () => {
       buildSheet(HEADERS, [
         ["", "ghost", "Prod", "DTNUM", "RENNES", "PHYSIQUE"],
       ]),
-      "user-1",
+      requestor,
       report,
     );
 
@@ -143,7 +148,7 @@ describe("HostingsSheetProcessor", () => {
       buildSheet(HEADERS, [
         ["ghost-host", APP_UUID, "Prod", "DTNUM", "RENNES", "PHYSIQUE"],
       ]),
-      "user-1",
+      requestor,
       report,
     );
 
@@ -159,11 +164,30 @@ describe("HostingsSheetProcessor", () => {
         ["ID Application", "Fournisseur d’hébergement"],
         [[APP_UUID, "DTNUM"]],
       ),
-      "user-1",
+      requestor,
       report,
     );
 
     expect(report.summary.processedSheets).not.toContain(sheetLabels.Hostings);
     expect(report.logs.join(" ")).toMatch(/colonnes manquantes/i);
+  });
+
+  it("refuse la ligne et consigne le motif sans droits HostingWrite sur l'application", async () => {
+    const { processor, checkPermissions, hostingsService } = setup();
+    checkPermissions.can.mockResolvedValue(false);
+    const report = createEmptyReport();
+    await processor.process(
+      buildSheet(HEADERS, [
+        ["", APP_UUID, "Prod", "DTNUM", "RENNES", "PHYSIQUE"],
+      ]),
+      requestor,
+      report,
+    );
+
+    expect(report.summary.errors).toBe(1);
+    expect(report.entries[0].message).toMatch(
+      /Droits insuffisants.*HostingWrite/i,
+    );
+    expect(hostingsService.createHosting).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/import/processors/hostings-sheet.processor.ts
+++ b/backend/src/import/processors/hostings-sheet.processor.ts
@@ -1,9 +1,11 @@
 import { Injectable, Logger } from "@nestjs/common";
+import { Permission } from "@prisma/client";
 import { plainToInstance } from "class-transformer";
 import { validate } from "class-validator";
 import * as ExcelJS from "exceljs";
 import { columnLabels } from "src/applications/columnLabels/application-export.columnLabels";
 import { sheetLabels } from "src/applications/constants/application-export.sheet-labels";
+import { CheckPermissions } from "src/common/service/check-permissions.service";
 import { CreateHostingOptionDto } from "src/hosting-option/dto/hosting-option.dto";
 import {
   CreateHostingDto,
@@ -11,11 +13,16 @@ import {
 } from "src/hostings/dto/hosting.dto";
 import { HostingsService } from "src/hostings/hostings.service";
 import { PrismaService } from "src/prisma/prisma.service";
+import { Requestor } from "src/user/entities/user.entity";
 import {
   ImportReportDto,
   ImportReportEntryDto,
 } from "../dto/import-report.dto";
-import { buildHeaderIndex, makeCellReader } from "../utils/excel.utils";
+import {
+  buildHeaderIndex,
+  insufficientRightsMessage,
+  makeCellReader,
+} from "../utils/excel.utils";
 
 /** En-têtes (libellés) attendus dans l'onglet « Hébergements », alignés sur l'export. */
 const HEADERS = {
@@ -46,11 +53,12 @@ export class HostingsSheetProcessor {
   constructor(
     private readonly prisma: PrismaService,
     private readonly hostingsService: HostingsService,
+    private readonly checkPermissions: CheckPermissions,
   ) {}
 
   async process(
     worksheet: ExcelJS.Worksheet,
-    requestorId: string,
+    requestor: Requestor,
     report: ImportReportDto,
   ): Promise<void> {
     const headerIndex = buildHeaderIndex(worksheet);
@@ -81,7 +89,7 @@ export class HostingsSheetProcessor {
       if (Object.values(data).every((v) => v === "")) continue;
 
       try {
-        const entry = await this.processRow(rowNumber, data, requestorId);
+        const entry = await this.processRow(rowNumber, data, requestor);
         report.entries.push(entry);
         if (entry.status === "created") report.summary.created++;
         else if (entry.status === "updated") report.summary.updated++;
@@ -114,7 +122,7 @@ export class HostingsSheetProcessor {
       building: string;
       room: string;
     },
-    requestorId: string,
+    requestor: Requestor,
   ): Promise<ImportReportEntryDto> {
     if (!data.applicationId) {
       throw new Error("Colonne « ID Application » vide.");
@@ -126,6 +134,18 @@ export class HostingsSheetProcessor {
     });
     if (!application) {
       throw new Error(`Application introuvable (id=${data.applicationId}).`);
+    }
+
+    // Droits applicatifs (portée incluse) sur CETTE application, comme l'API hébergements.
+    const allowed = await this.checkPermissions.can(
+      [Permission.HostingWrite],
+      requestor,
+      data.applicationId,
+    );
+    if (!allowed) {
+      throw new Error(
+        insufficientRightsMessage("HostingWrite", data.applicationId),
+      );
     }
 
     const hostingOptionId = await this.resolveHostingOptionId(data);
@@ -146,7 +166,7 @@ export class HostingsSheetProcessor {
         ...(hostingOptionId && { hostingOptionId }),
       });
       await this.validateDto(dto);
-      await this.hostingsService.updateHosting(data.id, dto, requestorId);
+      await this.hostingsService.updateHosting(data.id, dto, requestor.id);
       return { sheet: this.sheetName, row, status: "updated", identifier };
     }
 
@@ -157,7 +177,7 @@ export class HostingsSheetProcessor {
       isActive: null,
     });
     await this.validateDto(dto);
-    await this.hostingsService.createHosting(dto, requestorId);
+    await this.hostingsService.createHosting(dto, requestor.id);
     return { sheet: this.sheetName, row, status: "created", identifier };
   }
 

--- a/backend/src/import/utils/excel.utils.ts
+++ b/backend/src/import/utils/excel.utils.ts
@@ -77,3 +77,16 @@ export function coerceDate(value: string): string | undefined {
   const parsed = new Date(trimmed);
   return Number.isNaN(parsed.getTime()) ? trimmed : parsed.toISOString();
 }
+
+/**
+ * Motif explicite consigné dans le rapport quand une ligne est refusée faute de droits
+ * suffisants (US #1890). Reprend le nom de la permission exigée et, le cas échéant, l'application
+ * concernée — pour distinguer un refus de droits d'une erreur générique.
+ */
+export function insufficientRightsMessage(
+  permission: string,
+  applicationId?: string,
+): string {
+  const scope = applicationId ? ` sur l'application ${applicationId}` : "";
+  return `Droits insuffisants : permission « ${permission} » requise${scope}.`;
+}

--- a/e2e/tests/administration-referentiels.spec.ts
+++ b/e2e/tests/administration-referentiels.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "../fixtures/test";
-import { AdminPage } from "../pom";
+import { AdminPage, loginAs } from "../pom";
 import { buildActorImportWorkbook } from "../support/actor-import-xlsx";
 import { buildSheetWorkbook } from "../support/import-xlsx";
 import { dbQuery } from "../support/db";
@@ -534,5 +534,48 @@ test.describe("Administration des référentiels", () => {
       // La suppression de l'application supprime ses hébergements en cascade.
       await deleteThrowawayApp(appId);
     }
+  });
+
+  test("ADM-16 - import refusé hors périmètre pour un administrateur scopé (#1890)", async ({
+    page,
+    data,
+  }) => {
+    // L'application QA-SCOPE-ABCD est hors du périmètre de `scope-admin` (scopé TOTO/).
+    // On résout son id avec la session admin (fixture `data`) avant de basculer sur l'admin scopé,
+    // pour que le test se skippe proprement si le seed QA est absent.
+    const app = await data.applicationByLabel("QA-SCOPE-ABCD");
+    test.skip(!app, "Fixture QA absente — `pnpm db:seed:qa` requis.");
+
+    const ts = Date.now();
+    const attemptedLabel = `E2E-ADM16-${ts}`;
+    const originalLabel = app!.label;
+
+    await loginAs(page, "scope-admin");
+
+    const workbook = await buildSheetWorkbook(
+      "Applications",
+      ["Identifiant", "Libellé", "Description"],
+      [[app!.id, attemptedLabel, "Tentative de mise à jour hors périmètre"]],
+    );
+
+    const admin = new AdminPage(page);
+    await admin.open();
+    await admin.openBatchDataTab();
+    await admin.importExcel({
+      name: `import-adm16-${ts}.xlsx`,
+      mimeType: XLSX_MIME,
+      buffer: workbook,
+    });
+
+    // La ligne est refusée (droits insuffisants) et consignée dans le rapport ; rien n'est modifié.
+    await admin.expectImportReportSummary(/1 en erreur/);
+    await admin.expectImportReportSummary(/0 mis à jour/);
+    await admin.expectImportReportContains(/Droits insuffisants/i);
+
+    const rows = await dbQuery<{ label: string }>(
+      `SELECT label FROM "Application" WHERE id = $1`,
+      [app!.id],
+    );
+    expect(rows[0]?.label).toBe(originalLabel);
   });
 });

--- a/qa/protocoles/administration-referentiels.md
+++ b/qa/protocoles/administration-referentiels.md
@@ -8,7 +8,7 @@
 | Légende           |                                                                              |
 | :---------------- | :--------------------------------------------------------------------------- |
 | **Automatisé** ✅ | tests Playwright dédiés dans `e2e/tests/administration-referentiels.spec.ts` |
-| **Statut**        | 🟢 automatisé — 15 cas couverts par la CI                                    |
+| **Statut**        | 🟢 automatisé — 16 cas couverts par la CI                                    |
 
 ---
 
@@ -134,3 +134,12 @@
   fichier.
 - **Résultat attendu** : le rapport indique « 1 créé(s) » et « 0 en erreur » ; l'application possède
   désormais un hébergement (l'option d'hébergement est résolue ou créée comme via l'API).
+
+### ADM-16 — Import refusé hors périmètre pour un administrateur scopé (#1890) ✅
+
+- **Datafeature** : seed QA (`pnpm db:seed:qa`) — administrateur scopé `scope-admin` (périmètre TOTO/)
+  et application `QA-SCOPE-ABCD` hors de ce périmètre ; le test se skippe si la fixture est absente.
+- **Action** : se connecter en `scope-admin` → administration → onglet Batch de données → section
+  « Import Excel » → importer un onglet « Applications » mettant à jour `QA-SCOPE-ABCD`.
+- **Résultat attendu** : la ligne est **refusée** ; le rapport indique « 1 en erreur » / « 0 mis à
+  jour » avec le motif « Droits insuffisants » ; le libellé de l'application reste inchangé en base.


### PR DESCRIPTION
Closes #1890. Sous-tâche de #352. Suite des imports phase 1/2/3 (#1876, #1881, #1889, déjà mergées dans `main`).

## Problème
L'endpoint `POST /import/excel` était gardé par la seule permission **globale** `AdminPanelManage`. Or les écritures métier (`AppWrite`, `HostingWrite`, `ActorWrite`, `ComplianceWrite`) sont des permissions **applicatives**, calculées par application **avec la portée (scope)**. L'import court-circuitait donc ces contrôles : un **administrateur scopé** pouvait modifier des applications **hors de son périmètre**.

## Correctif
Chaque processeur vérifie désormais, **ligne par ligne**, la permission requise via `CheckPermissions.can(permission, requestor, applicationId)` — exactement comme l'API :

| Onglet | Opération | Permission | Type |
| :-- | :-- | :-- | :-- |
| Applications | création | `CreateApplication` | globale |
| Applications | mise à jour | `AppWrite` | applicative (scope) |
| Hébergements | création / mise à jour | `HostingWrite` | applicative (scope) |
| Acteurs | création / mise à jour | `ActorWrite` | applicative (scope) |
| Conformités | création / mise à jour | `ComplianceWrite` | applicative (scope) |

- Le `Requestor` complet circule du contrôleur (`@User()`) jusqu'aux processeurs.
- Les lignes refusées sont **consignées dans le rapport** avec un motif explicite (« Droits insuffisants : permission « X » requise [sur l'application Y] »), **sans interrompre** le traitement.
- **Politique** : un admin global garde tous les droits ; un admin scopé est limité à son périmètre.
- **Matrice documentée** : `backend/src/import/PERMISSIONS.md`.

## Tests
- **Unitaires** : 41 verts, dont **un cas de refus par processeur** (ligne en erreur avec motif, service métier non appelé).
- **e2e** : **ADM-16** — admin scopé refusé hors périmètre (rapport « 1 en erreur » + « Droits insuffisants », libellé inchangé). Se skippe si le seed QA est absent.
- **Non-régression** : imports ADM-08..15 toujours verts (admin global → contrôles transparents).

## Vérifications locales (stack docker)
`nest build` ✅ · 41 tests unitaires ✅ · imports e2e ADM-08..15 (chromium) ✅ · ADM-16 skip propre ✅ · `tsc` e2e ✅ · eslint ✅ · prettier ✅