### PR TITLE
fix: relabel "Maîtrise des coûts" & rename costMaturity → costContainment (#1900)

### DIFF
--- a/backend/prisma/docs/schema.md
+++ b/backend/prisma/docs/schema.md
@@ -82,9 +82,9 @@ erDiagram
 "TechnicalDebtInfo" {
   String id PK
   String applicationId FK
-  Decimal(3) technicalMaturity
-  Decimal(3) businessMaturity
-  Decimal(3) costContainment
+  Decimal(3) technicalMaturity "nullable"
+  Decimal(3) businessMaturity "nullable"
+  Decimal(3) costContainment "nullable"
   Int millesime
   DateTime createdAt
 }
@@ -236,9 +236,9 @@ Properties as follows:
 
 - `id`: Identifiant unique
 - `applicationId`:
-- `technicalMaturity`: Score de maturité technique (0-1)
-- `businessMaturity`: Score de maturité métier (0-1)
-- `costContainment`: Score de maîtrise des coûts (0-1)
+- `technicalMaturity`: Score de maturité technique (1-5). `null` = non évalué (valeurs < 1 migrées vers `null`).
+- `businessMaturity`: Score de maturité métier (1-5). `null` = non évalué (valeurs < 1 migrées vers `null`).
+- `costContainment`: Score de maîtrise des coûts (1-5). `null` = non évalué (valeurs < 1 migrées vers `null`).
 - `millesime`: Millésime (année) de la campagne dette IT à laquelle se rattache l'évaluation
 - `createdAt`: Date de création de l'évaluation
 

--- a/backend/prisma/docs/schema.md
+++ b/backend/prisma/docs/schema.md
@@ -236,9 +236,9 @@ Properties as follows:
 
 - `id`: Identifiant unique
 - `applicationId`:
-- `technicalMaturity`: Score de maturité technique (1-5). `null` = non évalué (valeurs < 1 migrées vers `null`).
-- `businessMaturity`: Score de maturité métier (1-5). `null` = non évalué (valeurs < 1 migrées vers `null`).
-- `costContainment`: Score de maîtrise des coûts (1-5). `null` = non évalué (valeurs < 1 migrées vers `null`).
+- `technicalMaturity`: Score de maturité technique (1-5). `null` = non noté (valeurs < 1 migrées vers `null`).
+- `businessMaturity`: Score de maturité métier (1-5). `null` = non noté (valeurs < 1 migrées vers `null`).
+- `costContainment`: Score de maîtrise des coûts (1-5). `null` = non noté (valeurs < 1 migrées vers `null`).
 - `millesime`: Millésime (année) de la campagne dette IT à laquelle se rattache l'évaluation
 - `createdAt`: Date de création de l'évaluation
 

--- a/backend/prisma/docs/schema.md
+++ b/backend/prisma/docs/schema.md
@@ -84,7 +84,7 @@ erDiagram
   String applicationId FK
   Decimal(3) technicalMaturity
   Decimal(3) businessMaturity
-  Decimal(3) costMaturity
+  Decimal(3) costContainment
   Int millesime
   DateTime createdAt
 }
@@ -238,7 +238,7 @@ Properties as follows:
 - `applicationId`:
 - `technicalMaturity`: Score de maturité technique (0-1)
 - `businessMaturity`: Score de maturité métier (0-1)
-- `costMaturity`: Score de maturité des coûts (0-1)
+- `costContainment`: Score de maîtrise des coûts (0-1)
 - `millesime`: Millésime (année) de la campagne dette IT à laquelle se rattache l'évaluation
 - `createdAt`: Date de création de l'évaluation
 

--- a/backend/prisma/migrations/20260625000000_rename_cost_maturity_to_cost_containment/migration.sql
+++ b/backend/prisma/migrations/20260625000000_rename_cost_maturity_to_cost_containment/migration.sql
@@ -1,0 +1,3 @@
+-- Renomme la colonne pour la cohérence base de données / IHM (cf. ticket #1900).
+-- RENAME COLUMN préserve les données existantes.
+ALTER TABLE "TechnicalDebtInfo" RENAME COLUMN "costMaturity" TO "costContainment";

--- a/backend/prisma/migrations/20260625001000_technical_debt_scores_nullable_below_one/migration.sql
+++ b/backend/prisma/migrations/20260625001000_technical_debt_scores_nullable_below_one/migration.sql
@@ -1,0 +1,14 @@
+-- Les scores de maturité passent sur une échelle 1-5 ; `null` = non évalué (cf. ticket #1900).
+-- Les colonnes deviennent nullables et perdent leur défaut 0.
+ALTER TABLE "TechnicalDebtInfo"
+  ALTER COLUMN "technicalMaturity" DROP DEFAULT,
+  ALTER COLUMN "technicalMaturity" DROP NOT NULL,
+  ALTER COLUMN "businessMaturity" DROP DEFAULT,
+  ALTER COLUMN "businessMaturity" DROP NOT NULL,
+  ALTER COLUMN "costContainment" DROP DEFAULT,
+  ALTER COLUMN "costContainment" DROP NOT NULL;
+
+-- Migration des valeurs existantes < 1 vers `null` (non évalué).
+UPDATE "TechnicalDebtInfo" SET "technicalMaturity" = NULL WHERE "technicalMaturity" < 1;
+UPDATE "TechnicalDebtInfo" SET "businessMaturity" = NULL WHERE "businessMaturity" < 1;
+UPDATE "TechnicalDebtInfo" SET "costContainment" = NULL WHERE "costContainment" < 1;

--- a/backend/prisma/migrations/20260625001000_technical_debt_scores_nullable_below_one/migration.sql
+++ b/backend/prisma/migrations/20260625001000_technical_debt_scores_nullable_below_one/migration.sql
@@ -1,4 +1,4 @@
--- Les scores de maturité passent sur une échelle 1-5 ; `null` = non évalué (cf. ticket #1900).
+-- Les scores de maturité passent sur une échelle 1-5 ; `null` = non noté (cf. ticket #1900).
 -- Les colonnes deviennent nullables et perdent leur défaut 0.
 ALTER TABLE "TechnicalDebtInfo"
   ALTER COLUMN "technicalMaturity" DROP DEFAULT,
@@ -8,7 +8,7 @@ ALTER TABLE "TechnicalDebtInfo"
   ALTER COLUMN "costContainment" DROP DEFAULT,
   ALTER COLUMN "costContainment" DROP NOT NULL;
 
--- Migration des valeurs existantes < 1 vers `null` (non évalué).
+-- Migration des valeurs existantes < 1 vers `null` (non noté).
 UPDATE "TechnicalDebtInfo" SET "technicalMaturity" = NULL WHERE "technicalMaturity" < 1;
 UPDATE "TechnicalDebtInfo" SET "businessMaturity" = NULL WHERE "businessMaturity" < 1;
 UPDATE "TechnicalDebtInfo" SET "costContainment" = NULL WHERE "costContainment" < 1;

--- a/backend/prisma/schema/technical-debt-info.prisma
+++ b/backend/prisma/schema/technical-debt-info.prisma
@@ -11,11 +11,11 @@ model TechnicalDebtInfo {
   /// Entrées de métadonnées pour cette évaluation
   metadatas     Metadata[]
 
-  /// Score de maturité technique (1-5). `null` = non évalué (valeurs < 1 migrées vers `null`).
+  /// Score de maturité technique (1-5). `null` = non noté (valeurs < 1 migrées vers `null`).
   technicalMaturity Decimal? @db.Decimal(3, 2)
-  /// Score de maturité métier (1-5). `null` = non évalué (valeurs < 1 migrées vers `null`).
+  /// Score de maturité métier (1-5). `null` = non noté (valeurs < 1 migrées vers `null`).
   businessMaturity  Decimal? @db.Decimal(3, 2)
-  /// Score de maîtrise des coûts (1-5). `null` = non évalué (valeurs < 1 migrées vers `null`).
+  /// Score de maîtrise des coûts (1-5). `null` = non noté (valeurs < 1 migrées vers `null`).
   costContainment   Decimal? @db.Decimal(3, 2)
   /// Millésime (année) de la campagne dette IT à laquelle se rattache l'évaluation
   millesime         Int      @default(dbgenerated("(EXTRACT(YEAR FROM CURRENT_DATE))::integer"))

--- a/backend/prisma/schema/technical-debt-info.prisma
+++ b/backend/prisma/schema/technical-debt-info.prisma
@@ -15,8 +15,8 @@ model TechnicalDebtInfo {
   technicalMaturity Decimal  @default(0) @db.Decimal(3, 2)
   /// Score de maturité métier (0-1)
   businessMaturity  Decimal  @default(0) @db.Decimal(3, 2)
-  /// Score de maturité des coûts (0-1)
-  costMaturity      Decimal  @default(0) @db.Decimal(3, 2)
+  /// Score de maîtrise des coûts (0-1)
+  costContainment   Decimal  @default(0) @db.Decimal(3, 2)
   /// Millésime (année) de la campagne dette IT à laquelle se rattache l'évaluation
   millesime         Int      @default(dbgenerated("(EXTRACT(YEAR FROM CURRENT_DATE))::integer"))
   /// Date de création de l'évaluation

--- a/backend/prisma/schema/technical-debt-info.prisma
+++ b/backend/prisma/schema/technical-debt-info.prisma
@@ -11,12 +11,12 @@ model TechnicalDebtInfo {
   /// Entrées de métadonnées pour cette évaluation
   metadatas     Metadata[]
 
-  /// Score de maturité technique (0-1)
-  technicalMaturity Decimal  @default(0) @db.Decimal(3, 2)
-  /// Score de maturité métier (0-1)
-  businessMaturity  Decimal  @default(0) @db.Decimal(3, 2)
-  /// Score de maîtrise des coûts (0-1)
-  costContainment   Decimal  @default(0) @db.Decimal(3, 2)
+  /// Score de maturité technique (1-5). `null` = non évalué (valeurs < 1 migrées vers `null`).
+  technicalMaturity Decimal? @db.Decimal(3, 2)
+  /// Score de maturité métier (1-5). `null` = non évalué (valeurs < 1 migrées vers `null`).
+  businessMaturity  Decimal? @db.Decimal(3, 2)
+  /// Score de maîtrise des coûts (1-5). `null` = non évalué (valeurs < 1 migrées vers `null`).
+  costContainment   Decimal? @db.Decimal(3, 2)
   /// Millésime (année) de la campagne dette IT à laquelle se rattache l'évaluation
   millesime         Int      @default(dbgenerated("(EXTRACT(YEAR FROM CURRENT_DATE))::integer"))
   /// Date de création de l'évaluation

--- a/backend/src/applications/infrastructure/repository/application.repository.ts
+++ b/backend/src/applications/infrastructure/repository/application.repository.ts
@@ -243,7 +243,7 @@ export class ApplicationRepository implements IApplicationRepository {
           select: {
             technicalMaturity: true,
             businessMaturity: true,
-            costMaturity: true,
+            costContainment: true,
             millesime: true,
           },
         },

--- a/backend/src/technical-debt-info/dto/create-technical-debt-info.dto.ts
+++ b/backend/src/technical-debt-info/dto/create-technical-debt-info.dto.ts
@@ -5,7 +5,7 @@ import { IsInt, IsNumber, IsOptional, Max, Min } from "class-validator";
 export class CreateTechnicalDebtInfoDto {
   @ApiProperty({
     example: 3.2,
-    description: "Technical maturity score (1-5). Omit / null = not evaluated.",
+    description: "Technical maturity score (1-5). Omit / null = not rated.",
     required: false,
     minimum: 1,
     maximum: 5,
@@ -18,7 +18,7 @@ export class CreateTechnicalDebtInfoDto {
 
   @ApiProperty({
     example: 4.5,
-    description: "Business maturity score (1-5). Omit / null = not evaluated.",
+    description: "Business maturity score (1-5). Omit / null = not rated.",
     required: false,
     minimum: 1,
     maximum: 5,
@@ -31,7 +31,7 @@ export class CreateTechnicalDebtInfoDto {
 
   @ApiProperty({
     example: 2.75,
-    description: "Cost containment score (1-5). Omit / null = not evaluated.",
+    description: "Cost containment score (1-5). Omit / null = not rated.",
     required: false,
     minimum: 1,
     maximum: 5,

--- a/backend/src/technical-debt-info/dto/create-technical-debt-info.dto.ts
+++ b/backend/src/technical-debt-info/dto/create-technical-debt-info.dto.ts
@@ -5,40 +5,40 @@ import { IsInt, IsNumber, IsOptional, Max, Min } from "class-validator";
 export class CreateTechnicalDebtInfoDto {
   @ApiProperty({
     example: 3.2,
-    description: "Technical maturity score (0-5)",
+    description: "Technical maturity score (1-5). Omit / null = not evaluated.",
     required: false,
-    minimum: 0,
+    minimum: 1,
     maximum: 5,
   })
   @IsOptional()
   @IsNumber({ maxDecimalPlaces: 2 })
-  @Min(0)
+  @Min(1)
   @Max(5)
   technicalMaturity?: number;
 
   @ApiProperty({
     example: 4.5,
-    description: "Business maturity score (0-5)",
+    description: "Business maturity score (1-5). Omit / null = not evaluated.",
     required: false,
-    minimum: 0,
+    minimum: 1,
     maximum: 5,
   })
   @IsOptional()
   @IsNumber({ maxDecimalPlaces: 2 })
-  @Min(0)
+  @Min(1)
   @Max(5)
   businessMaturity?: number;
 
   @ApiProperty({
     example: 2.75,
-    description: "Cost containment score (0-5)",
+    description: "Cost containment score (1-5). Omit / null = not evaluated.",
     required: false,
-    minimum: 0,
+    minimum: 1,
     maximum: 5,
   })
   @IsOptional()
   @IsNumber({ maxDecimalPlaces: 2 })
-  @Min(0)
+  @Min(1)
   @Max(5)
   costContainment?: number;
 

--- a/backend/src/technical-debt-info/dto/create-technical-debt-info.dto.ts
+++ b/backend/src/technical-debt-info/dto/create-technical-debt-info.dto.ts
@@ -31,7 +31,7 @@ export class CreateTechnicalDebtInfoDto {
 
   @ApiProperty({
     example: 2.75,
-    description: "Cost maturity score (0-5)",
+    description: "Cost containment score (0-5)",
     required: false,
     minimum: 0,
     maximum: 5,
@@ -40,7 +40,7 @@ export class CreateTechnicalDebtInfoDto {
   @IsNumber({ maxDecimalPlaces: 2 })
   @Min(0)
   @Max(5)
-  costMaturity?: number;
+  costContainment?: number;
 
   @ApiProperty({
     example: 2026,

--- a/backend/src/technical-debt-info/entities/technical-debt-info.entity.ts
+++ b/backend/src/technical-debt-info/entities/technical-debt-info.entity.ts
@@ -3,6 +3,6 @@ export class TechnicalDebtInfo {
   applicationId: string;
   technicalMaturity?: number | null;
   businessMaturity?: number | null;
-  costMaturity?: number | null;
+  costContainment?: number | null;
   millesime?: number | null;
 }

--- a/backend/tests/fakers/technical-debt-info.faker.ts
+++ b/backend/tests/fakers/technical-debt-info.faker.ts
@@ -32,17 +32,17 @@ export class TechnicalDebtInfoFaker {
         technicalMaturity:
           restOverride.technicalMaturity ??
           faker.helpers.maybe(() =>
-            faker.number.float({ min: 0, max: 5, multipleOf: 0.01 }),
+            faker.number.float({ min: 1, max: 5, multipleOf: 0.01 }),
           ),
         businessMaturity:
           restOverride.businessMaturity ??
           faker.helpers.maybe(() =>
-            faker.number.float({ min: 0, max: 5, multipleOf: 0.01 }),
+            faker.number.float({ min: 1, max: 5, multipleOf: 0.01 }),
           ),
         costContainment:
           restOverride.costContainment ??
           faker.helpers.maybe(() =>
-            faker.number.float({ min: 0, max: 5, multipleOf: 0.01 }),
+            faker.number.float({ min: 1, max: 5, multipleOf: 0.01 }),
           ),
         ...(restOverride.millesime != null
           ? { millesime: restOverride.millesime }

--- a/backend/tests/fakers/technical-debt-info.faker.ts
+++ b/backend/tests/fakers/technical-debt-info.faker.ts
@@ -8,7 +8,7 @@ export class TechnicalDebtInfoFaker {
     user: UserFakerReturnType;
     technicalMaturity?: number | null;
     businessMaturity?: number | null;
-    costMaturity?: number | null;
+    costContainment?: number | null;
     millesime?: number;
   }) {
     const prisma = getPrismaClient();
@@ -39,8 +39,8 @@ export class TechnicalDebtInfoFaker {
           faker.helpers.maybe(() =>
             faker.number.float({ min: 0, max: 5, multipleOf: 0.01 }),
           ),
-        costMaturity:
-          restOverride.costMaturity ??
+        costContainment:
+          restOverride.costContainment ??
           faker.helpers.maybe(() =>
             faker.number.float({ min: 0, max: 5, multipleOf: 0.01 }),
           ),

--- a/backend/tests/technical-debt-info.e2e-spec.ts
+++ b/backend/tests/technical-debt-info.e2e-spec.ts
@@ -94,7 +94,7 @@ describe("TechnicalDebtInfo", () => {
       .post(`/applications/${application.id}/technical-debt-info`)
       .send({
         technicalMaturity: 4.5,
-        // costContainment omis → non évalué (null), cf. ticket #1900.
+        // costContainment omis → non noté (null), cf. ticket #1900.
       })
       .set("Authorization", `Bearer ${TOKEN}`)
       .expect(201);
@@ -123,7 +123,7 @@ describe("TechnicalDebtInfo", () => {
       .set("Authorization", `Bearer ${TOKEN}`)
       .expect(400);
 
-    // Test value < 1 (l'échelle est désormais 1-5 ; en deçà = non évalué/null, cf. #1900).
+    // Test value < 1 (l'échelle est désormais 1-5 ; en deçà = non noté/null, cf. #1900).
     await request(app().getHttpServer())
       .post(`/applications/${newApplication.id}/technical-debt-info`)
       .send({

--- a/backend/tests/technical-debt-info.e2e-spec.ts
+++ b/backend/tests/technical-debt-info.e2e-spec.ts
@@ -94,14 +94,14 @@ describe("TechnicalDebtInfo", () => {
       .post(`/applications/${application.id}/technical-debt-info`)
       .send({
         technicalMaturity: 4.5,
-        costContainment: 0,
+        // costContainment omis → non évalué (null), cf. ticket #1900.
       })
       .set("Authorization", `Bearer ${TOKEN}`)
       .expect(201);
 
     expect(response.body.id).toBeDefined();
     expect(response.body.technicalMaturity).toEqual(4.5);
-    expect(response.body.costContainment).toEqual(0);
+    expect(response.body.costContainment ?? null).toBeNull();
 
     const listResponse = await request(app().getHttpServer())
       .get(`/applications/${application.id}/technical-debt-info`)
@@ -123,11 +123,11 @@ describe("TechnicalDebtInfo", () => {
       .set("Authorization", `Bearer ${TOKEN}`)
       .expect(400);
 
-    // Test value < 0
+    // Test value < 1 (l'échelle est désormais 1-5 ; en deçà = non évalué/null, cf. #1900).
     await request(app().getHttpServer())
       .post(`/applications/${newApplication.id}/technical-debt-info`)
       .send({
-        businessMaturity: -1,
+        businessMaturity: 0.5,
       })
       .set("Authorization", `Bearer ${TOKEN}`)
       .expect(400);

--- a/backend/tests/technical-debt-info.e2e-spec.ts
+++ b/backend/tests/technical-debt-info.e2e-spec.ts
@@ -34,7 +34,7 @@ describe("TechnicalDebtInfo", () => {
       .send({
         technicalMaturity: 3.25,
         businessMaturity: 4.1,
-        costMaturity: 2.75,
+        costContainment: 2.75,
       })
       .set("Authorization", `Bearer ${TOKEN}`)
       .expect(201);
@@ -42,7 +42,7 @@ describe("TechnicalDebtInfo", () => {
     expect(response.body.id).toBeDefined();
     expect(response.body.technicalMaturity).toEqual(3.25);
     expect(response.body.businessMaturity).toEqual(4.1);
-    expect(response.body.costMaturity).toEqual(2.75);
+    expect(response.body.costContainment).toEqual(2.75);
     // Le millésime est renseigné par défaut avec l'année courante.
     expect(response.body.millesime).toEqual(new Date().getFullYear());
   });
@@ -86,7 +86,7 @@ describe("TechnicalDebtInfo", () => {
     expect(latest.id).toBeDefined();
     expect(latest.technicalMaturity).toEqual(3.25);
     expect(latest.businessMaturity).toEqual(4.1);
-    expect(latest.costMaturity).toEqual(2.75);
+    expect(latest.costContainment).toEqual(2.75);
   });
 
   it("/POST applications/:applicationId/technical-debt-info - should add a new historic entry", async () => {
@@ -94,14 +94,14 @@ describe("TechnicalDebtInfo", () => {
       .post(`/applications/${application.id}/technical-debt-info`)
       .send({
         technicalMaturity: 4.5,
-        costMaturity: 0,
+        costContainment: 0,
       })
       .set("Authorization", `Bearer ${TOKEN}`)
       .expect(201);
 
     expect(response.body.id).toBeDefined();
     expect(response.body.technicalMaturity).toEqual(4.5);
-    expect(response.body.costMaturity).toEqual(0);
+    expect(response.body.costContainment).toEqual(0);
 
     const listResponse = await request(app().getHttpServer())
       .get(`/applications/${application.id}/technical-debt-info`)
@@ -213,7 +213,7 @@ describe("TechnicalDebts", () => {
       .send({
         technicalMaturity: 2.2,
         businessMaturity: 3.15,
-        costMaturity: 4.05,
+        costContainment: 4.05,
       })
       .set("Authorization", `Bearer ${TOKEN}`)
       .expect(201);
@@ -223,7 +223,7 @@ describe("TechnicalDebts", () => {
       .send({
         technicalMaturity: 1.1,
         businessMaturity: 2.25,
-        costMaturity: 3.5,
+        costContainment: 3.5,
       })
       .set("Authorization", `Bearer ${TOKEN}`)
       .expect(201);

--- a/e2e/fixtures/api-client.ts
+++ b/e2e/fixtures/api-client.ts
@@ -146,6 +146,15 @@ export class ApiClient {
     if (found) await this.del(`/mdit-campaigns/${found.id}`);
   }
 
+  /** Évaluations de dette technique d'une application (plus récente d'abord), paginées. */
+  applicationTechnicalDebtInfo(
+    appId: string,
+  ): Promise<Paginated<{ id: string; costContainment?: number }> | null> {
+    return this.get<Paginated<{ id: string; costContainment?: number }>>(
+      `/applications/${appId}/technical-debt-info?pageSize=1&page=0`,
+    );
+  }
+
   /** Crée une évaluation de dette technique (campagne `millesime`) pour une application. */
   createTechnicalDebtInfo(
     appId: string,

--- a/e2e/fixtures/datafeature.ts
+++ b/e2e/fixtures/datafeature.ts
@@ -53,6 +53,22 @@ export class DataFeature {
     return created ? app : null;
   }
 
+  /**
+   * Sème une évaluation de dette technique dont la maîtrise des coûts est **non évaluée**
+   * (`costContainment` omis → `null`) sur la première application, et la renvoie. Sert à vérifier
+   * que la carte affiche « Non évalué » pour un axe sans score (FIC-16, ticket #1900). Comme les
+   * évaluations sont historisées, la plus récente — celle-ci — pilote l'affichage.
+   */
+  async seedTechnicalDebtWithoutCost(): Promise<AppRef | null> {
+    const app = await this.firstApplication();
+    if (!app) return null;
+    const created = await this.api.createTechnicalDebtInfo(app.id, {
+      technicalMaturity: 3,
+      businessMaturity: 3,
+    });
+    return created ? app : null;
+  }
+
   /** Une application possédant au moins une relation inter-applications. */
   async applicationWithRelations(probe = 15): Promise<AppRef | null> {
     const list = await this.api.applications(`pageSize=${probe}&page=0`);

--- a/e2e/fixtures/datafeature.ts
+++ b/e2e/fixtures/datafeature.ts
@@ -54,9 +54,9 @@ export class DataFeature {
   }
 
   /**
-   * Sème une évaluation de dette technique dont la maîtrise des coûts est **non évaluée**
+   * Sème une évaluation de dette technique dont la maîtrise des coûts est **non notée**
    * (`costContainment` omis → `null`) sur la première application, et la renvoie. Sert à vérifier
-   * que la carte affiche « Non évalué » pour un axe sans score (FIC-16, ticket #1900). Comme les
+   * que la carte affiche « Non notée » pour un axe sans score (FIC-16, ticket #1900). Comme les
    * évaluations sont historisées, la plus récente — celle-ci — pilote l'affichage.
    */
   async seedTechnicalDebtWithoutCost(): Promise<AppRef | null> {

--- a/e2e/fixtures/datafeature.ts
+++ b/e2e/fixtures/datafeature.ts
@@ -34,6 +34,25 @@ export class DataFeature {
     return page?.results?.find((a) => a.label === label) ?? null;
   }
 
+  /**
+   * Une application possédant une évaluation de dette technique, afin que la carte « Dette
+   * technique » (et son libellé « Maîtrise des coûts ») soit rendue sur l'onglet Informations
+   * générales (FIC-15, ticket #1900). Sème l'évaluation « create-if-absent » sur la première
+   * application si elle n'en a pas. Renvoie `null` si aucune application n'existe.
+   */
+  async applicationWithTechnicalDebt(): Promise<AppRef | null> {
+    const app = await this.firstApplication();
+    if (!app) return null;
+    const existing = await this.api.applicationTechnicalDebtInfo(app.id);
+    if (existing?.results?.length) return app;
+    const created = await this.api.createTechnicalDebtInfo(app.id, {
+      technicalMaturity: 3,
+      businessMaturity: 3,
+      costContainment: 3,
+    });
+    return created ? app : null;
+  }
+
   /** Une application possédant au moins une relation inter-applications. */
   async applicationWithRelations(probe = 15): Promise<AppRef | null> {
     const list = await this.api.applications(`pageSize=${probe}&page=0`);

--- a/e2e/pom/application.page.ts
+++ b/e2e/pom/application.page.ts
@@ -127,10 +127,10 @@ export class ApplicationPage extends BasePage {
     await expect(card.getByText("Maturité des coûts")).toHaveCount(0);
   }
 
-  /** Le badge « Maîtrise des coûts » affiche « Non évalué » quand le score est `null` (FIC-16, #1900). */
-  async expectCostContainmentNotEvaluated(): Promise<void> {
+  /** Le badge « Maîtrise des coûts » affiche « Non notée » quand le score est `null` (FIC-16, #1900). */
+  async expectCostContainmentNotRated(): Promise<void> {
     await expect(this.byTestId("costContainment-badge")).toContainText(
-      "Non évalué",
+      "Non notée",
     );
   }
 

--- a/e2e/pom/application.page.ts
+++ b/e2e/pom/application.page.ts
@@ -127,6 +127,13 @@ export class ApplicationPage extends BasePage {
     await expect(card.getByText("Maturité des coûts")).toHaveCount(0);
   }
 
+  /** Le badge « Maîtrise des coûts » affiche « Non évalué » quand le score est `null` (FIC-16, #1900). */
+  async expectCostContainmentNotEvaluated(): Promise<void> {
+    await expect(this.byTestId("costContainment-badge")).toContainText(
+      "Non évalué",
+    );
+  }
+
   // --- Axe RGAA, section dédiée en bas de l'onglet conformités (FIC-06) ---
   async expectRgaaSectionVisible(): Promise<void> {
     await expect(this.page.getByText(/Conformités RGAA/i)).toBeVisible();

--- a/e2e/pom/application.page.ts
+++ b/e2e/pom/application.page.ts
@@ -115,6 +115,18 @@ export class ApplicationPage extends BasePage {
     await expect(this.byTestId("info-edit-btn")).toBeDisabled();
   }
 
+  // --- Carte Dette technique sur l'onglet Infos (FIC-15, ticket #1900) ---
+  /**
+   * La carte dette technique affiche le libellé « Maîtrise des coûts » (renommé depuis
+   * « Maturité des coûts ») et ne présente plus l'ancien libellé.
+   */
+  async expectCostContainmentLabel(): Promise<void> {
+    const card = this.byTestId("info-technical-debt");
+    await expect(card).toBeVisible();
+    await expect(card.getByText("Maîtrise des coûts")).toBeVisible();
+    await expect(card.getByText("Maturité des coûts")).toHaveCount(0);
+  }
+
   // --- Axe RGAA, section dédiée en bas de l'onglet conformités (FIC-06) ---
   async expectRgaaSectionVisible(): Promise<void> {
     await expect(this.page.getByText(/Conformités RGAA/i)).toBeVisible();

--- a/e2e/tests/fiche-application.spec.ts
+++ b/e2e/tests/fiche-application.spec.ts
@@ -157,7 +157,7 @@ test.describe("Fiche application", () => {
     await fiche.expectCostContainmentLabel();
   });
 
-  test("FIC-16 - onglet Informations générales : un score non évalué affiche « Non évalué »", async ({
+  test("FIC-16 - onglet Informations générales : un score non noté affiche « Non notée »", async ({
     page,
     data,
   }) => {
@@ -169,6 +169,6 @@ test.describe("Fiche application", () => {
 
     const fiche = new ApplicationPage(page);
     await fiche.open(app!.id, "tab-infos");
-    await fiche.expectCostContainmentNotEvaluated();
+    await fiche.expectCostContainmentNotRated();
   });
 });

--- a/e2e/tests/fiche-application.spec.ts
+++ b/e2e/tests/fiche-application.spec.ts
@@ -156,4 +156,19 @@ test.describe("Fiche application", () => {
     await fiche.open(app!.id, "tab-infos");
     await fiche.expectCostContainmentLabel();
   });
+
+  test("FIC-16 - onglet Informations générales : un score non évalué affiche « Non évalué »", async ({
+    page,
+    data,
+  }) => {
+    const app = await data.seedTechnicalDebtWithoutCost();
+    test.skip(
+      !app,
+      "Impossible de garantir une application avec dette technique partielle",
+    );
+
+    const fiche = new ApplicationPage(page);
+    await fiche.open(app!.id, "tab-infos");
+    await fiche.expectCostContainmentNotEvaluated();
+  });
 });

--- a/e2e/tests/fiche-application.spec.ts
+++ b/e2e/tests/fiche-application.spec.ts
@@ -141,4 +141,19 @@ test.describe("Fiche application", () => {
     await fiche.open(app!.id, "tab-modifications");
     await fiche.expectModificationsTabLoaded();
   });
+
+  test("FIC-15 - onglet Informations générales : libellé « Maîtrise des coûts » (dette technique)", async ({
+    page,
+    data,
+  }) => {
+    const app = await data.applicationWithTechnicalDebt();
+    test.skip(
+      !app,
+      "Impossible de garantir une application avec dette technique",
+    );
+
+    const fiche = new ApplicationPage(page);
+    await fiche.open(app!.id, "tab-infos");
+    await fiche.expectCostContainmentLabel();
+  });
 });

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -5814,22 +5814,22 @@ components:
       properties:
         technicalMaturity:
           type: number
-          minimum: 0
+          minimum: 1
           maximum: 5
           example: 3.2
-          description: Technical maturity score (0-5)
+          description: Technical maturity score (1-5). Omit / null = not evaluated.
         businessMaturity:
           type: number
-          minimum: 0
+          minimum: 1
           maximum: 5
           example: 4.5
-          description: Business maturity score (0-5)
+          description: Business maturity score (1-5). Omit / null = not evaluated.
         costContainment:
           type: number
-          minimum: 0
+          minimum: 1
           maximum: 5
           example: 2.75
-          description: Cost containment score (0-5)
+          description: Cost containment score (1-5). Omit / null = not evaluated.
         millesime:
           type: number
           minimum: 2000
@@ -7835,22 +7835,22 @@ components:
       properties:
         technicalMaturity:
           type: number
-          minimum: 0
+          minimum: 1
           maximum: 5
           example: 3.2
-          description: Technical maturity score (0-5)
+          description: Technical maturity score (1-5). Omit / null = not evaluated.
         businessMaturity:
           type: number
-          minimum: 0
+          minimum: 1
           maximum: 5
           example: 4.5
-          description: Business maturity score (0-5)
+          description: Business maturity score (1-5). Omit / null = not evaluated.
         costContainment:
           type: number
-          minimum: 0
+          minimum: 1
           maximum: 5
           example: 2.75
-          description: Cost containment score (0-5)
+          description: Cost containment score (1-5). Omit / null = not evaluated.
         millesime:
           type: number
           minimum: 2000

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -5824,12 +5824,12 @@ components:
           maximum: 5
           example: 4.5
           description: Business maturity score (0-5)
-        costMaturity:
+        costContainment:
           type: number
           minimum: 0
           maximum: 5
           example: 2.75
-          description: Cost maturity score (0-5)
+          description: Cost containment score (0-5)
         millesime:
           type: number
           minimum: 2000
@@ -7845,12 +7845,12 @@ components:
           maximum: 5
           example: 4.5
           description: Business maturity score (0-5)
-        costMaturity:
+        costContainment:
           type: number
           minimum: 0
           maximum: 5
           example: 2.75
-          description: Cost maturity score (0-5)
+          description: Cost containment score (0-5)
         millesime:
           type: number
           minimum: 2000

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -5817,19 +5817,19 @@ components:
           minimum: 1
           maximum: 5
           example: 3.2
-          description: Technical maturity score (1-5). Omit / null = not evaluated.
+          description: Technical maturity score (1-5). Omit / null = not rated.
         businessMaturity:
           type: number
           minimum: 1
           maximum: 5
           example: 4.5
-          description: Business maturity score (1-5). Omit / null = not evaluated.
+          description: Business maturity score (1-5). Omit / null = not rated.
         costContainment:
           type: number
           minimum: 1
           maximum: 5
           example: 2.75
-          description: Cost containment score (1-5). Omit / null = not evaluated.
+          description: Cost containment score (1-5). Omit / null = not rated.
         millesime:
           type: number
           minimum: 2000
@@ -7838,19 +7838,19 @@ components:
           minimum: 1
           maximum: 5
           example: 3.2
-          description: Technical maturity score (1-5). Omit / null = not evaluated.
+          description: Technical maturity score (1-5). Omit / null = not rated.
         businessMaturity:
           type: number
           minimum: 1
           maximum: 5
           example: 4.5
-          description: Business maturity score (1-5). Omit / null = not evaluated.
+          description: Business maturity score (1-5). Omit / null = not rated.
         costContainment:
           type: number
           minimum: 1
           maximum: 5
           example: 2.75
-          description: Cost containment score (1-5). Omit / null = not evaluated.
+          description: Cost containment score (1-5). Omit / null = not rated.
         millesime:
           type: number
           minimum: 2000

--- a/frontend/src/chart/time-chart.builder.ts
+++ b/frontend/src/chart/time-chart.builder.ts
@@ -251,7 +251,7 @@ export class TimeChartBuilder {
     return this;
   }
 
-  /** Barre de dégradé couleur MCO en bas à droite (jaune → rouge, valeurs 0-5) */
+  /** Barre de dégradé couleur MCO en bas à droite (jaune → rouge, valeurs 1-5) */
   drawColorLegend(): this {
     const { color } = this.scales;
     const { plotWidth, plotHeight } = this.layout;
@@ -270,7 +270,7 @@ export class TimeChartBuilder {
       .attr("y1", "0%")
       .attr("y2", "0%");
 
-    gradient.append("stop").attr("offset", "0%").attr("stop-color", color(0));
+    gradient.append("stop").attr("offset", "0%").attr("stop-color", color(1));
     gradient.append("stop").attr("offset", "100%").attr("stop-color", color(5));
 
     legend
@@ -282,7 +282,7 @@ export class TimeChartBuilder {
       .attr("ry", 2);
 
     const legendAxis = d3
-      .axisBottom(d3.scaleLinear().domain([0, 5]).range([0, legendWidth]))
+      .axisBottom(d3.scaleLinear().domain([1, 5]).range([0, legendWidth]))
       .ticks(5)
       .tickFormat((d) => `${d}`)
       .tickSize(legendHeight);

--- a/frontend/src/chart/time-chart.builder.ts
+++ b/frontend/src/chart/time-chart.builder.ts
@@ -219,8 +219,8 @@ export class TimeChartBuilder {
       .append("circle")
       .attr("cx", (d) => x(d.technicalDebtInfo?.businessMaturity ?? 0))
       .attr("cy", (d) => y(d.technicalDebtInfo?.technicalMaturity ?? 0))
-      .attr("r", (d) => radius(d.technicalDebtInfo?.costMaturity ?? 0))
-      .attr("fill", (d) => color(d.technicalDebtInfo?.costMaturity ?? 0))
+      .attr("r", (d) => radius(d.technicalDebtInfo?.costContainment ?? 0))
+      .attr("fill", (d) => color(d.technicalDebtInfo?.costContainment ?? 0))
       .attr("opacity", 0.9)
       .attr("stroke", "#9F0126")
       .attr("stroke-width", 0.6)
@@ -235,7 +235,7 @@ export class TimeChartBuilder {
               `${shortNameHtml}<br/>` +
               `Technique: ${d.technicalDebtInfo?.technicalMaturity ?? "-"}<br/>` +
               `Metier: ${d.technicalDebtInfo?.businessMaturity ?? "-"}<br/>` +
-              `Coût MCO: ${d.technicalDebtInfo?.costMaturity ?? "-"}`,
+              `Coût MCO: ${d.technicalDebtInfo?.costContainment ?? "-"}`,
           );
       })
       .on("mousemove", (event) => {

--- a/frontend/src/components/ApplicationTableView.vue
+++ b/frontend/src/components/ApplicationTableView.vue
@@ -84,7 +84,7 @@ const applications = computed(() =>
       statusDisplay: formatStatus(app.currentStatus?.status),
       technicalMaturity: app.technicalDebtInfo?.technicalMaturity,
       businessMaturity: app.technicalDebtInfo?.businessMaturity,
-      costMaturity: app.technicalDebtInfo?.costMaturity,
+      costContainment: app.technicalDebtInfo?.costContainment,
     };
   }),
 );

--- a/frontend/src/components/technical-debt/TechnicalDebtCard.vue
+++ b/frontend/src/components/technical-debt/TechnicalDebtCard.vue
@@ -37,7 +37,7 @@ function getMaturityBadgeType(value: number): "error" | "warning" | "info" | "su
 const maturityFields = computed(() => [
   { key: "technicalMaturity", label: "Maturité technique", value: props.technicalDebtInfo?.technicalMaturity ?? 0 },
   { key: "businessMaturity", label: "Maturité métier", value: props.technicalDebtInfo?.businessMaturity ?? 0 },
-  { key: "costMaturity", label: "Maturité des coûts", value: props.technicalDebtInfo?.costMaturity ?? 0 },
+  { key: "costContainment", label: "Maîtrise des coûts", value: props.technicalDebtInfo?.costContainment ?? 0 },
 ]);
 </script>
 

--- a/frontend/src/components/technical-debt/TechnicalDebtCard.vue
+++ b/frontend/src/components/technical-debt/TechnicalDebtCard.vue
@@ -13,8 +13,9 @@ defineEmits<{
   edit: [];
 }>();
 
+const NOT_EVALUATED_LABEL = "Non évalué";
+
 const maturityLabels: Record<number, string> = {
-  0: "Très faible",
   1: "Faible",
   2: "Moyen",
   3: "Correct",
@@ -23,11 +24,17 @@ const maturityLabels: Record<number, string> = {
 };
 
 function getMaturityLabel(value: number): string {
-  const rounded = Math.min(5, Math.max(0, Math.round(value)));
+  const rounded = Math.min(5, Math.max(1, Math.round(value)));
   return maturityLabels[rounded] ?? "Non défini";
 }
 
-function getMaturityBadgeType(value: number): "error" | "warning" | "info" | "success" {
+// `null` = non évalué (les scores < 1 ont été migrés vers `null`, cf. ticket #1900).
+function getBadgeLabel(value: number | null): string {
+  return value == null ? NOT_EVALUATED_LABEL : `${value}/5 - ${getMaturityLabel(value)}`;
+}
+
+function getMaturityBadgeType(value: number | null): "error" | "warning" | "info" | "success" | undefined {
+  if (value == null) return undefined;
   if (value <= 1) return "error";
   if (value <= 2) return "warning";
   if (value <= 3) return "info";
@@ -35,9 +42,9 @@ function getMaturityBadgeType(value: number): "error" | "warning" | "info" | "su
 }
 
 const maturityFields = computed(() => [
-  { key: "technicalMaturity", label: "Maturité technique", value: props.technicalDebtInfo?.technicalMaturity ?? 0 },
-  { key: "businessMaturity", label: "Maturité métier", value: props.technicalDebtInfo?.businessMaturity ?? 0 },
-  { key: "costContainment", label: "Maîtrise des coûts", value: props.technicalDebtInfo?.costContainment ?? 0 },
+  { key: "technicalMaturity", label: "Maturité technique", value: props.technicalDebtInfo?.technicalMaturity ?? null },
+  { key: "businessMaturity", label: "Maturité métier", value: props.technicalDebtInfo?.businessMaturity ?? null },
+  { key: "costContainment", label: "Maîtrise des coûts", value: props.technicalDebtInfo?.costContainment ?? null },
 ]);
 </script>
 
@@ -69,7 +76,7 @@ const maturityFields = computed(() => [
                 {{ field.label }}
               </p>
               <DsfrBadge
-                :label="`${field.value}/5 - ${getMaturityLabel(field.value)}`"
+                :label="getBadgeLabel(field.value)"
                 :type="getMaturityBadgeType(field.value)"
                 :small="small"
                 :data-testid="`${field.key}-badge`"

--- a/frontend/src/components/technical-debt/TechnicalDebtCard.vue
+++ b/frontend/src/components/technical-debt/TechnicalDebtCard.vue
@@ -13,7 +13,7 @@ defineEmits<{
   edit: [];
 }>();
 
-const NOT_EVALUATED_LABEL = "Non évalué";
+const NOT_RATED_LABEL = "Non notée";
 
 const maturityLabels: Record<number, string> = {
   1: "Faible",
@@ -28,9 +28,9 @@ function getMaturityLabel(value: number): string {
   return maturityLabels[rounded] ?? "Non défini";
 }
 
-// `null` = non évalué (les scores < 1 ont été migrés vers `null`, cf. ticket #1900).
+// `null` = non noté (les scores < 1 ont été migrés vers `null`, cf. ticket #1900).
 function getBadgeLabel(value: number | null): string {
-  return value == null ? NOT_EVALUATED_LABEL : `${value}/5 - ${getMaturityLabel(value)}`;
+  return value == null ? NOT_RATED_LABEL : `${value}/5 - ${getMaturityLabel(value)}`;
 }
 
 function getMaturityBadgeType(value: number | null): "error" | "warning" | "info" | "success" | undefined {

--- a/frontend/src/components/technical-debt/TechnicalDebtModal.vue
+++ b/frontend/src/components/technical-debt/TechnicalDebtModal.vue
@@ -18,8 +18,9 @@ const toaster = useToasterStore();
 const isSubmitting = ref(false);
 const isEditMode = computed(() => !!props.initialData);
 
+// Champ vide = score non évalué (`null`). Une valeur saisie doit être comprise entre 1 et 5.
 function toInputValue(value: number | string | null | undefined): string {
-  if (value == null) return "0";
+  if (value == null) return "";
   return String(value);
 }
 
@@ -29,14 +30,20 @@ const form = ref({
   costContainment: toInputValue(props.initialData?.costContainment),
 });
 
-function toNumberOrZero(value: string): number {
-  const parsed = Number(value);
-  return Number.isNaN(parsed) ? 0 : parsed;
+// Renvoie le score saisi (1-5) ou `undefined` si le champ est vide (non évalué).
+function toScoreOrUndefined(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (trimmed === "") return undefined;
+  const parsed = Number(trimmed);
+  return Number.isNaN(parsed) ? undefined : parsed;
 }
 
+// Un champ est valide s'il est vide (non évalué) ou contient une valeur entre 1 et 5.
 function isValidScore(value: string): boolean {
-  const parsed = Number(value);
-  return !Number.isNaN(parsed) && parsed >= 0 && parsed <= 5;
+  const trimmed = value.trim();
+  if (trimmed === "") return true;
+  const parsed = Number(trimmed);
+  return !Number.isNaN(parsed) && parsed >= 1 && parsed <= 5;
 }
 
 async function handleSubmit() {
@@ -48,14 +55,14 @@ async function handleSubmit() {
     !isValidScore(form.value.costContainment)
   ) {
     isSubmitting.value = false;
-    toaster.addErrorMessage("Les valeurs de maturité doivent être comprises entre 0 et 5.");
+    toaster.addErrorMessage("Les valeurs de maturité doivent être comprises entre 1 et 5 (ou laissées vides).");
     return;
   }
 
   const body: CreateTechnicalDebtInfoDto = {
-    technicalMaturity: toNumberOrZero(form.value.technicalMaturity),
-    businessMaturity: toNumberOrZero(form.value.businessMaturity),
-    costContainment: toNumberOrZero(form.value.costContainment),
+    technicalMaturity: toScoreOrUndefined(form.value.technicalMaturity),
+    businessMaturity: toScoreOrUndefined(form.value.businessMaturity),
+    costContainment: toScoreOrUndefined(form.value.costContainment),
   };
 
   const response = await api.applicationTechnicalDebtInfoControllerCreate({ path: { applicationId: props.applicationId }, body });
@@ -87,10 +94,10 @@ async function handleSubmit() {
           label="Maturité technique"
           label-visible
           type="number"
-          min="0"
+          min="1"
           max="5"
           step=".01"
-          hint="Entre 0 et 5, avec 2 décimales (ex : 1,20)"
+          hint="Entre 1 et 5 (laisser vide si non évalué)"
           class="fr-mb-3w"
           data-testid="technical-maturity-select"
         />
@@ -99,10 +106,10 @@ async function handleSubmit() {
           label="Maturité métier"
           label-visible
           type="number"
-          min="0"
+          min="1"
           max="5"
           step=".01"
-          hint="Entre 0 et 5, avec 2 décimales (ex : 1,20)"
+          hint="Entre 1 et 5 (laisser vide si non évalué)"
           class="fr-mb-3w"
           data-testid="business-maturity-select"
         />
@@ -111,10 +118,10 @@ async function handleSubmit() {
           label="Maîtrise des coûts"
           label-visible
           type="number"
-          min="0"
+          min="1"
           max="5"
           step=".01"
-          hint="Entre 0 et 5, avec 2 décimales (ex : 1,20)"
+          hint="Entre 1 et 5 (laisser vide si non évalué)"
           class="fr-mb-3w"
           data-testid="cost-containment-select"
         />

--- a/frontend/src/components/technical-debt/TechnicalDebtModal.vue
+++ b/frontend/src/components/technical-debt/TechnicalDebtModal.vue
@@ -26,7 +26,7 @@ function toInputValue(value: number | string | null | undefined): string {
 const form = ref({
   technicalMaturity: toInputValue(props.initialData?.technicalMaturity),
   businessMaturity: toInputValue(props.initialData?.businessMaturity),
-  costMaturity: toInputValue(props.initialData?.costMaturity),
+  costContainment: toInputValue(props.initialData?.costContainment),
 });
 
 function toNumberOrZero(value: string): number {
@@ -42,7 +42,11 @@ function isValidScore(value: string): boolean {
 async function handleSubmit() {
   isSubmitting.value = true;
 
-  if (!isValidScore(form.value.technicalMaturity) || !isValidScore(form.value.businessMaturity) || !isValidScore(form.value.costMaturity)) {
+  if (
+    !isValidScore(form.value.technicalMaturity) ||
+    !isValidScore(form.value.businessMaturity) ||
+    !isValidScore(form.value.costContainment)
+  ) {
     isSubmitting.value = false;
     toaster.addErrorMessage("Les valeurs de maturité doivent être comprises entre 0 et 5.");
     return;
@@ -51,7 +55,7 @@ async function handleSubmit() {
   const body: CreateTechnicalDebtInfoDto = {
     technicalMaturity: toNumberOrZero(form.value.technicalMaturity),
     businessMaturity: toNumberOrZero(form.value.businessMaturity),
-    costMaturity: toNumberOrZero(form.value.costMaturity),
+    costContainment: toNumberOrZero(form.value.costContainment),
   };
 
   const response = await api.applicationTechnicalDebtInfoControllerCreate({ path: { applicationId: props.applicationId }, body });
@@ -103,8 +107,8 @@ async function handleSubmit() {
           data-testid="business-maturity-select"
         />
         <DsfrInput
-          v-model="form.costMaturity"
-          label="Maturité des coûts"
+          v-model="form.costContainment"
+          label="Maîtrise des coûts"
           label-visible
           type="number"
           min="0"
@@ -112,7 +116,7 @@ async function handleSubmit() {
           step=".01"
           hint="Entre 0 et 5, avec 2 décimales (ex : 1,20)"
           class="fr-mb-3w"
-          data-testid="cost-maturity-select"
+          data-testid="cost-containment-select"
         />
       </div>
       <div class="fr-btns-group fr-btns-group--right fr-mt-4w">

--- a/frontend/src/components/technical-debt/TechnicalDebtModal.vue
+++ b/frontend/src/components/technical-debt/TechnicalDebtModal.vue
@@ -18,7 +18,7 @@ const toaster = useToasterStore();
 const isSubmitting = ref(false);
 const isEditMode = computed(() => !!props.initialData);
 
-// Champ vide = score non évalué (`null`). Une valeur saisie doit être comprise entre 1 et 5.
+// Champ vide = score non noté (`null`). Une valeur saisie doit être comprise entre 1 et 5.
 function toInputValue(value: number | string | null | undefined): string {
   if (value == null) return "";
   return String(value);
@@ -30,7 +30,7 @@ const form = ref({
   costContainment: toInputValue(props.initialData?.costContainment),
 });
 
-// Renvoie le score saisi (1-5) ou `undefined` si le champ est vide (non évalué).
+// Renvoie le score saisi (1-5) ou `undefined` si le champ est vide (non noté).
 function toScoreOrUndefined(value: string): number | undefined {
   const trimmed = value.trim();
   if (trimmed === "") return undefined;
@@ -38,7 +38,7 @@ function toScoreOrUndefined(value: string): number | undefined {
   return Number.isNaN(parsed) ? undefined : parsed;
 }
 
-// Un champ est valide s'il est vide (non évalué) ou contient une valeur entre 1 et 5.
+// Un champ est valide s'il est vide (non noté) ou contient une valeur entre 1 et 5.
 function isValidScore(value: string): boolean {
   const trimmed = value.trim();
   if (trimmed === "") return true;
@@ -97,7 +97,7 @@ async function handleSubmit() {
           min="1"
           max="5"
           step=".01"
-          hint="Entre 1 et 5 (laisser vide si non évalué)"
+          hint="Entre 1 et 5 (laisser vide si non noté)"
           class="fr-mb-3w"
           data-testid="technical-maturity-select"
         />
@@ -109,7 +109,7 @@ async function handleSubmit() {
           min="1"
           max="5"
           step=".01"
-          hint="Entre 1 et 5 (laisser vide si non évalué)"
+          hint="Entre 1 et 5 (laisser vide si non noté)"
           class="fr-mb-3w"
           data-testid="business-maturity-select"
         />
@@ -121,7 +121,7 @@ async function handleSubmit() {
           min="1"
           max="5"
           step=".01"
-          hint="Entre 1 et 5 (laisser vide si non évalué)"
+          hint="Entre 1 et 5 (laisser vide si non noté)"
           class="fr-mb-3w"
           data-testid="cost-containment-select"
         />

--- a/frontend/src/composables/use-technical-debt-chart.ts
+++ b/frontend/src/composables/use-technical-debt-chart.ts
@@ -45,8 +45,8 @@ export function useTechnicalDebtChart(props: { data: TechnicalDebtPoint[]; heigh
       radius: d3.scaleLinear().domain([1, 5]).range([4, 12]),
     };
 
-    // Un point n'apparaît que si ses trois maturités sont évaluées (≥ 1) : les valeurs
-    // non évaluées (`null`, issues de la migration des valeurs < 1) sont exclues (ticket #1900).
+    // Un point n'apparaît que si ses trois maturités sont notées (≥ 1) : les valeurs
+    // non notées (`null`, issues de la migration des valeurs < 1) sont exclues (ticket #1900).
     const points = props.data.filter((d) => {
       const t = d.technicalDebtInfo;
       return t != null && t.technicalMaturity != null && t.businessMaturity != null && t.costContainment != null;

--- a/frontend/src/composables/use-technical-debt-chart.ts
+++ b/frontend/src/composables/use-technical-debt-chart.ts
@@ -39,13 +39,20 @@ export function useTechnicalDebtChart(props: { data: TechnicalDebtPoint[]; heigh
     const g = svg.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
 
     const scales: ChartScales = {
-      x: d3.scaleLinear().domain([0, 5]).range([0, plotWidth]),
-      y: d3.scaleLinear().domain([0, 5]).range([plotHeight, 0]),
-      color: d3.scaleSequential(d3.interpolateYlOrRd).domain([0, 5]),
-      radius: d3.scaleLinear().domain([0, 5]).range([4, 12]),
+      x: d3.scaleLinear().domain([1, 5]).range([0, plotWidth]),
+      y: d3.scaleLinear().domain([1, 5]).range([plotHeight, 0]),
+      color: d3.scaleSequential(d3.interpolateYlOrRd).domain([1, 5]),
+      radius: d3.scaleLinear().domain([1, 5]).range([4, 12]),
     };
 
-    new TimeChartBuilder(g, svg, root, scales, { plotWidth, plotHeight, margin }, props.data)
+    // Un point n'apparaît que si ses trois maturités sont évaluées (≥ 1) : les valeurs
+    // non évaluées (`null`, issues de la migration des valeurs < 1) sont exclues (ticket #1900).
+    const points = props.data.filter((d) => {
+      const t = d.technicalDebtInfo;
+      return t != null && t.technicalMaturity != null && t.businessMaturity != null && t.costContainment != null;
+    });
+
+    new TimeChartBuilder(g, svg, root, scales, { plotWidth, plotHeight, margin }, points)
       .drawTitle()
       .drawAxes()
       .drawQuadrants()

--- a/frontend/src/types/columns.ts
+++ b/frontend/src/types/columns.ts
@@ -204,7 +204,7 @@ export const AVAILABLE_COLUMNS: ColumnConfig[] = [
     alwaysAvailable: true,
   },
   {
-    field: "costMaturity",
+    field: "costContainment",
     header: "Coûts",
     sortable: false,
     defaultWidth: "120px",

--- a/frontend/src/utils/get-time-quadrant.ts
+++ b/frontend/src/utils/get-time-quadrant.ts
@@ -1,4 +1,5 @@
-export const TRESHOLD_TIME_MATURITY = 2.5;
+// Échelle de maturité 1-5 ; les axes du diagramme TIME se croisent à 3 (cf. ticket #1900).
+export const TRESHOLD_TIME_MATURITY = 3;
 export type TimeQuadrant = "Tolerate" | "Invest" | "Migrate" | "Eliminate";
 export function getTimeQuadrant(technicalMaturity: number, businessMaturity: number) {
   const threshold = TRESHOLD_TIME_MATURITY;

--- a/qa/protocoles/fiche-application.md
+++ b/qa/protocoles/fiche-application.md
@@ -88,3 +88,8 @@
 
 - **Action** : onglet `tab-modifications`.
 - **Résultat attendu** : l'historique d'audit (qui/quoi/quand) de l'application est affiché.
+
+### FIC-15 — Onglet Informations générales : libellé « Maîtrise des coûts » ✅
+
+- **Action** : sur une application disposant d'une évaluation de dette technique, ouvrir l'onglet `tab-infos` et consulter la carte « Dette technique ».
+- **Résultat attendu** : la troisième dimension est libellée **« Maîtrise des coûts »** (renommée depuis « Maturité des coûts », cf. ticket #1900) ; l'ancien libellé n'apparaît plus.

--- a/qa/protocoles/fiche-application.md
+++ b/qa/protocoles/fiche-application.md
@@ -94,7 +94,7 @@
 - **Action** : sur une application disposant d'une évaluation de dette technique, ouvrir l'onglet `tab-infos` et consulter la carte « Dette technique ».
 - **Résultat attendu** : la troisième dimension est libellée **« Maîtrise des coûts »** (renommée depuis « Maturité des coûts », cf. ticket #1900) ; l'ancien libellé n'apparaît plus.
 
-### FIC-16 — Onglet Informations générales : score non évalué ✅
+### FIC-16 — Onglet Informations générales : score non noté ✅
 
 - **Action** : sur une application dont un axe de maturité n'est pas renseigné (`null`, p. ex. maîtrise des coûts), ouvrir l'onglet `tab-infos` et consulter la carte « Dette technique ».
-- **Résultat attendu** : le badge de l'axe affiche **« Non évalué »** (et non « 0/5 »). L'échelle est désormais 1-5 ; toute valeur < 1 est traitée comme non évaluée (`null`), cf. ticket #1900.
+- **Résultat attendu** : le badge de l'axe affiche **« Non notée »** (et non « 0/5 »). L'échelle est désormais 1-5 ; toute valeur < 1 est traitée comme non notée (`null`), cf. ticket #1900.

--- a/qa/protocoles/fiche-application.md
+++ b/qa/protocoles/fiche-application.md
@@ -93,3 +93,8 @@
 
 - **Action** : sur une application disposant d'une évaluation de dette technique, ouvrir l'onglet `tab-infos` et consulter la carte « Dette technique ».
 - **Résultat attendu** : la troisième dimension est libellée **« Maîtrise des coûts »** (renommée depuis « Maturité des coûts », cf. ticket #1900) ; l'ancien libellé n'apparaît plus.
+
+### FIC-16 — Onglet Informations générales : score non évalué ✅
+
+- **Action** : sur une application dont un axe de maturité n'est pas renseigné (`null`, p. ex. maîtrise des coûts), ouvrir l'onglet `tab-infos` et consulter la carte « Dette technique ».
+- **Résultat attendu** : le badge de l'axe affiche **« Non évalué »** (et non « 0/5 »). L'échelle est désormais 1-5 ; toute valeur < 1 est traitée comme non évaluée (`null`), cf. ticket #1900.

--- a/qa/protocoles/time.md
+++ b/qa/protocoles/time.md
@@ -24,7 +24,7 @@
 - **Résultat attendu** : le graphique SVG de maturité TIME s'affiche, ou l'état vide « Aucune donnée
   TIME disponible » si l'utilisateur n'a pas de données autorisées.
 - **Note (ticket #1900)** : échelle de maturité 1-5, axes du quadrant qui se croisent à **3** ; seuls
-  les points dont les trois maturités sont évaluées (≥ 1) sont tracés — un score non évalué (`null`,
+  les points dont les trois maturités sont notées (≥ 1) sont tracés — un score non noté (`null`,
   issu de la migration des valeurs < 1) exclut le point du diagramme.
 
 ### TIM-03 — La sidebar de filtres est présente ✅

--- a/qa/protocoles/time.md
+++ b/qa/protocoles/time.md
@@ -23,6 +23,9 @@
 - **Action** : ouvrir `/time` et attendre la fin du chargement.
 - **Résultat attendu** : le graphique SVG de maturité TIME s'affiche, ou l'état vide « Aucune donnée
   TIME disponible » si l'utilisateur n'a pas de données autorisées.
+- **Note (ticket #1900)** : échelle de maturité 1-5, axes du quadrant qui se croisent à **3** ; seuls
+  les points dont les trois maturités sont évaluées (≥ 1) sont tracés — un score non évalué (`null`,
+  issu de la migration des valeurs < 1) exclut le point du diagramme.
 
 ### TIM-03 — La sidebar de filtres est présente ✅
 


### PR DESCRIPTION
Closes #1900.

## Contexte
Au-delà du libellé, le commentaire du ticket (échange @Code-Oz / @mogador26) précise le comportement attendu pour la dette technique (MDIT) :
- renommer `costMaturity` → `costContainment` ;
- libellé « Maturité des coûts » → « Maîtrise des coûts » ;
- **échelle 1-5**, axes du diagramme TIME qui **se croisent à 3** ;
- **valeurs < 1 migrées vers `null`** (non évalué) ;
- un point **non évalué (`null`) n'apparaît pas** dans le diagramme TIME.

## Changements
### Backend
- `TechnicalDebtInfo` : `technicalMaturity`, `businessMaturity`, `costContainment` deviennent **nullables**, sans défaut 0.
- Migrations : rename de colonne **+** drop default/not-null **+** `UPDATE … = NULL WHERE … < 1` sur les 3 axes (préserve les données).
- DTO : validation **1-5** (`@Min(1)`), champ omis/`null` = non évalué.

### Frontend
- `TechnicalDebtCard` : libellé « Maîtrise des coûts » ; un score `null` affiche **« Non évalué »** (au lieu de « 0/5 »).
- `TechnicalDebtModal` : saisie 1-5, champ vide = non évalué (`null`).
- Diagramme TIME : domaines `[1,5]`, seuil des quadrants à **3** (`get-time-quadrant`), et **filtrage** des points dont une maturité est `null` (`use-technical-debt-chart`).
- Client API et `swagger.yaml` régénérés.

### Tests de non-régression (e2e, POM strict)
- **FIC-15** : la carte affiche « Maîtrise des coûts » (et plus « Maturité des coûts »).
- **FIC-16** : un axe non évalué (`null`) affiche **« Non évalué »**.
- Helpers datafeature (`applicationWithTechnicalDebt`, `seedTechnicalDebtWithoutCost`), méthodes POM, et blocs de protocole `fiche-application.md` / `time.md`.

## Vérifications
- `nest build` ✅ · `type-check` frontend ✅ · `type-check` e2e ✅
- Jest `technical-debt-info` : **11/11** ✅
- Playwright **FIC-15/16** + **TIM-01→06** chromium/firefox/webkit ✅

> ⚠️ Déploiement : migrations de colonne (rename + nullable + migration <1→null) → `prisma migrate deploy` + régénération du client Prisma.