### PR TITLE
fix(a11y): RGAA lot J — liens explicites & « nouvelle fenêtre » (#1780)

### DIFF
--- a/frontend/src/components/LinksTab.vue
+++ b/frontend/src/components/LinksTab.vue
@@ -243,7 +243,14 @@ onMounted(async () => {
           @page="onPage"
         >
           <template #body-lien="{ data }">
-            <a :href="data.lien.to" target="_blank" rel="noopener noreferrer" data-testid="link-item">{{ data.lien.label }}</a>
+            <a
+              :href="data.lien.to"
+              target="_blank"
+              rel="noopener noreferrer"
+              :title="`${data.lien.label} - nouvelle fenêtre`"
+              data-testid="link-item"
+              >{{ data.lien.label }}</a
+            >
           </template>
 
           <template #body-typeDeLien="{ data }">

--- a/frontend/src/components/PaginationFooter.vue
+++ b/frontend/src/components/PaginationFooter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, nextTick, onMounted, ref, watch } from "vue";
 
 const props = defineProps<{
   totalFiltered: number;
@@ -20,6 +20,23 @@ const pages = computed(() => {
     href: `#page-${index + 1}`,
   }));
 });
+
+// RGAA-032 : DsfrPagination ne restitue le `title` que sur la page courante. On pose
+// un intitulé explicite « Page N » (aria-label) sur chaque lien numéroté, à l'init et
+// à chaque re-rendu (changement de page / de nombre de pages).
+const paginationRoot = ref<HTMLElement>();
+function labelPaginationLinks() {
+  paginationRoot.value?.querySelectorAll<HTMLAnchorElement>("a.fr-pagination__link").forEach((link) => {
+    const text = link.textContent?.trim() ?? "";
+    if (/^\d+$/.test(text)) {
+      link.setAttribute("aria-label", `Page ${text}`);
+    }
+  });
+}
+onMounted(labelPaginationLinks);
+watch([() => props.page, () => props.totalFiltered, () => props.limit], () => nextTick(labelPaginationLinks), {
+  flush: "post",
+});
 </script>
 
 <template>
@@ -39,7 +56,7 @@ const pages = computed(() => {
       </select>
     </div>
 
-    <nav class="footer-item pagination-centered" role="navigation" aria-label="Pagination">
+    <nav ref="paginationRoot" class="footer-item pagination-centered" role="navigation" aria-label="Pagination">
       <DsfrPagination
         :current-page="page"
         :pages="pages"

--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -79,9 +79,11 @@
         <a
           class="fr-col fr-btn fr-btn--secondary fr-btn--md"
           data-testid="home-contact-link"
-          title="Contacter l’équipe sur Tchap"
+          title="Contacter l’équipe sur Tchap – nouvelle fenêtre"
+          aria-label="Contacter l’équipe sur Tchap – nouvelle fenêtre"
           href="https://www.tchap.gouv.fr/#/room/!ydoKqFOXRAQPQYFvqa:agent.interieur.tchap.gouv.fr?via=agent.interieur.tchap.gouv.fr"
           target="_blank"
+          rel="noopener"
           ><span class="fr-icon-mail-open-line fr-icon--sm fr-mr-1w"></span>
           Nous Contacter sur Tchap
         </a>


### PR DESCRIPTION
Closes #1780 — Audit RGAA 4.1.2 (v1.75.0), **lot J** : liens explicites & « nouvelle fenêtre » (critère 6.1). Sous-issue de #1767.

> ⚠️ **PR empilée sur #1921 (lot E)** : la base est la branche `1775-rgaa-lot-e-gabarit-global` car RGAA-032 modifie le `<nav>` de pagination introduit par le lot E. À merger après #1921 (ou rebaser sur `main` une fois #1921 mergée).

## Corrections (3 tickets)

| Ticket | Critère | Correctif |
|---|---|---|
| RGAA-032 | 6.1 | `PaginationFooter.vue` — `DsfrPagination` ne pose le `title` que sur la page courante ; on ajoute un `aria-label="Page N"` sur chaque lien numéroté (init + à chaque re-rendu via watch `flush: "post"`) |
| RGAA-042 | 6.1 | `HomePage.vue` — lien « Nous contacter sur Tchap » : « – nouvelle fenêtre » ajouté sur `title` **et** `aria-label`, + `rel="noopener"` |
| RGAA-053 | 6.1 | `LinksTab.vue` — lien de l'onglet « Liens » (table) : `title` reprenant l'intitulé visible + « nouvelle fenêtre » |

## Notes

- **RGAA-032** : vérifié dans le rendu de `@gouvminint/vue-dsfr` 8.15 — la fonction interne `S(n)` ne renvoie le `title` que pour la page active, donc le `title: "Page N"` du modèle `pages` est ignoré pour les autres liens. Aucune prop n'expose un `aria-label` par page → correctif côté DOM, idempotent et réappliqué aux changements de page.
- **RGAA-053 / carte mobile** : `DsfrCard` rend son lien **sans** `target="_blank"` (même onglet) → pas de mention « nouvelle fenêtre » à ajouter sur la carte ; seul le lien `target="_blank"` de la table est concerné.

## Vérifications

- ✅ `pnpm -C frontend type-check`
- ✅ `pnpm exec eslint` sur les fichiers modifiés (0 erreur)
- ⏳ **Reste à faire (DoD #1785)** : re-test manuel sous NVDA + Firefox (liste des liens INS+F7).
