### PR TITLE
chore(ci): exclut les faux positifs Sonar durablement (tests Supertest, templates email)

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -114,6 +114,15 @@ jobs:
             -Dsonar.coverage.exclusions=**/tests/**
             -Dsonar.tests=backend/tests
             -Dsonar.scm.provider=git
+            -Dsonar.issue.ignore.multicriteria=e2699,emailWidth,emailLayout,emailRole
+            -Dsonar.issue.ignore.multicriteria.e2699.ruleKey=typescript:S2699
+            -Dsonar.issue.ignore.multicriteria.e2699.resourceKey=backend/tests/**
+            -Dsonar.issue.ignore.multicriteria.emailWidth.ruleKey=Web:S1827
+            -Dsonar.issue.ignore.multicriteria.emailWidth.resourceKey=backend/src/email/templates/**
+            -Dsonar.issue.ignore.multicriteria.emailLayout.ruleKey=Web:S5257
+            -Dsonar.issue.ignore.multicriteria.emailLayout.resourceKey=backend/src/email/templates/**
+            -Dsonar.issue.ignore.multicriteria.emailRole.ruleKey=Web:S6819
+            -Dsonar.issue.ignore.multicriteria.emailRole.resourceKey=backend/src/email/templates/**
             ${{ github.event_name == 'pull_request' && steps.sonar-args.outputs.SONAR_ARGS_PR || steps.sonar-args.outputs.SONAR_ARGS_BRANCH }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Contexte
Sur le Sonar local, 138 issues ont été résolues (60 `S2699` faux positifs + 78 accessibilité/email acceptées). Ces résolutions **ne se reportent pas** sur le Sonar DSO (CI). Cette PR rend les exclusions **durables** côté CI via `sonar.issue.ignore.multicriteria`.

## Règles ignorées (CI)
| Règle | Chemin | Raison |
|-------|--------|--------|
| `typescript:S2699` | `backend/tests/**` | Assertions Supertest `.expect()` non reconnues (faux positifs, cf #1896) |
| `Web:S1827` | `backend/src/email/templates/**` | Attribut `width` requis en HTML email |
| `Web:S5257` | `backend/src/email/templates/**` | Tables de mise en page imposées par les clients mail |
| `Web:S6819` | `backend/src/email/templates/**` | `<output>`/éléments natifs non supportés en email |

## Hors périmètre
Les rares cas restants (pattern ARIA combobox `AccessibleAutocomplete`, `role=group` carte) restent gérés en **« Accepted »** dans Sonar (persistant via le suivi d'issues), car file-specific.

Le job `code-scan` est en `continue-on-error: true` : aucun risque de blocage.