### PR TITLE
fix(a11y): RGAA lot O — déclaration d'accessibilité & mention « Partiellement conforme » (#1784)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -155,7 +155,7 @@ const ecosystemLinks = computed(() => {
   }));
 });
 const mandatoryLinks = computed(() => [
-  { label: "Accessibilité : non conforme", title: "Aller à la page d'accessibilité", to: "accessibilite" },
+  { label: "Accessibilité : Partiellement conforme", title: "Aller à la page d'accessibilité", to: "accessibilite" },
   { label: "Plan du site", title: "Aller au plan du site", to: "plan-du-site" },
   {
     // RGAA-015 : ouverture dans un nouvel onglet mentionnée dans l'intitulé.

--- a/frontend/src/views/AccessibilityPage.vue
+++ b/frontend/src/views/AccessibilityPage.vue
@@ -11,14 +11,52 @@
 
     <h2 class="fr-h2">État de conformité</h2>
     <p>
-      Le référentiel des applications est en cours d'audit d'accessibilité pour évaluer sa conformité aux RGAA (Référentiel Général
-      d'Amélioration de l'Accessibilité).
+      Le référentiel des applications est
+      <strong>partiellement conforme</strong>
+      au RGAA 4.1.2 (Référentiel Général d'Amélioration de l'Accessibilité) en raison des non-conformités énumérées ci-dessous.
     </p>
 
-    <h2 class="fr-h2">Signaler un problème d'accessibilité</h2>
+    <h2 class="fr-h2">Résultats des tests</h2>
+    <!-- TODO #1784 : renseigner le taux de conformité exact issu de l'audit avant publication. -->
     <p>
-      Si vous rencontrez un défaut d'accessibilité vous empêchant d'accéder à un contenu ou une fonctionnalité du site, merci de nous le
-      signaler.
+      L'audit de conformité réalisé en 2026 révèle 28 critères non conformes. Le taux de conformité global au RGAA 4.1.2 est de
+      <strong>XX&nbsp;%</strong>
+      (valeur à confirmer avec les résultats définitifs de l'audit).
     </p>
+
+    <h2 class="fr-h2">Établissement de cette déclaration</h2>
+    <!-- TODO #1784 : renseigner la date d'établissement de la déclaration avant publication. -->
+    <p>Cette déclaration a été établie le JJ/MM/AAAA (date à confirmer).</p>
+
+    <h2 class="fr-h2">Retour d'information et contact</h2>
+    <p>
+      Si vous rencontrez un défaut d'accessibilité vous empêchant d'accéder à un contenu ou à une fonctionnalité du site, merci de nous le
+      signaler en contactant l'équipe à l'adresse
+      <a href="mailto:support-referentiel-applications@interieur.gouv.fr">support-referentiel-applications@interieur.gouv.fr</a>.
+    </p>
+
+    <h2 class="fr-h2">Voies de recours</h2>
+    <p>
+      Cette procédure est à utiliser dans le cas suivant : vous avez signalé au responsable du site un défaut d'accessibilité qui vous
+      empêche d'accéder à un contenu ou à un service et vous n'avez pas obtenu de réponse satisfaisante.
+    </p>
+    <p>Vous pouvez :</p>
+    <ul>
+      <li>
+        écrire un message au
+        <a href="https://formulaire.defenseurdesdroits.fr/" target="_blank" rel="noopener noreferrer"
+          >Défenseur des droits - nouvelle fenêtre</a
+        >&nbsp;;
+      </li>
+      <li>
+        contacter le délégué du
+        <a href="https://www.defenseurdesdroits.fr/saisir/delegues" target="_blank" rel="noopener noreferrer"
+          >Défenseur des droits dans votre région - nouvelle fenêtre</a
+        >&nbsp;;
+      </li>
+      <li>
+        envoyer un courrier par la poste (gratuit, sans timbre) à&nbsp;: Défenseur des droits, Libre réponse 71120, 75342 Paris CEDEX 07.
+      </li>
+    </ul>
   </div>
 </template>


### PR DESCRIPTION
Closes #1784 — Audit RGAA 4.1.2 (v1.75.0), **lot O** : déclaration d'accessibilité & mention réglementaire. Sous-issue de #1767.

## RGAA-091 — mention obligatoire & déclaration (organisationnel)

| Correctif | Fichier |
|---|---|
| Mention du footer corrigée : « Accessibilité : non conforme » → **« Accessibilité : Partiellement conforme »** (valeur exacte requise par l'arrêté, cohérente avec le résultat d'audit) | `App.vue` |
| Déclaration d'accessibilité **complétée** sur `/accessibilite` : état de conformité (partiellement conforme au RGAA 4.1.2), résultats des tests, établissement de la déclaration, retour d'information/contact, **voies de recours** (Défenseur des droits) | `AccessibilityPage.vue` |

## ⚠️ Placeholders à renseigner avant publication

La déclaration contient des valeurs à confirmer avec les données réelles de l'audit (marquées par des commentaires `TODO #1784`) :
- **taux de conformité** global (`XX %`) ;
- **date d'établissement** de la déclaration (`JJ/MM/AAAA`).

Le reste est factuel : contact = `support-referentiel-applications@interieur.gouv.fr`, recours = Défenseur des droits, 28 critères non conformes (issu de l'audit). Les liens externes mentionnent « nouvelle fenêtre » (cohérent avec le lot J).

## Vérifications

- ✅ `pnpm exec eslint` sur les fichiers modifiés (0 erreur)
- ✅ Pas d'erreur de type dans les fichiers modifiés (`AccessibilityPage.vue` est un template statique ; `App.vue` = modification d'un libellé). _NB : le `type-check` local global est bruité par un `openapi/swagger.yaml` committé désynchronisé (client généré) — sans rapport avec ce lot ; la CI régénère le client._
- ⏳ **DoD #1785** : re-test manuel + renseigner les placeholders avant merge/publication.
