### PR TITLE
fix(a11y): RGAA lot I — messages de statut (aria-live) & focus après action (#1779)

### DIFF
--- a/frontend/src/components/actor/ActorTab.vue
+++ b/frontend/src/components/actor/ActorTab.vue
@@ -10,7 +10,7 @@ import { useToasterStore } from "@/stores/toasterStore";
 import { useUserStore } from "@/stores/userStore";
 import type { TableColumn } from "@/types/table";
 import type { DsfrButtonProps } from "@gouvminint/vue-dsfr";
-import { computed, onBeforeMount, ref } from "vue";
+import { computed, nextTick, onBeforeMount, ref } from "vue";
 import RefAppTable from "../RefAppTable.vue";
 import ActorForm from "./ActorForm.vue";
 
@@ -114,6 +114,13 @@ onBeforeMount(async () => {
   }
 });
 
+// RGAA-059 (7.5 / 12.8) : message de statut restitué aux TA + focus rendu au bouton déclencheur.
+const statusMessage = ref("");
+const lastTrigger = ref<HTMLElement | null>(null);
+function rememberTrigger(event: Event) {
+  lastTrigger.value = (event.currentTarget as HTMLElement) ?? null;
+}
+
 async function handleSaveActors(actor: CreateActorDto & { id?: string }) {
   loading.value = true;
   actorModal.closeModal();
@@ -128,7 +135,10 @@ async function handleSaveActors(actor: CreateActorDto & { id?: string }) {
       });
     }
     await fetchActorsByApplication(props.application.id);
+    statusMessage.value = "Acteur sauvegardé avec succès !";
     toaster.addSuccessMessage("Acteur sauvegardé avec succès !");
+    await nextTick();
+    lastTrigger.value?.focus();
   } catch {
     toaster.addErrorMessage("Erreur lors de la sauvegarde de l’acteur.");
   } finally {
@@ -205,6 +215,7 @@ function getCardButtons(actor: ActorDto): DsfrButtonProps[] {
 </script>
 
 <template>
+  <p class="fr-sr-only" aria-live="polite" aria-atomic="true" data-testid="actor-status">{{ statusMessage }}</p>
   <div class="fr-grid-row fr-grid-row--middle fr-mb-3w" v-bind="$attrs" data-testid="actor-tab">
     <div class="fr-col">
       <h3 class="fr-mb-0">Gestion des acteurs</h3>
@@ -217,7 +228,12 @@ function getCardButtons(actor: ActorDto): DsfrButtonProps[] {
         class="fr-btn--icon-left fr-icon-add-line"
         :disabled="!canEdit"
         data-testid="actor-add-btn"
-        @click="actorModal.openCreateModal()"
+        @click="
+          (e) => {
+            rememberTrigger(e);
+            actorModal.openCreateModal();
+          }
+        "
       >
         Ajouter un acteur
       </DsfrButton>
@@ -299,7 +315,12 @@ function getCardButtons(actor: ActorDto): DsfrButtonProps[] {
             icon="fr-icon-edit-line"
             :disabled="!canEdit"
             data-testid="actor-edit-btn"
-            @click="data.Actions.edit"
+            @click="
+              (e) => {
+                rememberTrigger(e);
+                data.Actions.edit();
+              }
+            "
           >
             Modifier
           </DsfrButton>

--- a/frontend/src/components/admin/AdminLabelSourcesTab.vue
+++ b/frontend/src/components/admin/AdminLabelSourcesTab.vue
@@ -44,6 +44,16 @@ const itemsPerPage = ref(15);
 const currentPage = ref(0);
 const firstIndex = computed(() => currentPage.value * itemsPerPage.value);
 
+// RGAA-084 (7.5) : message de statut sur le nombre de résultats, restitué aux TA.
+const statusMessage = computed(() => {
+  if (isLoading.value) return "Chargement des sources de noms alternatifs…";
+  const total = data.value.total;
+  if (total === 0) return "Aucune donnée ne correspond à votre recherche : Résultat 0 à 0";
+  const from = firstIndex.value + 1;
+  const to = Math.min(firstIndex.value + data.value.results.length, total);
+  return `Résultat ${from} à ${to} sur ${total}`;
+});
+
 async function fetchLabelSources() {
   isLoading.value = true;
 
@@ -116,6 +126,10 @@ onMounted(fetchLabelSources);
       class="fr-col-12"
       data-testid="admin-label-source-search"
     />
+  </div>
+
+  <div aria-live="polite" aria-atomic="true" class="fr-sr-only" data-testid="admin-label-sources-status">
+    <p>{{ statusMessage }}</p>
   </div>
 
   <div v-if="isLoading" class="fr-alert fr-alert--info" data-testid="admin-label-sources-loading">

--- a/frontend/src/components/admin/AdminTagsTab.vue
+++ b/frontend/src/components/admin/AdminTagsTab.vue
@@ -50,6 +50,16 @@ const itemsPerPage = ref(15);
 const currentPage = ref(0);
 const firstIndex = computed(() => currentPage.value * itemsPerPage.value);
 
+// RGAA-084 (7.5) : message de statut sur le nombre de résultats, restitué aux TA.
+const statusMessage = computed(() => {
+  if (isLoading.value) return "Chargement des tags…";
+  const total = data.value.total;
+  if (total === 0) return "Aucune donnée ne correspond à votre recherche : Résultat 0 à 0";
+  const from = firstIndex.value + 1;
+  const to = Math.min(firstIndex.value + data.value.results.length, total);
+  return `Résultat ${from} à ${to} sur ${total}`;
+});
+
 async function fetchTags() {
   isLoading.value = true;
 
@@ -124,6 +134,10 @@ onMounted(fetchTags);
       class="fr-col-12"
       data-testid="admin-tag-search"
     />
+  </div>
+
+  <div aria-live="polite" aria-atomic="true" class="fr-sr-only" data-testid="admin-tags-status">
+    <p>{{ statusMessage }}</p>
   </div>
 
   <div v-if="isLoading" class="fr-alert fr-alert--info" data-testid="admin-tags-loading">

--- a/frontend/src/components/admin/AdminUsersTab.vue
+++ b/frontend/src/components/admin/AdminUsersTab.vue
@@ -61,6 +61,16 @@ const itemsPerPage = ref<number>(15);
 const currentPage = ref<number>(0);
 const firstIndex = computed(() => currentPage.value * itemsPerPage.value);
 
+// RGAA-084 (7.5) : message de statut sur le nombre de résultats, restitué aux TA.
+const statusMessage = computed(() => {
+  if (isLoading.value) return "Chargement des utilisateurs…";
+  const total = data.value.total;
+  if (total === 0) return "Aucune donnée ne correspond à votre recherche : Résultat 0 à 0";
+  const from = firstIndex.value + 1;
+  const to = Math.min(firstIndex.value + data.value.results.length, total);
+  return `Résultat ${from} à ${to} sur ${total}`;
+});
+
 async function fetchUsers() {
   try {
     isLoading.value = true;
@@ -141,6 +151,10 @@ onMounted(fetchUsers);
         class="fr-col-12"
         data-testid="admin-user-search"
       />
+    </div>
+
+    <div aria-live="polite" aria-atomic="true" class="fr-sr-only" data-testid="admin-users-status">
+      <p>{{ statusMessage }}</p>
     </div>
 
     <div v-if="isLoading" class="fr-alert fr-alert--info" data-testid="admin-users-loading">

--- a/frontend/src/components/admin/UserActions.vue
+++ b/frontend/src/components/admin/UserActions.vue
@@ -13,7 +13,7 @@ import { useUserStore } from "@/stores/userStore";
 import { RolesOptions, RolesScopes } from "@/utils/roles-utils";
 import type { DsfrCheckboxProps } from "@gouvminint/vue-dsfr";
 import { useMemoize } from "@vueuse/core";
-import { computed, ref } from "vue";
+import { computed, nextTick, ref } from "vue";
 import OrganizationSearchSelect from "../common/OrganizationSearchSelect.vue";
 
 const props = defineProps<{ user: Required<UserEntity> }>();
@@ -86,6 +86,17 @@ function closeEditModal() {
   maiaSuggestion.value = null;
 }
 
+// RGAA-088 (7.5 / 12.8) : confirmation restituée aux TA + focus rendu au bouton « Modifier ».
+const editBtn = ref<{ $el?: HTMLElement } | null>(null);
+const confirmationMessage = ref("");
+function focusOpener() {
+  nextTick(() => {
+    const el = editBtn.value?.$el;
+    const btn = el instanceof HTMLButtonElement ? el : (el?.querySelector?.("button") ?? null);
+    btn?.focus();
+  });
+}
+
 async function saveUser() {
   isSaving.value = true;
   try {
@@ -99,9 +110,11 @@ async function saveUser() {
       } as UpdateUserDto,
     });
     if (!response.error && response.data) {
+      confirmationMessage.value = "Utilisateur mis à jour avec succès";
       toaster.addSuccessMessage("Utilisateur mis à jour avec succès");
       closeEditModal();
       emit("userUpdated", response.data);
+      focusOpener();
     } else {
       const errorMessage =
         (response.error as { message: string })?.message ?? "Une erreur est survenue lors de la mise à jour de l'utilisateur";
@@ -186,6 +199,7 @@ const isScopeDisabled = computed(() => {
         @click="syncFromMaia"
       />
       <DsfrButton
+        ref="editBtn"
         label="Modifier"
         size="sm"
         secondary
@@ -194,6 +208,10 @@ const isScopeDisabled = computed(() => {
         aria-label="Modifier les permissions de l'utilisateur"
         @click="openEditModal"
       />
+
+      <div aria-live="polite" aria-atomic="true" class="fr-sr-only" data-testid="admin-user-edit-status">
+        <p v-if="confirmationMessage">{{ confirmationMessage }}</p>
+      </div>
       <DsfrButton
         v-if="canImpersonate"
         :label="isImpersonating ? '...' : 'Se connecter en tant que'"

--- a/frontend/src/components/common/OrganizationSearchSelect.vue
+++ b/frontend/src/components/common/OrganizationSearchSelect.vue
@@ -51,6 +51,16 @@ const searchLabel = computed(() => {
   return props.required ? "Organisation *" : "Organisation";
 });
 
+// RGAA-040 / RGAA-058 / RGAA-087 (7.5) : message de statut unique restitué aux TA
+// via une région live (nombre de suggestions / recherche en cours / absence de résultat).
+const searchStatus = computed(() => {
+  if (!searchQuery.value) return "";
+  if (isLoading.value) return "Recherche en cours…";
+  const n = organizations.value.length;
+  if (n === 0) return "Aucune organisation trouvée";
+  return `${n} résultat${n > 1 ? "s" : ""} trouvé${n > 1 ? "s" : ""}`;
+});
+
 // Computed options for the select
 const selectOptions = computed(() => {
   const options = [];
@@ -155,18 +165,8 @@ watchDebounced(searchQuery, searchOrganizations, { debounce: 300 });
       />
     </div>
 
-    <div v-if="searchQuery && !isLoading && organizations.length > 0" class="fr-mt-1w">
-      <p class="fr-text--xs fr-text--mention-grey">
-        {{ organizations.length }} résultat{{ organizations.length > 1 ? "s" : "" }} trouvé{{ organizations.length > 1 ? "s" : "" }}
-      </p>
-    </div>
-
-    <div v-if="isLoading" class="fr-mt-1w">
-      <p class="fr-text--sm">Recherche en cours...</p>
-    </div>
-
-    <div v-else-if="searchQuery && organizations.length === 0" class="fr-mt-1w">
-      <p class="fr-text--xs fr-text--mention-grey">Aucune organisation trouvée</p>
+    <div class="fr-mt-1w" aria-live="polite" aria-atomic="true" data-testid="org-search-status">
+      <p v-if="searchStatus" class="fr-text--xs fr-text--mention-grey">{{ searchStatus }}</p>
     </div>
   </div>
 </template>

--- a/frontend/src/components/compliances/RgaaComplianceSection.vue
+++ b/frontend/src/components/compliances/RgaaComplianceSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, computed } from "vue";
+import { ref, onMounted, computed, nextTick } from "vue";
 import { rgaaControllerFindAll, rgaaControllerCreate, rgaaControllerUpdate, rgaaControllerDelete } from "@/client/sdk.gen";
 import type { CreateRgaaComplianceDto, RgaaComplianceDto } from "@/client/types.gen";
 import { useToasterStore } from "@/stores/toasterStore";
@@ -22,6 +22,17 @@ const editingItem = ref<RgaaComplianceDto | null>(null);
 const submitting = ref(false);
 
 const form = ref<Record<string, string | number | undefined>>({});
+
+// RGAA-055 (7.5 / 12.8) : message de statut restitué aux TA + focus rendu au bouton « Ajouter ».
+const statusMessage = ref("");
+const addBtn = ref<{ $el?: HTMLElement } | null>(null);
+function focusAddButton() {
+  nextTick(() => {
+    const el = addBtn.value?.$el;
+    const btn = el instanceof HTMLButtonElement ? el : (el?.querySelector?.("button") ?? null);
+    btn?.focus();
+  });
+}
 
 const canWrite = computed(() => userStore.hasPermissions([Permission.COMPLIANCE_WRITE], Array.from(props.appPerms)));
 
@@ -109,6 +120,7 @@ async function saveCreate(payload: CreateRgaaComplianceDto) {
   }
   if (res.data) {
     items.value.push(res.data);
+    statusMessage.value = "Conformité RGAA créée.";
     toaster.addSuccessMessage("Conformité RGAA créée avec succès !");
   }
 }
@@ -124,6 +136,7 @@ async function save() {
       await saveCreate(payload);
     }
     closeModal();
+    focusAddButton();
   } catch {
     toaster.addErrorMessage(
       editing ? "Erreur lors de la modification de la conformité RGAA." : "Erreur lors de la création de la conformité RGAA.",
@@ -140,7 +153,9 @@ async function remove(item: RgaaComplianceDto) {
       path: { applicationId: props.applicationId, id: item.id },
     });
     items.value = items.value.filter((i) => i.id !== item.id);
+    statusMessage.value = "Conformité RGAA supprimée.";
     toaster.addSuccessMessage("Conformité RGAA supprimée.");
+    focusAddButton();
   } catch {
     toaster.addErrorMessage("Erreur lors de la suppression de la conformité RGAA.");
   }
@@ -149,10 +164,12 @@ async function remove(item: RgaaComplianceDto) {
 
 <template>
   <section data-testid="rgaa-section">
+    <p class="fr-sr-only" aria-live="polite" aria-atomic="true" data-testid="rgaa-status">{{ statusMessage }}</p>
     <div class="fr-grid-row fr-grid-row--middle fr-justify-content-between fr-mb-2w">
       <h4 class="fr-mb-0">Conformités RGAA</h4>
       <DsfrButton
         v-if="canWrite"
+        ref="addBtn"
         icon="fr-icon-add-line"
         size="sm"
         label="Ajouter"

--- a/frontend/src/views/MetadataPage.vue
+++ b/frontend/src/views/MetadataPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref, computed, watch } from "vue";
+import { onMounted, ref, computed, watch, nextTick } from "vue";
 import { useRoute } from "vue-router";
 const route = useRoute();
 import { useMetadataStore } from "@/stores/metadataStore";
@@ -79,9 +79,16 @@ function fetchData() {
     });
 }
 
+// RGAA-064 (7.5 / 12.8) : annoncer le nombre de résultats aux TA + focus sur le tableau.
+const resultsAnnouncement = ref("");
+const tableRegion = ref<HTMLElement | null>(null);
+
 async function applyFilters() {
   currentPage.value = 0;
   await fetchData();
+  resultsAnnouncement.value = `${data.value.total} résultat(s)`;
+  await nextTick();
+  tableRegion.value?.focus();
 }
 
 function clearFilters() {
@@ -191,11 +198,15 @@ const metadataTableRows = computed(() =>
       </div>
     </form>
 
+    <div aria-live="polite" aria-atomic="true" class="fr-sr-only" data-testid="history-results-status">
+      <p v-if="resultsAnnouncement">{{ resultsAnnouncement }}</p>
+    </div>
+
     <div v-if="metadataTableRows.length === 0" class="text-center fr-mb-3w" data-testid="history-empty">
       <p>Aucune donnée recensée.</p>
     </div>
 
-    <div v-else>
+    <div v-else ref="tableRegion" tabindex="-1" data-testid="history-table-region">
       <RefAppTable
         :items="metadataTableRows"
         :columns="columns"


### PR DESCRIPTION
Closes #1779 — Audit RGAA 4.1.2 (v1.75.0), **lot I** : messages de statut (`aria-live`, critère 7.5) + cohérence de l'ordre de tabulation après action (12.8). Sous-issue de #1767.

## Corrections (8 tickets)

| Ticket | Critère | Fichier | Correctif |
|---|---|---|---|
| RGAA-040 / 058 / 087 | 7.5 | `common/OrganizationSearchSelect.vue` | 3 états (recherche / N résultats / aucun) consolidés dans **une** région `aria-live="polite"` alimentée par un `computed searchStatus` |
| RGAA-084 | 7.5 | `admin/AdminUsersTab.vue`, `AdminTagsTab.vue`, `AdminLabelSourcesTab.vue` | région live `fr-sr-only` annonçant chargement / « Résultat X à Y sur N » / aucun résultat (`computed statusMessage`) |
| RGAA-055 | 7.5 / 12.8 | `compliances/RgaaComplianceSection.vue` | message live création/suppression + focus rendu au bouton « Ajouter » |
| RGAA-059 | 7.5 / 12.8 | `actor/ActorTab.vue` | message live sauvegarde + focus rendu au bouton déclencheur (mémorisé via `rememberTrigger`) |
| RGAA-064 | 7.5 / 12.8 | `views/MetadataPage.vue` | annonce du nombre de résultats après « Appliquer » + focus sur le tableau (`tabindex="-1"`) |
| RGAA-088 | 7.5 / 12.8 | `admin/UserActions.vue` | confirmation live de mise à jour + focus rendu au bouton « Modifier » |

Toutes les régions live sont présentes en permanence dans le DOM (`aria-atomic="true"`) pour que les mises à jour soient notifiées, sans déplacer le focus.

## Vérifications

- ✅ `pnpm exec eslint` sur les 8 fichiers (0 erreur ; warnings préexistants inchangés)
- ✅ Aucune erreur de type dans les 8 fichiers modifiés (`vue-tsc`). _NB : `type-check` global bruité par le client généré/`swagger.yaml` committé désynchronisé sur `main` (backend local éteint), sans rapport avec ce lot ; la CI régénère le client._
- ⏳ **DoD #1785** : re-test manuel NVDA + Firefox (vocalisation auto des messages, focus après action).
