### PR TITLE
fix(docker): retire les droits d'écriture 'others' de l'image frontend (Sonar S2612)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -32,9 +32,9 @@ FROM nginxinc/nginx-unprivileged:1.27-alpine AS prod
 
 USER 0
 
-RUN chmod 777 /usr/share/nginx/html
+RUN chown -R 1001:1001 /usr/share/nginx/html && chmod -R 755 /usr/share/nginx/html
 COPY --chown=1001:1001 --chmod=444 nginx.conf /etc/nginx/nginx.conf
-COPY --chown=1001:1001 --chmod=777 --from=build /app/dist /app
+COPY --chown=1001:1001 --chmod=755 --from=build /app/dist /app
 
 COPY --chown=1001:1001 --chmod=775 entrypoint.sh /docker-entrypoint.d/entrypoint.sh
 


### PR DESCRIPTION
## Contexte
Corrige la vulnérabilité SonarQube `docker:S2612` dans `frontend/Dockerfile` (droits d'écriture accordés à `others` via `chmod 777` / `--chmod=777`).

## Changements
```diff
- RUN chmod 777 /usr/share/nginx/html
+ RUN chown -R 1001:1001 /usr/share/nginx/html && chmod -R 755 /usr/share/nginx/html
- COPY --chown=1001:1001 --chmod=777 --from=build /app/dist /app
+ COPY --chown=1001:1001 --chmod=755 --from=build /app/dist /app
```

## Pourquoi ce choix (et pas un simple 755 en root)
L'entrypoint s'exécute en `USER 1001` et **écrit** dans `/usr/share/nginx/html` (`rm -rf` + `cp`, lignes 30-31 de `entrypoint.sh`) et dans `/app` (substitution d'env). On transfère donc la **propriété à 1001** : le propriétaire conserve l'écriture (runtime intact), seul le write `others`/`group` est retiré.

## Vérifs
- `docker build --check --target prod` ✅ (no warnings)

Closes #1895