### PR TITLE
fix(docker): make frontend image writable under OpenShift arbitrary UID

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -34,11 +34,15 @@ FROM nginxinc/nginx-unprivileged:1.27-alpine AS prod
 
 USER 0
 
-RUN chown -R 1001:1001 /usr/share/nginx/html && chmod -R 755 /usr/share/nginx/html
-COPY --chown=1001:1001 --chmod=444 nginx.conf /etc/nginx/nginx.conf
-COPY --chown=1001:1001 --chmod=755 --from=build /app/dist /app
+# OpenShift (et tout runtime "arbitrary UID") lance le conteneur avec un UID
+# aléatoire mais toujours dans le groupe 0. L'entrypoint réécrit /app et recopie
+# vers /usr/share/nginx/html à chaque démarrage : ces deux dossiers doivent donc
+# être inscriptibles par le groupe 0. On reste NON world-writable (Sonar S2612 OK).
+RUN chown -R 1001:0 /usr/share/nginx/html && chmod -R g=u /usr/share/nginx/html
+COPY --chown=1001:0 --chmod=444 nginx.conf /etc/nginx/nginx.conf
+COPY --chown=1001:0 --chmod=775 --from=build /app/dist /app
 
-COPY --chown=1001:1001 --chmod=775 entrypoint.sh /docker-entrypoint.d/entrypoint.sh
+COPY --chown=1001:0 --chmod=775 entrypoint.sh /docker-entrypoint.d/entrypoint.sh
 
 USER 1001
 


### PR DESCRIPTION
## Problème

Depuis la **1.80.0**, le front sur qualif (OpenShift) sert la page **« Welcome to nginx »** au lieu de la SPA. Logs du pod front au démarrage :

```
cp: can't create '/usr/share/nginx/html/...': Permission denied   (répété)
```

## Cause

`ad0675d3` (#1904, durcissement Sonar S2612) a remplacé `chmod 777` par :

```
chown -R 1001:1001 /usr/share/nginx/html && chmod -R 755 ...
COPY --chown=1001:1001 --chmod=755 --from=build /app/dist /app
```

Or l'`entrypoint.sh` **réécrit `/app`** (substitution des `VITE_RDA_*`) et **recopie vers `/usr/share/nginx/html`** à chaque démarrage. Sur OpenShift, le conteneur tourne avec un **UID aléatoire** (pas 1001) mais dans le **groupe 0**. Les dossiers en `755` possédés par `1001:1001` ne sont donc **pas inscriptibles** par cet UID → `Permission denied` → `/usr/share/nginx/html` reste vide → page nginx par défaut.

## Correctif

Possède les dossiers par le **groupe 0** et les rend **inscriptibles par le groupe** (sans redevenir world-writable, donc Sonar S2612 reste satisfait) — pattern standard « OpenShift arbitrary UID » :

```
chown -R 1001:0 /usr/share/nginx/html && chmod -R g=u ...
COPY --chown=1001:0 --chmod=775 --from=build /app/dist /app
COPY --chown=1001:0 --chmod=775 entrypoint.sh ...
```

## Déploiement

Nécessite un **rebuild de l'image front** (≥ 1.80.1). En attendant, qualif peut être restauré en **rollback sur `v1.79.0`** (image d'avant `ad0675d3`).

## Note

Idéalement, faire la substitution d'env + la copie au **build** plutôt qu'au runtime éliminerait tout besoin d'écriture au démarrage (suivi possible).
