### PR TITLE
fix(a11y): RGAA lot M — page Time : transcription du diagramme SVG (#1770)

### DIFF
--- a/frontend/src/chart/time-chart.builder.ts
+++ b/frontend/src/chart/time-chart.builder.ts
@@ -300,7 +300,7 @@ export class TimeChartBuilder {
           .attr("text-anchor", "end")
           .attr("fill", "currentColor")
           .attr("font-size", "12px")
-          .text("Cout du MCO"),
+          .text("Coût du MCO"),
       );
 
     return this;

--- a/frontend/src/components/technical-debt/TechnicalDebtChart.vue
+++ b/frontend/src/components/technical-debt/TechnicalDebtChart.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import type { TechnicalDebtPoint } from "@/composables/use-application-search";
 import { useTechnicalDebtChart } from "@/composables/use-technical-debt-chart";
+import { getTimeQuadrant, type TimeQuadrant } from "@/utils/get-time-quadrant";
+import { computed } from "vue";
 
 const props = defineProps<{
   data: TechnicalDebtPoint[];
@@ -11,13 +13,79 @@ const props = defineProps<{
 // En <script setup>, Vue résout ref="containerRef" en cherchant la variable dans ce scope.
 // Sans cette destructuration, les refs du composable resteraient null et le chart ne se dessinerait pas.
 const { containerRef, svgRef } = useTechnicalDebtChart(props);
+
+// RGAA-082 (1.6) : transcription textuelle du diagramme SVG. Libellés de quadrant
+// alignés sur ceux affichés dans le graphe (cf. time-chart.builder.ts).
+const QUADRANT_LABELS_FR: Record<TimeQuadrant, string> = {
+  Tolerate: "Tolérer",
+  Invest: "À privilégier",
+  Migrate: "À migrer",
+  Eliminate: "À décommissionner",
+};
+
+const PLACEHOLDER = "—";
+
+const transcriptionRows = computed(() =>
+  props.data.map((point) => {
+    const info = point.technicalDebtInfo;
+    const technicalMaturity = info?.technicalMaturity;
+    const businessMaturity = info?.businessMaturity;
+    const quadrant =
+      typeof technicalMaturity === "number" && typeof businessMaturity === "number"
+        ? QUADRANT_LABELS_FR[getTimeQuadrant(technicalMaturity, businessMaturity)]
+        : PLACEHOLDER;
+    return {
+      key: point.id,
+      name: point.shortName ?? point.label,
+      technicalMaturity: technicalMaturity ?? PLACEHOLDER,
+      businessMaturity: businessMaturity ?? PLACEHOLDER,
+      cost: info?.costContainment ?? PLACEHOLDER,
+      quadrant,
+    };
+  }),
+);
 </script>
 
 <template>
   <div ref="containerRef" class="technical-debt-scatter">
-    <svg v-if="props.data.length" ref="svgRef" role="img" aria-label="Graphique de maturite TIME"></svg>
+    <template v-if="props.data.length">
+      <svg
+        ref="svgRef"
+        role="img"
+        aria-label="Diagramme TIME de la maturité technique et métier du portefeuille applicatif. La transcription détaillée est disponible juste après le graphique."
+      ></svg>
+
+      <details class="fr-mt-2w" data-testid="technical-debt-transcription">
+        <summary>Transcription du diagramme TIME</summary>
+        <div class="fr-table fr-table--bordered fr-mt-1w">
+          <table>
+            <caption>
+              Maturité TIME par application
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Application</th>
+                <th scope="col">Maturité technique</th>
+                <th scope="col">Maturité métier</th>
+                <th scope="col">Coût du MCO</th>
+                <th scope="col">Quadrant TIME</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="row in transcriptionRows" :key="row.key">
+                <td>{{ row.name }}</td>
+                <td>{{ row.technicalMaturity }}</td>
+                <td>{{ row.businessMaturity }}</td>
+                <td>{{ row.cost }}</td>
+                <td>{{ row.quadrant }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </template>
     <p v-else class="fr-text--sm fr-text--italic fr-mt-2w" data-testid="technical-debt-empty">
-      Aucune donnee TIME disponible pour vos applications autorisees.
+      Aucune donnée TIME disponible pour vos applications autorisées.
     </p>
   </div>
 </template>


### PR DESCRIPTION
Closes #1770 — Audit RGAA 4.1.2 (v1.75.0), **lot M** : page Time / diagramme TIME `<svg>`. Sous-issue de #1767.

## RGAA-082 — image graphique interactif `<svg>` (1.3 / 1.6 / 8.7)

| Critère | Correctif |
|---|---|
| **1.6** (description détaillée) | `TechnicalDebtChart.vue` — transcription du graphe dans un `<details>` : tableau DSFR (caption + `th scope="col"`) avec une ligne par application (nom, maturité technique, maturité métier, coût du MCO, **quadrant TIME**) |
| **1.3** (alternative pertinente) | `aria-label` du `<svg>` remplacé (« Graphique de maturite TIME » → description pertinente renvoyant à la transcription) |
| **8.7** (changement de langue) | **Sans objet** : les libellés du graphe sont déjà en français sur `main` (« Tolérer », « À privilégier », « À migrer », « À décommissionner », « Maturité métier/technique », « Pire/Meilleur »). Seul « Cout du MCO » corrigé en « Coût du MCO » dans `time-chart.builder.ts` |

Bonus : accents corrigés sur l'état vide (« Aucune donnée TIME… pour vos applications autorisées »).

## Notes

- Le quadrant TIME du tableau est calculé via `getTimeQuadrant()` (seuil 3) et mappé sur les libellés français affichés dans le graphe.
- Champs réels du DTO utilisés : `technicalDebtInfo.{technicalMaturity, businessMaturity, costContainment}` (l'issue mentionnait `costMaturity`/`quadrant`, inexistants).

## Vérifications

- ✅ `pnpm -C frontend type-check`
- ✅ `pnpm exec eslint` sur les fichiers modifiés (0 erreur)
- ⏳ **Reste à faire (DoD #1785)** : re-test manuel NVDA + Firefox (restitution de l'alternative et de la transcription).
