### PR TITLE
test(e2e): use allowed DIMA duration in ADM-11 import fixture

### DIFF
--- a/e2e/tests/administration-referentiels.spec.ts
+++ b/e2e/tests/administration-referentiels.spec.ts
@@ -531,7 +531,8 @@ test.describe("Administration des référentiels", () => {
           "DIMA Durée (heures)",
           "DSFR Implémenté",
         ],
-        [[appId, impact, 5, "Oui"]],
+        // 4 h : valeur de durée DIMA autorisée (cf. DIMA_DURATION_HOURS_VALUES, #1901/#1910).
+        [[appId, impact, 4, "Oui"]],
       );
 
       const admin = new AdminPage(page);
@@ -557,7 +558,7 @@ test.describe("Administration des référentiels", () => {
         [appId],
       );
       expect(rows[0]?.dima_business_impact).toBe(impact);
-      expect(rows[0]?.dima_duration_hours).toBe(5);
+      expect(rows[0]?.dima_duration_hours).toBe(4);
       expect(rows[0]?.dsfr_implemented).toBe(true);
     } finally {
       await deleteThrowawayApp(appId);


### PR DESCRIPTION
## Contexte

La campagne de non-régression (PR release-please #1819) est bloquée par **ADM-11 — importer une conformité via un fichier Excel (création)**.

## Cause

#1901/#1910 (`feat: restrict DIMA/PDMA duration to allowed values`) a ajouté `@IsIn(DIMA_DURATION_HOURS_VALUES)` sur `dima_duration_hours`, avec les valeurs autorisées `{96, 72, 48, 24, 4, 1, 0}`.

Or le fixture ADM-11 importe une durée DIMA de **5 h**, désormais invalide. La ligne part donc en erreur (« 0 créé(s) / 1 en erreur ») et l'assertion `expect(...admin-import-report-summary).toContainText(/1 créé\(s\)/)` expire (timeout 15 s).

C'est un **test obsolète**, pas une régression applicative : la validation fonctionne comme prévu.

## Correctif

Fixture ADM-11 : durée DIMA `5` → `4` (valeur autorisée), assertion BDD `dima_duration_hours` alignée sur `4`, + commentaire renvoyant à `DIMA_DURATION_HOURS_VALUES`.

## Vérifications

- `type-check` e2e ✅
- `eslint` ✅
