### PR TITLE
fix(a11y): éléments natifs vs rôles ARIA dans les composants Vue (#1897)

### DIFF
--- a/frontend/src/components/AccessibleAutocomplete.vue
+++ b/frontend/src/components/AccessibleAutocomplete.vue
@@ -170,7 +170,9 @@ onClickOutside(containerEl, () => {
         </button>
       </li>
 
-      <li v-if="!hasResults && displayNoResult" class="no-result" role="option" aria-disabled="true">Aucun résultat</li>
+      <li v-if="!hasResults && displayNoResult" class="no-result" role="option" :aria-selected="false" aria-disabled="true">
+        Aucun résultat
+      </li>
     </ul>
 
     <div class="visually-hidden" aria-live="polite" aria-atomic="true">{{ liveRegionText }}</div>

--- a/frontend/src/components/ApplicationSearchActions.vue
+++ b/frontend/src/components/ApplicationSearchActions.vue
@@ -62,7 +62,7 @@ const hasCreateGlobalReport = computed(() => {
 
 <template>
   <div class="fr-container-fluid" data-testid="application-search-actions">
-    <div aria-live="polite" class="sr-only" role="status">{{ reportStatusMessage }}</div>
+    <output aria-live="polite" class="sr-only">{{ reportStatusMessage }}</output>
 
     <div class="actions">
       <DsfrButton

--- a/frontend/src/components/RefAppTable.vue
+++ b/frontend/src/components/RefAppTable.vue
@@ -102,7 +102,7 @@ watch(
 </script>
 
 <template>
-  <div class="fr-table" role="region" :aria-label="`Tableau de ${totalRecords} éléments`">
+  <section class="fr-table" :aria-label="`Tableau de ${totalRecords} éléments`">
     <DataTable
       :value="items"
       :lazy="lazy"
@@ -129,7 +129,7 @@ watch(
       table-style="min-width: 50rem"
     >
       <template #empty>
-        <div class="fr-py-2w fr-text--center" role="status" aria-live="polite">{{ emptyMessage }}</div>
+        <output class="fr-py-2w fr-text--center" aria-live="polite" style="display: block">{{ emptyMessage }}</output>
       </template>
 
       <Column
@@ -152,7 +152,7 @@ watch(
         </template>
       </Column>
     </DataTable>
-  </div>
+  </section>
 </template>
 
 <style scoped>

--- a/frontend/src/components/data-application/DataApplicationDetail.vue
+++ b/frontend/src/components/data-application/DataApplicationDetail.vue
@@ -99,9 +99,15 @@ function goToProfileApp(appId: string) {
     />
 
     <!-- ── Loading ────────────────────────────────────────────────── -->
-    <div v-if="isLoading" role="status" aria-live="polite" class="fr-py-6w fr-text--center" data-testid="data-application-detail-loading">
+    <output
+      v-if="isLoading"
+      aria-live="polite"
+      class="fr-py-6w fr-text--center"
+      data-testid="data-application-detail-loading"
+      style="display: block"
+    >
       <span class="fr-text--sm">Chargement…</span>
-    </div>
+    </output>
 
     <!-- ── Not found ──────────────────────────────────────────────── -->
     <div v-else-if="!item" role="alert" class="fr-alert fr-alert--warning fr-mt-2w" data-testid="data-application-detail-not-found">

--- a/frontend/src/components/stats/IqChart.vue
+++ b/frontend/src/components/stats/IqChart.vue
@@ -114,9 +114,9 @@ onMounted(async () => {
           <div v-else-if="error" data-testid="iq-chart-error" role="alert" aria-live="assertive">
             {{ error }}
           </div>
-          <div v-else-if="!iqStats.length" data-testid="iq-chart-no-data" role="status">
+          <output v-else-if="!iqStats.length" data-testid="iq-chart-no-data" style="display: block">
             Aucune donnée disponible pour la période sélectionnée.
-          </div>
+          </output>
           <figure v-show="!isLoading && !error && !isTableView" focus-visible>
             <figcaption class="fr-sr-only">
               Graphique linéaire représentant l’évolution de l’IQ moyen, avec l’axe des X pour la date et l’axe des Y pour l’IQ moyen.

--- a/frontend/src/components/users/UsrFollowTab.vue
+++ b/frontend/src/components/users/UsrFollowTab.vue
@@ -66,9 +66,9 @@ const unsubscribe = async (appId: string) => {
     </DsfrTable>
 
     <div v-if="successMessage" class="fr-mt-2w">
-      <div class="fr-alert fr-alert--success" role="status" aria-live="polite">
+      <output class="fr-alert fr-alert--success" aria-live="polite" style="display: block">
         {{ successMessage }}
-      </div>
+      </output>
     </div>
 
     <div v-if="errorMessage" class="fr-mt-2w">

--- a/frontend/src/views/ApplicationPage.vue
+++ b/frontend/src/views/ApplicationPage.vue
@@ -110,9 +110,9 @@ const actions = computed(() => [
 
 <template>
   <div>
-    <div v-if="isLoading" data-testid="application-loading" role="status" aria-live="polite" aria-atomic="true">
+    <output v-if="isLoading" data-testid="application-loading" aria-live="polite" aria-atomic="true" style="display: block">
       <AppLoader></AppLoader>
-    </div>
+    </output>
 
     <div v-else-if="errorMessage" data-testid="application-error" role="alert" class="fr-alert fr-alert--error fr-m-2w">
       {{ errorMessage }}

--- a/frontend/src/views/ApplicationSearchPage.vue
+++ b/frontend/src/views/ApplicationSearchPage.vue
@@ -35,10 +35,10 @@ const averageIqDisplay = computed(() => {
     <main class="main-content" id="main-content" data-testid="main-content" role="main">
       <h1 class="fr-h1" data-testid="application-search-title">Recherche d'applications</h1>
 
-      <div v-if="isLoading" class="loader" data-testid="application-loader" role="status" aria-live="polite" aria-atomic="true">
+      <output v-if="isLoading" class="loader" data-testid="application-loader" aria-live="polite" aria-atomic="true">
         <AppLoader />
         <span class="sr-only">Chargement des résultats…</span>
-      </div>
+      </output>
 
       <div class="search-actions-wrapper" data-testid="application-search-actions-wrapper">
         <ApplicationSearchActions />

--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -80,7 +80,6 @@
           class="fr-col fr-btn fr-btn--secondary fr-btn--md"
           data-testid="home-contact-link"
           title="Contacter l’équipe sur Tchap"
-          aria-label="Contacter l’équipe sur Tchap"
           href="https://www.tchap.gouv.fr/#/room/!ydoKqFOXRAQPQYFvqa:agent.interieur.tchap.gouv.fr?via=agent.interieur.tchap.gouv.fr"
           target="_blank"
           ><span class="fr-icon-mail-open-line fr-icon--sm fr-mr-1w"></span>

--- a/frontend/src/views/TimePage.vue
+++ b/frontend/src/views/TimePage.vue
@@ -59,10 +59,10 @@ watchDebounced(
       <h1 class="fr-h1" data-testid="time-title">Diagramme Time</h1>
 
       <section id="technical-debt-chart" class="chart-section" data-testid="technical-debt-chart-section">
-        <div v-if="isTechnicalDebtLoading" class="loader" role="status" aria-live="polite" aria-atomic="true">
+        <output v-if="isTechnicalDebtLoading" class="loader" aria-live="polite" aria-atomic="true">
           <AppLoader />
           <span class="sr-only">Chargement du graphique…</span>
-        </div>
+        </output>
         <TechnicalDebtChart v-else :data="applications" />
       </section>
     </main>


### PR DESCRIPTION
## Contexte
Ticket de dette #1897 — 89 issues SonarQube `Web:*` (accessibilité/HTML). Tri entre **vraies améliorations a11y** (composants Vue) et **faux positifs** (contraintes des clients mail).

## Corrigé en code (11)
- **8× S6819** `role="status"` → `<output>` (qui porte implicitement `role=status`+`aria-live=polite`), en **préservant le layout** (`display:block`/`flex` conservé selon le cas) : `DataApplicationDetail`, `TimePage`, `RefAppTable` (slot empty), `UsrFollowTab`, `ApplicationSearchPage`, `ApplicationSearchActions`, `ApplicationPage`, `IqChart`.
- **S6819** `role="region"` → `<section aria-label>` dans `RefAppTable`.
- **S6807** `AccessibleAutocomplete` : ajout de `aria-selected` manquant sur l'option « Aucun résultat » (vrai bug a11y).
- **S7927** `HomePage` : `aria-label` divergent du texte visible retiré → le libellé visible devient le nom accessible.

## Marqués *won't fix* dans SonarQube (78, hors code)
- **71 — templates email** (`S1827` attribut `width`, `S5257` tables de layout, `role=status`) : imposés par les clients mail (Outlook & co), `<output>`/CSS-layout non supportés.
- **6 — `AccessibleAutocomplete`** rôles `listbox`/`option`/`presentation` (S6819/S6842) : **pattern ARIA combobox correct et voulu** ; les éléments natifs `<select>`/`<datalist>` ne conviennent pas à un autocomplete custom.
- **1 — `CompliancesAccordionManager`** `role="group"` sur une carte : aucun élément natif (`fieldset`/`details`/…) sans régression visuelle/sémantique.

## Vérifications
- `vue-tsc` ✅ (hors `AdminActorsTab` préexistant, corrigé par #1906)
- eslint `--quiet` ✅ 0 erreur

Closes #1897