### PR TITLE
fix(frontend): corrige un bug de type AdminActorsTab et la config des tests unitaires

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,8 +25,8 @@ RUN pnpm install --frozen-lockfile --ignore-scripts
 COPY . .
 
 RUN pnpm api:generate
-# Temporary disable type checking
-RUN pnpm build-only
+# build = type-check (vue-tsc) + build-only, en parallèle
+RUN pnpm build
 
 FROM nginxinc/nginx-unprivileged:1.27-alpine AS prod
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,8 +25,10 @@ RUN pnpm install --frozen-lockfile --ignore-scripts
 COPY . .
 
 RUN pnpm api:generate
-# build = type-check (vue-tsc) + build-only, en parallèle
-RUN pnpm build
+# Type-check désactivé au build : vue-tsc nécessite les d.ts d'auto-imports
+# (unplugin-auto-import) générés pendant le build Vite, et inclurait les specs.
+# Le type-check tourne via `pnpm type-check` (dev / job CI dédié), pas dans l'image.
+RUN pnpm build-only
 
 FROM nginxinc/nginx-unprivileged:1.27-alpine AS prod
 

--- a/frontend/src/components/admin/AdminActorsTab.vue
+++ b/frontend/src/components/admin/AdminActorsTab.vue
@@ -95,7 +95,7 @@ const tableRows = computed(() =>
 );
 
 function onSort(event: TableSortEvent) {
-  sortColumn.value = event.sortField;
+  sortColumn.value = event.sortField as (typeof headers)[number]["key"];
   isSortDescending.value = event.sortOrder === -1;
 }
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -7,7 +7,9 @@ export default mergeConfig(
   defineConfig({
     test: {
       environment: "jsdom",
-      exclude: [...configDefaults.exclude, "e2e/*"],
+      // Les specs Playwright vivent dans tests/ (playwright.config testDir) et tests-examples/ :
+      // on les exclut pour que vitest ne ramasse que les tests unitaires co-localisés dans src/.
+      exclude: [...configDefaults.exclude, "e2e/*", "tests/**", "tests-examples/**"],
       root: fileURLToPath(new URL("./", import.meta.url)),
       setupFiles: [fileURLToPath(new URL("./vitest-setup.ts", import.meta.url))],
     },


### PR DESCRIPTION
## Contexte
Corrige des erreurs **préexistantes** repérées en travaillant sur les tickets Sonar.

## Changements
1. **`AdminActorsTab.vue`** — vraie erreur de type : `event.sortField` (`string`) assigné à `sortColumn` (union des clés de colonnes) sans cast. Aligné sur l'idiome des composants frères : `as (typeof headers)[number]["key"]`.
2. **`vitest.config.ts`** — `test:unit` ramassait les specs **Playwright** (`tests/`, `tests-examples/`) → échecs de collecte. La config excluait `e2e/*` (inexistant) au lieu du `testDir` Playwright. Ajout de `tests/**`/`tests-examples/**`.

## Note sur le type-check au build
J'avais tenté de réactiver `vue-tsc` dans le build de l'image (`pnpm build`), mais la CI a confirmé que c'est **désactivé pour de bonnes raisons** : `vue-tsc` a besoin des `*.d.ts` d'auto-imports (générés pendant le build Vite) et inclurait les specs vitest → erreurs `Cannot find name 'computed'/'ref'/'vi'…`. Revert : on garde `build-only`, avec un commentaire qui explique pourquoi. Le type-check reste exécutable via `pnpm type-check` (dev / job dédié).

## Vérifications
- `pnpm type-check` ✅ (hors specs, avec d.ts générés)
- `vitest run` ✅ `ReloadPrompt.spec.ts` uniquement
- Build Frontend CI ✅ (build-only)