### PR TITLE
feat: restrict DIMA/PDMA duration to allowed values (#1901)

### DIFF
--- a/backend/src/compliances/constants/compliance-metadata.constants.ts
+++ b/backend/src/compliances/constants/compliance-metadata.constants.ts
@@ -1,3 +1,15 @@
+/**
+ * Valeurs autorisées (en heures) pour la durée DIMA (Délai d'Indisponibilité Maximale Admissible),
+ * du plus permissif au plus strict (cf. ticket #1901).
+ */
+export const DIMA_DURATION_HOURS_VALUES = [96, 72, 48, 24, 4, 1, 0] as const;
+
+/**
+ * Valeurs autorisées (en heures) pour la durée PDMA (Perte de Données Maximale Admissible),
+ * du plus permissif au plus strict (cf. ticket #1901).
+ */
+export const PDMA_DURATION_HOURS_VALUES = [48, 24, 2, 0] as const;
+
 /** Libellés FR des champs de conformité, utilisés pour tracer les métadonnées de modification. */
 export const COMPLIANCE_METADATA_FIELDS = {
   dima_duration_hours: "durée DIMA (heures)",

--- a/backend/src/compliances/dto/create-compliance.dto.ts
+++ b/backend/src/compliances/dto/create-compliance.dto.ts
@@ -3,21 +3,28 @@ import {
   IsBoolean,
   IsDateString,
   IsEnum,
+  IsIn,
   IsInt,
   IsOptional,
   IsString,
 } from "class-validator";
 import { BackupStorage, HomologationStatus, TestResult } from "src/enum";
+import {
+  DIMA_DURATION_HOURS_VALUES,
+  PDMA_DURATION_HOURS_VALUES,
+} from "../constants/compliance-metadata.constants";
 
 export class CreateComplianceDto {
   // DIMA specific fields
   @ApiProperty({
     example: 4,
-    description: "DIMA duration in hours (1, 4, 8, 12, 24, 48, 72)",
+    description: "DIMA duration in hours (one of 96, 72, 48, 24, 4, 1, 0)",
     required: false,
+    enum: DIMA_DURATION_HOURS_VALUES,
   })
   @IsOptional()
   @IsInt()
+  @IsIn(DIMA_DURATION_HOURS_VALUES)
   dima_duration_hours?: number;
 
   @ApiProperty({
@@ -85,12 +92,14 @@ export class CreateComplianceDto {
 
   // PDMA specific fields
   @ApiProperty({
-    example: 8,
-    description: "PDMA duration in hours (1, 4, 8, 12, 24, 48, 72)",
+    example: 24,
+    description: "PDMA duration in hours (one of 48, 24, 2, 0)",
     required: false,
+    enum: PDMA_DURATION_HOURS_VALUES,
   })
   @IsOptional()
   @IsInt()
+  @IsIn(PDMA_DURATION_HOURS_VALUES)
   pdma_duration_hours?: number;
 
   @ApiProperty({

--- a/backend/src/import/processors/compliances-sheet.processor.spec.ts
+++ b/backend/src/import/processors/compliances-sheet.processor.spec.ts
@@ -55,7 +55,7 @@ describe("CompliancesSheetProcessor", () => {
           "DSFR Implémenté",
           "DIMA HNO",
         ],
-        [["app-1", 5, "Oui", "Non"]],
+        [["app-1", 4, "Oui", "Non"]],
       ),
       requestor,
       report,
@@ -68,7 +68,7 @@ describe("CompliancesSheetProcessor", () => {
     ).toHaveBeenCalledWith(
       "app-1",
       expect.objectContaining({
-        dima_duration_hours: 5,
+        dima_duration_hours: 4,
         dsfr_implemented: true,
         dima_is_hno: false,
       }),

--- a/backend/tests/compliances.e2e-spec.ts
+++ b/backend/tests/compliances.e2e-spec.ts
@@ -89,6 +89,34 @@ describe("Compliances", () => {
     expect(response.body.rgpd_has_aipd).toEqual(true);
     expect(response.body.rgpd_dpo_name).toEqual("Jean Dupont");
   });
+
+  // Ticket #1901 : la durée DIMA/PDMA est restreinte à une liste de valeurs autorisées.
+  it("/POST applications/:applicationId/compliances - should reject an out-of-range DIMA duration", async () => {
+    await request(app().getHttpServer())
+      .post(`/applications/${application.id}/compliances`)
+      .send({ dima_duration_hours: 5 })
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .expect(400);
+  });
+
+  it("/POST applications/:applicationId/compliances - should reject an out-of-range PDMA duration", async () => {
+    await request(app().getHttpServer())
+      .post(`/applications/${application.id}/compliances`)
+      .send({ pdma_duration_hours: 4 })
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .expect(400);
+  });
+
+  it("/POST applications/:applicationId/compliances - should accept the allowed DIMA/PDMA durations", async () => {
+    const response = await request(app().getHttpServer())
+      .post(`/applications/${application.id}/compliances`)
+      .send({ dima_duration_hours: 96, pdma_duration_hours: 48 })
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .expect(200);
+
+    expect(response.body.dima_duration_hours).toEqual(96);
+    expect(response.body.pdma_duration_hours).toEqual(48);
+  });
 });
 
 describe("application guard", () => {

--- a/backend/tests/fakers/compliance.faker.ts
+++ b/backend/tests/fakers/compliance.faker.ts
@@ -38,7 +38,7 @@ const complianceSeeds: ComplianceSeedData[] = [
   },
 
   {
-    pdma_duration_hours: 1,
+    pdma_duration_hours: 2,
     pdma_data_types: "Transactions critiques, journaux de securite",
     pdma_backup_frequency: "Horaire",
     pdma_backup_method: "Snapshots incrementaux",
@@ -48,7 +48,7 @@ const complianceSeeds: ComplianceSeedData[] = [
     pdma_restoration_manager: "Equipe Sauvegarde",
   },
   {
-    pdma_duration_hours: 4,
+    pdma_duration_hours: 24,
     pdma_data_types: "Documents metier et pieces jointes",
     pdma_backup_frequency: "Quotidienne",
     pdma_backup_method: "Sauvegarde complete nocturne",

--- a/e2e/pom/application.page.ts
+++ b/e2e/pom/application.page.ts
@@ -287,6 +287,27 @@ export class ApplicationPage extends BasePage {
     ).toBeDisabled();
   }
 
+  // --- Durées DIMA / PDMA : valeurs autorisées (#1901, CMP-05/06) ---
+  /**
+   * Ouvre l'édition d'un axe (par son libellé de ligne, p. ex. « DIMA ») et vérifie que la liste
+   * déroulante de durée propose exactement les valeurs autorisées (en heures), dans l'ordre attendu.
+   */
+  async expectComplianceDurationOptions(
+    rowLabel: string,
+    durationTestId: string,
+    expectedHours: number[],
+  ): Promise<void> {
+    await this.openComplianceEdit(rowLabel);
+    const values = await this.byTestId(durationTestId)
+      .locator("option")
+      .evaluateAll((els) =>
+        els
+          .map((el) => (el as HTMLOptionElement).value)
+          .filter((value) => value !== ""),
+      );
+    expect(values).toEqual(expectedHours.map(String));
+  }
+
   // --- Onglet Acteurs : ajout & import MAIA (#1825, MAI-*) ---
   /** Ouvre le formulaire d'ajout d'acteur depuis l'onglet Acteurs. */
   async openAddActorForm(): Promise<void> {

--- a/e2e/tests/conformites.spec.ts
+++ b/e2e/tests/conformites.spec.ts
@@ -91,4 +91,36 @@ test.describe("Conformités — éco-conception & homologation", () => {
       await ctx.close();
     }
   });
+
+  test("CMP-05 - DIMA : la liste de durée propose les valeurs autorisées (#1901)", async ({
+    page,
+    data,
+  }) => {
+    const app = await data.firstApplication();
+    test.skip(!app, "Aucune application dans le jeu de données");
+
+    const fiche = new ApplicationPage(page);
+    await fiche.open(app!.id, "tab-compliances");
+    await fiche.expectComplianceDurationOptions(
+      "DIMA",
+      "compliance-dima-duration",
+      [96, 72, 48, 24, 4, 1, 0],
+    );
+  });
+
+  test("CMP-06 - PDMA : la liste de durée propose les valeurs autorisées (#1901)", async ({
+    page,
+    data,
+  }) => {
+    const app = await data.firstApplication();
+    test.skip(!app, "Aucune application dans le jeu de données");
+
+    const fiche = new ApplicationPage(page);
+    await fiche.open(app!.id, "tab-compliances");
+    await fiche.expectComplianceDurationOptions(
+      "PDMA",
+      "compliance-pdma-duration",
+      [48, 24, 2, 0],
+    );
+  });
 });

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -7033,8 +7033,16 @@ components:
       properties:
         dima_duration_hours:
           type: number
+          enum: &a32
+            - 96
+            - 72
+            - 48
+            - 24
+            - 4
+            - 1
+            - 0
           example: 4
-          description: DIMA duration in hours (1, 4, 8, 12, 24, 48, 72)
+          description: DIMA duration in hours (one of 96, 72, 48, 24, 4, 1, 0)
         dima_is_hno:
           type: boolean
           example: true
@@ -7056,7 +7064,7 @@ components:
           example: 2023-01-01
           description: DIMA last test date
         dima_test_result:
-          enum: &a32
+          enum: &a33
             - OK
             - KO
           type: string
@@ -7067,8 +7075,13 @@ components:
           description: DIMA recovery manager
         pdma_duration_hours:
           type: number
-          example: 8
-          description: PDMA duration in hours (1, 4, 8, 12, 24, 48, 72)
+          enum: &a34
+            - 48
+            - 24
+            - 2
+            - 0
+          example: 24
+          description: PDMA duration in hours (one of 48, 24, 2, 0)
         pdma_data_types:
           type: string
           example: Transactions, logs, fichiers utilisateur
@@ -7082,7 +7095,7 @@ components:
           example: Snapshot, backup incrémental
           description: PDMA backup method used
         pdma_backup_storage:
-          enum: &a33
+          enum: &a35
             - S3
             - LOCAL
             - EXTERNE
@@ -7093,7 +7106,7 @@ components:
           example: 2023-01-01
           description: PDMA last test date
         pdma_test_result:
-          enum: &a34
+          enum: &a36
             - OK
             - KO
           type: string
@@ -7103,7 +7116,7 @@ components:
           example: Marie Martin
           description: PDMA restoration manager
         homologation_status:
-          enum: &a35
+          enum: &a37
             - homologuee
             - en_cours
             - dispensee
@@ -7144,8 +7157,9 @@ components:
       properties:
         dima_duration_hours:
           type: number
+          enum: *a32
           example: 4
-          description: DIMA duration in hours (1, 4, 8, 12, 24, 48, 72)
+          description: DIMA duration in hours (one of 96, 72, 48, 24, 4, 1, 0)
         dima_is_hno:
           type: boolean
           example: true
@@ -7167,7 +7181,7 @@ components:
           example: 2023-01-01
           description: DIMA last test date
         dima_test_result:
-          enum: *a32
+          enum: *a33
           type: string
           description: DIMA test result
         dima_recovery_manager:
@@ -7176,8 +7190,9 @@ components:
           description: DIMA recovery manager
         pdma_duration_hours:
           type: number
-          example: 8
-          description: PDMA duration in hours (1, 4, 8, 12, 24, 48, 72)
+          enum: *a34
+          example: 24
+          description: PDMA duration in hours (one of 48, 24, 2, 0)
         pdma_data_types:
           type: string
           example: Transactions, logs, fichiers utilisateur
@@ -7191,7 +7206,7 @@ components:
           example: Snapshot, backup incrémental
           description: PDMA backup method used
         pdma_backup_storage:
-          enum: *a33
+          enum: *a35
           type: string
           description: PDMA backup storage
         pdma_last_test_date:
@@ -7199,7 +7214,7 @@ components:
           example: 2023-01-01
           description: PDMA last test date
         pdma_test_result:
-          enum: *a34
+          enum: *a36
           type: string
           description: PDMA test result
         pdma_restoration_manager:
@@ -7207,7 +7222,7 @@ components:
           example: Marie Martin
           description: PDMA restoration manager
         homologation_status:
-          enum: *a35
+          enum: *a37
           type: string
           description: Homologation status
         homologation_date_end:
@@ -7266,8 +7281,9 @@ components:
       properties:
         dima_duration_hours:
           type: number
+          enum: *a32
           example: 4
-          description: DIMA duration in hours (1, 4, 8, 12, 24, 48, 72)
+          description: DIMA duration in hours (one of 96, 72, 48, 24, 4, 1, 0)
         dima_is_hno:
           type: boolean
           example: true
@@ -7289,7 +7305,7 @@ components:
           example: 2023-01-01
           description: DIMA last test date
         dima_test_result:
-          enum: *a32
+          enum: *a33
           type: string
           description: DIMA test result
         dima_recovery_manager:
@@ -7298,8 +7314,9 @@ components:
           description: DIMA recovery manager
         pdma_duration_hours:
           type: number
-          example: 8
-          description: PDMA duration in hours (1, 4, 8, 12, 24, 48, 72)
+          enum: *a34
+          example: 24
+          description: PDMA duration in hours (one of 48, 24, 2, 0)
         pdma_data_types:
           type: string
           example: Transactions, logs, fichiers utilisateur
@@ -7313,7 +7330,7 @@ components:
           example: Snapshot, backup incrémental
           description: PDMA backup method used
         pdma_backup_storage:
-          enum: *a33
+          enum: *a35
           type: string
           description: PDMA backup storage
         pdma_last_test_date:
@@ -7321,7 +7338,7 @@ components:
           example: 2023-01-01
           description: PDMA last test date
         pdma_test_result:
-          enum: *a34
+          enum: *a36
           type: string
           description: PDMA test result
         pdma_restoration_manager:
@@ -7329,7 +7346,7 @@ components:
           example: Marie Martin
           description: PDMA restoration manager
         homologation_status:
-          enum: *a35
+          enum: *a37
           type: string
           description: Homologation status
         homologation_date_end:

--- a/frontend/src/constants/dictionary.ts
+++ b/frontend/src/constants/dictionary.ts
@@ -60,18 +60,22 @@ export const homologationStatusDict = {
   a_mettre_en_place: "À mettre en place",
 } as const satisfies Record<NonNullable<CreateComplianceDto["homologation_status"]>, string>;
 
+// Valeurs autorisées DIMA / PDMA (cf. ticket #1901), présentées du plus permissif au plus strict.
 export const dimaDurationHoursOptions = [
-  { value: 1, text: "1H" },
-  { value: 4, text: "4H" },
-  { value: 24, text: "24H" },
   { value: 96, text: "96H" },
+  { value: 72, text: "72H" },
+  { value: 48, text: "48H" },
+  { value: 24, text: "24H" },
+  { value: 4, text: "4H" },
+  { value: 1, text: "1H" },
+  { value: 0, text: "0H" },
 ];
 
 export const pdmaDurationHoursOptions = [
-  { value: 0, text: "0H" },
-  { value: 2, text: "2H" },
-  { value: 24, text: "24H" },
   { value: 48, text: "48H" },
+  { value: 24, text: "24H" },
+  { value: 2, text: "2H" },
+  { value: 0, text: "0H" },
 ];
 
 export const linkTypesDict = {

--- a/qa/protocoles/conformites.md
+++ b/qa/protocoles/conformites.md
@@ -40,3 +40,17 @@
 - **Action** : ouvrir l'onglet conformités après avoir posé un score de 95 puis de 12.
 - **Résultat attendu** : le résumé de la ligne Écoconception affiche le grade correspondant (95 → A,
   12 → F) selon les seuils 80/70/55/40/25/10.
+
+### CMP-05 — DIMA : valeurs de durée autorisées ✅
+
+- **Datafeature** : 1ʳᵉ application existante (admin).
+- **Action** : onglet `tab-compliances` → éditer l'axe DIMA, dérouler `compliance-dima-duration`.
+- **Résultat attendu** : la liste propose exactement **96H, 72H, 48H, 24H, 4H, 1H, 0H** (cf. ticket
+  #1901), dans cet ordre.
+
+### CMP-06 — PDMA : valeurs de durée autorisées ✅
+
+- **Datafeature** : 1ʳᵉ application existante (admin).
+- **Action** : onglet `tab-compliances` → éditer l'axe PDMA, dérouler `compliance-pdma-duration`.
+- **Résultat attendu** : la liste propose exactement **48H, 24H, 2H, 0H** (cf. ticket #1901), dans cet
+  ordre.


### PR DESCRIPTION
Closes #1901.

## Contexte
Restreindre les durées DIMA et PDMA aux seules valeurs autorisées :
- **DIMA** : 96h, 72h, 48h, 24h, 4h, 1h, 0h
- **PDMA** : 48h, 24h, 2h, 0h

## Changements
### Backend
- Constantes `DIMA_DURATION_HOURS_VALUES` / `PDMA_DURATION_HOURS_VALUES` (`compliance-metadata.constants.ts`).
- `CreateComplianceDto` : validation `@IsIn(...)` sur `dima_duration_hours` / `pdma_duration_hours` + `enum` Swagger et descriptions à jour. La validation couvre aussi l'**import Excel** (le processeur valide le DTO).
- Jeux de tests alignés (faker PDMA, spec du processeur d'import).

### Frontend
- `dimaDurationHoursOptions` / `pdmaDurationHoursOptions` (`dictionary.ts`) : listes mises à jour, présentées du plus permissif au plus strict.

### Tests de non-régression (e2e, POM strict)
- **CMP-05** (DIMA) et **CMP-06** (PDMA) : ouvrent l'édition de l'axe et vérifient que la liste de durée propose **exactement** les valeurs autorisées, dans l'ordre.
- Méthode POM `expectComplianceDurationOptions()` + blocs protocole `qa/protocoles/conformites.md`.

## Vérifications
- `nest build` backend ✅ · `type-check` frontend ✅ · `type-check` e2e ✅
- Jest `compliances.e2e-spec` (16) + `compliances-sheet.processor` (8) ✅ — dont 3 nouveaux cas (rejet valeur hors liste DIMA/PDMA, acceptation valeurs limites)
- Playwright **CMP-05/06** chromium/firefox/webkit ✅