### PR TITLE
fix: tris déterministes avec comparateur (Sonar S2871)

### DIFF
--- a/backend/src/permissions/role-to-permissions.ts
+++ b/backend/src/permissions/role-to-permissions.ts
@@ -31,13 +31,13 @@ const ADMIN_PERMISSIONS = new Set([
 export const roleToPermissions = (role: Roles) => {
   switch (role) {
     case Roles.ADMIN:
-      return Array.from(ADMIN_PERMISSIONS).sort();
+      return Array.from(ADMIN_PERMISSIONS).sort((a, b) => a.localeCompare(b));
     case Roles.CONTRIBUTOR:
-      return Array.from(WRITE_PERMISSIONS).sort();
+      return Array.from(WRITE_PERMISSIONS).sort((a, b) => a.localeCompare(b));
     case Roles.READER:
-      return Array.from(READ_PERMISSIONS).sort();
+      return Array.from(READ_PERMISSIONS).sort((a, b) => a.localeCompare(b));
     case Roles.VISITOR:
-      return Array.from(NONE_PERMISSIONS).sort();
+      return Array.from(NONE_PERMISSIONS).sort((a, b) => a.localeCompare(b));
   }
 };
 
@@ -64,11 +64,17 @@ const ADMIN_APP_PERMISSIONS = new Set([...Array.from(WRITE_APP_PERMISSIONS)]);
 export const roleToAppPermissions = (role: Roles) => {
   switch (role) {
     case Roles.ADMIN:
-      return Array.from(ADMIN_APP_PERMISSIONS).sort();
+      return Array.from(ADMIN_APP_PERMISSIONS).sort((a, b) =>
+        a.localeCompare(b),
+      );
     case Roles.CONTRIBUTOR:
-      return Array.from(WRITE_APP_PERMISSIONS).sort();
+      return Array.from(WRITE_APP_PERMISSIONS).sort((a, b) =>
+        a.localeCompare(b),
+      );
     case Roles.READER:
-      return Array.from(READ_APP_PERMISSIONS).sort();
+      return Array.from(READ_APP_PERMISSIONS).sort((a, b) =>
+        a.localeCompare(b),
+      );
     case Roles.VISITOR:
       return [];
   }

--- a/frontend/src/composables/use-application-search.ts
+++ b/frontend/src/composables/use-application-search.ts
@@ -102,7 +102,10 @@ function parseQueryParamArray(value: QueryParam): string[] | undefined {
 }
 
 function sortAsStrings(values: readonly unknown[]): string[] {
-  return values.map(String).slice().sort();
+  return values
+    .map(String)
+    .slice()
+    .sort((a, b) => a.localeCompare(b));
 }
 
 function sameStringArray(a: readonly string[], b: readonly string[]): boolean {


### PR DESCRIPTION
## Contexte
Corrige les 8 bugs SonarQube `typescript:S2871` (tris `Array.sort()` sans fonction de comparaison, ordre non fiable).

## Changements
- `backend/src/permissions/role-to-permissions.ts` : ajout d'un comparateur `localeCompare` sur les 7 `.sort()` (roleToPermissions / roleToAppPermissions).
- `frontend/src/composables/use-application-search.ts` : `sortAsStrings` utilise désormais `localeCompare`.

## Vérifs
- eslint ✅
- typecheck backend (`tsc --noEmit`) ✅

Closes #1893