### PR TITLE
fix(a11y): RGAA lot E — gabarit global (header / footer / landmarks / titres) (#1775)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,6 +13,7 @@ import ImpersonationBanner from "./components/ImpersonationBanner.vue";
 import AppToaster from "./components/AppToaster.vue";
 import { useScheme } from "@gouvminint/vue-dsfr";
 import ReloadPrompt from "./components/ReloadPrompt.vue";
+import { useRgaaGlobalA11y } from "./composables/use-rgaa-a11y";
 
 const route = useRoute();
 const router = useRouter();
@@ -36,9 +37,14 @@ configureClients(toaster);
 const appVersion = __APP_VERSION__;
 const environmentLabel = computed(() => appConfig.value?.environmentLabel);
 
+// RGAA-016 : pas d'emoji « 📦 » lu tel quel par les lecteurs d'écran.
+// RGAA-015 : mention « nouvelle fenêtre » (le lien s'ouvre dans un nouvel onglet).
 const versionLink = computed(() => ({
-  label: `📦 ${appVersion}`,
+  label: appVersion,
+  title: `Version ${appVersion} - nouvelle fenêtre`,
   href: `https://github.com/dnum-mi/referentiel-applications/releases/tag/${appVersion}`,
+  target: "_blank",
+  to: undefined,
 }));
 
 interface QuickLink {
@@ -142,43 +148,58 @@ const ecosystemLinks = computed(() => {
   if (appConfig.value?.footerLinks) {
     links.push(...appConfig.value.footerLinks);
   }
-  return links;
+  // RGAA-015 : ces liens sont rendus par DSFR avec target="_blank" → l'indiquer dans l'intitulé.
+  return links.map((link) => ({
+    ...link,
+    title: link.title?.includes("nouvelle fenêtre") ? link.title : `${link.title ?? link.label} - nouvelle fenêtre`,
+  }));
 });
 const mandatoryLinks = computed(() => [
   { label: "Accessibilité : non conforme", title: "Aller à la page d'accessibilité", to: "accessibilite" },
   { label: "Plan du site", title: "Aller au plan du site", to: "plan-du-site" },
   {
+    // RGAA-015 : ouverture dans un nouvel onglet mentionnée dans l'intitulé.
     label: "Contact Tchap",
-    title: "Aller au contact Tchap",
+    title: "Contact Tchap - nouvelle fenêtre",
     href: "https://www.tchap.gouv.fr/#/room/!ydoKqFOXRAQPQYFvqa:agent.interieur.tchap.gouv.fr?via=agent.interieur.tchap.gouv.fr",
-    to: "",
     target: "_blank",
+    to: undefined,
   },
   {
     label: "Contacter l'équipe",
-    title: "Envoyer un email à l'équipe du Référentiel des Applications",
+    title: "Contacter l'équipe par email - nouvelle fenêtre",
     href: "mailto:support-referentiel-applications@interieur.gouv.fr",
-    to: "",
     target: "_blank",
     icon: "fr-icon-mail-line",
+    to: undefined,
   },
-  { ...versionLink.value, to: "" },
+  versionLink.value,
 ]);
-const afterMandatoryLinks = [
-  {
-    label: "Paramètres d'affichage",
-    button: true,
-    class: "fr-icon-theme-fill fr-link--icon-left fr-px-2v",
-    to: "/settings",
-    onclick: changeTheme,
-  },
-];
-
 const scheme = useScheme();
 function changeTheme() {
   if (!scheme) return;
   scheme.setScheme(scheme.theme.value === "light" ? "dark" : "light");
 }
+
+// RGAA-017 : le bouton « Paramètres d'affichage » doit restituer son état (mode courant).
+const themeButtonTitle = computed(() =>
+  scheme?.theme.value === "dark"
+    ? "Paramètres d'affichage : actuellement en mode sombre, passer en mode clair"
+    : "Paramètres d'affichage : actuellement en mode clair, passer en mode sombre",
+);
+
+const afterMandatoryLinks = computed(() => [
+  {
+    label: "Paramètres d'affichage",
+    button: true,
+    title: themeButtonTitle.value,
+    class: "fr-icon-theme-fill fr-link--icon-left fr-px-2v",
+    to: "/settings",
+    onclick: changeTheme,
+  },
+]);
+
+useRgaaGlobalA11y();
 
 const { offlineReady, needRefresh, updateServiceWorker } = useRegisterSW();
 function close() {
@@ -227,6 +248,7 @@ function close() {
 
   <DsfrFooter
     :logo-text="logoText"
+    desc-text="Référentiel des applications du ministère de l'Intérieur : recensement des applications, de leurs données et de leurs relations."
     :operator-img-src="operatorImgSrc"
     :operator-img-alt="operatorImgAlt"
     :operator-img-style="operatorImgStyle"

--- a/frontend/src/components/PaginationFooter.vue
+++ b/frontend/src/components/PaginationFooter.vue
@@ -39,14 +39,14 @@ const pages = computed(() => {
       </select>
     </div>
 
-    <div class="footer-item pagination-centered">
+    <nav class="footer-item pagination-centered" role="navigation" aria-label="Pagination">
       <DsfrPagination
         :current-page="page"
         :pages="pages"
         data-testid="pagination-component"
         @update:current-page="emit('update:page', $event)"
       />
-    </div>
+    </nav>
 
     <div class="footer-item total-count" data-testid="pagination-total-count">{{ totalFiltered }} résultat(s)</div>
   </div>

--- a/frontend/src/composables/use-rgaa-a11y.ts
+++ b/frontend/src/composables/use-rgaa-a11y.ts
@@ -1,0 +1,52 @@
+import { nextTick, onMounted } from "vue";
+
+const DEVISE = "Liberté, égalité, fraternité";
+const OPERATOR_LINK_TITLE = "Accueil - Ministère de l'intérieur - Référentiel des Applications";
+
+/**
+ * Corrections d'accessibilité RGAA appliquées au gabarit global (header / footer)
+ * pour les points que `@gouvminint/vue-dsfr` n'expose ni via props ni via slots.
+ * Réf. issue #1775 (lot E) : RGAA-008, RGAA-009, RGAA-013, RGAA-014.
+ *
+ * Le header et le footer ne sont montés qu'une fois et leurs blocs marque /
+ * titre de service ne sont pas re-rendus (logoText / serviceTitle constants),
+ * donc ces retouches DOM restent stables. Les opérations sont idempotentes.
+ */
+function applyRgaaEnhancements() {
+  // RGAA-009 — le titre de service du header doit être un vrai titre de niveau 1.
+  document.querySelectorAll<HTMLElement>(".fr-header__service-title").forEach((el) => {
+    if (!el.getAttribute("role")) {
+      el.setAttribute("role", "heading");
+      el.setAttribute("aria-level", "1");
+    }
+  });
+
+  // RGAA-008 / RGAA-013 — restituer la devise « Liberté, égalité, fraternité »,
+  // rendue par DSFR via des pseudo-éléments CSS et donc muette pour les lecteurs d'écran.
+  document.querySelectorAll<HTMLElement>(".fr-logo").forEach((logo) => {
+    if (logo.querySelector("[data-rgaa-devise]")) return;
+    const span = document.createElement("span");
+    span.className = "fr-sr-only";
+    span.dataset.rgaaDevise = "";
+    span.textContent = DEVISE;
+    logo.appendChild(span);
+  });
+
+  // RGAA-014 — intitulé du lien logo du footer cohérent avec le texte visible.
+  document.querySelectorAll<HTMLAnchorElement>("a.fr-footer__brand-link").forEach((link) => {
+    if (!link.getAttribute("title")) {
+      link.setAttribute("title", OPERATOR_LINK_TITLE);
+    }
+  });
+}
+
+/** À appeler depuis le composant racine (App.vue). */
+export function useRgaaGlobalA11y() {
+  onMounted(() => {
+    nextTick(() => {
+      applyRgaaEnhancements();
+      // Filet de sécurité si le footer est peint au frame suivant.
+      requestAnimationFrame(applyRgaaEnhancements);
+    });
+  });
+}

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -84,3 +84,11 @@ body,
 :deep(.fr-input-group) {
   margin-bottom: 0.5rem !important;
 }
+
+/* RGAA-011 : la page courante ne doit pas être signalée par la seule couleur. */
+.fr-nav__link[aria-current="page"] {
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 0.25em;
+  text-decoration-thickness: 2px;
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -162,7 +162,19 @@ router.beforeEach(async (to) => {
   }
 });
 
-// Update document title when navigating
+const APP_TITLE_SUFFIX = "Référentiel des applications";
+
+/**
+ * RGAA-007 : titres de page uniques et explicites. Appelable depuis les vues
+ * dont le titre dépend de données chargées après la navigation (nom d'application,
+ * pagination…). Le `afterEach` ci-dessous fournit le titre par défaut.
+ */
+export function setPageTitle(parts: string | string[]) {
+  const segments = Array.isArray(parts) ? parts : [parts];
+  document.title = [...segments, APP_TITLE_SUFFIX].filter(Boolean).join(" - ");
+}
+
+// Update document title when navigating (titre par défaut)
 router.afterEach((to) => {
   if (to.meta.title) {
     document.title = to.meta.title as string;

--- a/frontend/src/views/ApplicationPage.vue
+++ b/frontend/src/views/ApplicationPage.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { ApplicationWithPerms } from "@/models/Application";
 import ApplicationOverview from "@/components/ApplicationOverview.vue";
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { useRoute } from "vue-router";
+import { setPageTitle } from "@/router";
 import { formatDateFR } from "@/composables/use-date";
 import { statusApplicationDictionary, typeApplicationDictionary } from "@/constants/dictionary";
 import { useApplicationStore } from "@/stores/applicationStore";
@@ -42,6 +43,15 @@ async function toggleSubscription() {
 const deleteModalOpened = ref(false);
 const deleteConfirmationInput = ref("");
 const applicationLabel = computed(() => application.value?.label ?? "");
+
+// RGAA-007 : titre de page explicite reprenant le nom de l'application.
+watch(
+  applicationLabel,
+  (label) => {
+    if (label) setPageTitle(`Profil d'application : ${label}`);
+  },
+  { immediate: true },
+);
 
 const canReadMetadata = computed(() => {
   return userStore.hasPermissions([Permission.METADATA_READ], Array.from(application.value.myPerms));

--- a/frontend/src/views/MetadataPage.vue
+++ b/frontend/src/views/MetadataPage.vue
@@ -6,6 +6,7 @@ import { useMetadataStore } from "@/stores/metadataStore";
 import { formatDate } from "@/composables/use-date";
 import { metadataActionLabels } from "@/constants/dictionary";
 import PaginationFooter from "@/components/PaginationFooter.vue";
+import { setPageTitle } from "@/router";
 import RefAppTable from "@/components/RefAppTable.vue";
 import type { TableColumn, TableSortEvent } from "@/types/table";
 import type { PaginatedMetadataDto } from "@/client/types.gen";
@@ -44,6 +45,9 @@ const columnToFieldKeyMap: Record<string, string> = {
 watch([currentPage, pageSize], () => {
   fetchData();
 });
+
+// RGAA-007 : titre de page explicite reflétant la pagination courante.
+watch(currentPage, (page) => setPageTitle(`Modifications - page ${page + 1}`), { immediate: true });
 
 function convertLocalToUTC(localDateTimeString: string): string {
   if (!localDateTimeString) return "";


### PR DESCRIPTION
Closes #1775 — Audit RGAA 4.1.2 (v1.75.0), **lot E** : gabarit global (header / footer / landmarks / titres). Sous-issue de #1767.

## Corrections (12 tickets)

| Ticket | Critère | Correctif |
|---|---|---|
| RGAA-005 | 9.2 | `<div id="main-content">` → `<main role="main" tabindex="-1">` (cible réelle du lien d'évitement) — `App.vue` |
| RGAA-006 | 12.6 | pagination encapsulée dans `<nav role="navigation" aria-label="Pagination">` — `PaginationFooter.vue` |
| RGAA-007 | 8.6 | helper `setPageTitle()` (router) + titres dynamiques : nom de l'application (`ApplicationPage`), n° de page (`MetadataPage`) |
| RGAA-008 | 10.2 | devise « Liberté, égalité, fraternité » restituée dans le bloc-marque du header (sortie de pseudo-éléments CSS) |
| RGAA-009 | 9.1 | titre de service du header rendu comme vrai titre (`role="heading" aria-level="1"`) |
| RGAA-011 | 3.1 | page courante distinguée par une forme (soulignement renforcé) en plus de la couleur — `main.css` |
| RGAA-012 | 8.9 | `<p>` vide du footer supprimé via un `desc-text` renseigné |
| RGAA-013 | 10.2 | devise restituée dans le bloc-marque du footer |
| RGAA-014 | 6.1 | `title` du lien logo footer cohérent avec l'intitulé visible (« Accueil - … ») |
| RGAA-015 | 6.1 | « nouvelle fenêtre » ajouté aux liens `target="_blank"` (Contact Tchap, équipe, version, liens écosystème) |
| RGAA-016 | 6.1 | emoji « 📦 » retiré de l'intitulé du lien version |
| RGAA-017 | 7.1 | bouton « Paramètres d'affichage » : `title` dynamique annonçant le mode courant et l'action |

## Notes d'implémentation

- **`@gouvminint/vue-dsfr` 8.15** n'expose ni prop ni slot pour 4 points (devise dans `.fr-logo`, titre de service en titre, `title` du lien marque footer). Ils sont traités par une retouche DOM idempotente et stable, montée une fois : `composables/use-rgaa-a11y.ts` (header/footer non re-rendus, `logoText`/`serviceTitle` constants).
- **RGAA-012** : le `<p>` vide provenait du `<p class="fr-footer__content-desc">` rendu inconditionnellement par DSFR (et non des `to:""` comme supposé initialement) → corrigé en fournissant `desc-text` (les `to:""` redondants sont aussi nettoyés).
- **RGAA-009 / double `<h1>`** : les 19 pages ont déjà leur propre `<h1>`. Le titre de service est donc rendu en `role="heading" aria-level="1"` (conforme à l'option proposée par l'audit) plutôt qu'en `<h1>`, pour ne pas multiplier les `<h1>`.

## Vérifications

- ✅ `pnpm -C frontend type-check` (vue-tsc)
- ✅ `pnpm exec eslint` sur les fichiers modifiés (0 erreur)
- ⏳ **Reste à faire (DoD #1785)** : re-test manuel de chaque ticket sous NVDA + Firefox.
