### PR TITLE
fix(statuses): supprime le repli mort sur une Promise (Sonar S6544)

### DIFF
--- a/backend/src/statuses/statuses.controller.ts
+++ b/backend/src/statuses/statuses.controller.ts
@@ -82,7 +82,7 @@ export class StatusesController {
     type: [ApplicationStatusDto],
   })
   async find(@Param("applicationId") applicationId: string) {
-    return this.statusesService.find({ applicationId }) || [];
+    return this.statusesService.find({ applicationId });
   }
 
   @Patch(":statusId")


### PR DESCRIPTION
## Contexte
Corrige le bug SonarQube `typescript:S6544` dans `statuses.controller.ts:85`.

`this.statusesService.find()` exécute un `findMany` : il renvoie **toujours** une `Promise<Array>` (`[]` si rien). Le `|| []` portait donc sur une Promise toujours *truthy* → code mort, jamais évalué.

## Changement
```diff
- return this.statusesService.find({ applicationId }) || [];
+ return this.statusesService.find({ applicationId });
```
Comportement inchangé (tableau vide déjà renvoyé par `findMany`).

## Vérifs
- eslint ✅
- typecheck backend (`tsc --noEmit`) ✅

Closes #1894