### PR TITLE
fix(a11y): RGAA lot F — regroupements de champs (fieldset/legend) (#1776)

### DIFF
--- a/frontend/src/components/ColumnCustomization.vue
+++ b/frontend/src/components/ColumnCustomization.vue
@@ -49,11 +49,9 @@ defineExpose({ showDialog });
     />
 
     <DsfrModal :opened="visible" title="Personnaliser les colonnes" data-testid="customize-columns-dialog" @close="hideDialog">
-      <p class="fr-text--sm description">Sélectionnez les colonnes à afficher dans le tableau :</p>
-
       <DsfrCheckboxSet
         v-model="selectedColumns"
-        legend=""
+        legend="Sélectionnez les colonnes à afficher dans le tableau :"
         :options="columnOptions"
         name="column-selection"
         data-testid="column-selection-checkboxes"

--- a/frontend/src/components/actor/ActorForm.vue
+++ b/frontend/src/components/actor/ActorForm.vue
@@ -164,23 +164,15 @@ function handleSubmit() {
     />
 
     <template v-if="!isGroup">
-      <DsfrInput
-        v-model="form.firstname"
-        label="Prénom"
-        label-visible
-        placeholder="Prénom"
-        data-testid="actor-firstname-input"
-        class="fr-mb-3w"
-      />
-
-      <DsfrInput
-        v-model="form.lastname"
-        label="Nom"
-        label-visible
-        placeholder="Nom de famille"
-        data-testid="actor-lastname-input"
-        class="fr-mb-3w"
-      />
+      <fieldset class="fr-fieldset fr-mb-3w" aria-labelledby="actor-identity-legend">
+        <legend id="actor-identity-legend" class="fr-fieldset__legend">Identité de l'acteur</legend>
+        <div class="fr-fieldset__element">
+          <DsfrInput v-model="form.firstname" label="Prénom" label-visible placeholder="Prénom" data-testid="actor-firstname-input" />
+        </div>
+        <div class="fr-fieldset__element">
+          <DsfrInput v-model="form.lastname" label="Nom" label-visible placeholder="Nom de famille" data-testid="actor-lastname-input" />
+        </div>
+      </fieldset>
     </template>
 
     <div class="fr-btns-group fr-btns-group--right fr-mt-4w">

--- a/frontend/src/components/admin/UserActions.vue
+++ b/frontend/src/components/admin/UserActions.vue
@@ -228,27 +228,41 @@ const isScopeDisabled = computed(() => {
     <DsfrModal :opened="isEditModalOpen" title="Modifier l'utilisateur" data-testid="admin-edit-user-modal" @close="closeEditModal">
       <p><strong>Utilisateur :</strong> {{ user.email }}</p>
 
-      <OrganizationSearchSelect
-        v-model="editingOrganizationId"
-        class="fr-mb-1w"
-        description="Recherchez et sélectionnez une organisation pour cet utilisateur"
-        :initial-organization="user.organization"
-        data-testid="user-organization-search"
-      />
+      <!-- RGAA-086 (11.5) : regroupement des champs organisation de même nature. -->
+      <fieldset class="fr-fieldset">
+        <legend class="fr-fieldset__legend">Organisations</legend>
+        <OrganizationSearchSelect
+          v-model="editingOrganizationId"
+          class="fr-mb-1w"
+          description="Recherchez et sélectionnez une organisation pour cet utilisateur"
+          :initial-organization="user.organization"
+          data-testid="user-organization-search"
+        />
 
-      <div class="fr-mb-2w">
-        <p v-if="isFetchingMaiaSuggestion" class="fr-text--sm fr-text-mention--grey fr-mb-0">Récupération de la suggestion MAIA…</p>
-        <template v-else-if="maiaSuggestion?.organizationPath">
-          <p class="fr-text--sm fr-mb-1v">
-            <span class="fr-text-mention--grey">Organisation MAIA : </span>
-            <strong>{{ maiaSuggestion.organizationPath }}</strong>
-          </p>
-          <p v-if="isNotValidated" class="fr-badge fr-badge--error fr-badge--no-icon fr-mb-0" data-testid="user-org-not-validated-badge">
-            NON VALIDÉE
-          </p>
-          <p v-else class="fr-badge fr-badge--success fr-badge--no-icon fr-mb-0" data-testid="user-org-not-validated-badge">VALIDÉE</p>
-        </template>
-      </div>
+        <div class="fr-mb-2w">
+          <p v-if="isFetchingMaiaSuggestion" class="fr-text--sm fr-text-mention--grey fr-mb-0">Récupération de la suggestion MAIA…</p>
+          <template v-else-if="maiaSuggestion?.organizationPath">
+            <p class="fr-text--sm fr-mb-1v">
+              <span class="fr-text-mention--grey">Organisation MAIA : </span>
+              <strong>{{ maiaSuggestion.organizationPath }}</strong>
+            </p>
+            <p v-if="isNotValidated" class="fr-badge fr-badge--error fr-badge--no-icon fr-mb-0" data-testid="user-org-not-validated-badge">
+              NON VALIDÉE
+            </p>
+            <p v-else class="fr-badge fr-badge--success fr-badge--no-icon fr-mb-0" data-testid="user-org-not-validated-badge">VALIDÉE</p>
+          </template>
+        </div>
+
+        <OrganizationSearchSelect
+          v-show="!isScopeDisabled"
+          v-model="editingScopePermissions"
+          class="fr-mb-2w"
+          :label="labelScope"
+          :initial-organization="user.scopeOrganization"
+          data-testid="user-organization-search-scope"
+        />
+      </fieldset>
+
       <DsfrCheckboxSet
         v-model="editingAdditionalPermissions"
         legend="Capacités"
@@ -263,15 +277,6 @@ const isScopeDisabled = computed(() => {
         :options="RolesOptions"
         name="admin-level-radio"
         data-testid="admin-level-radio"
-      />
-
-      <OrganizationSearchSelect
-        v-show="!isScopeDisabled"
-        v-model="editingScopePermissions"
-        class="fr-mb-2w"
-        :label="labelScope"
-        :initial-organization="user.scopeOrganization"
-        data-testid="user-organization-search"
       />
 
       <template #footer>

--- a/frontend/src/components/common/OrganizationSearchSelect.vue
+++ b/frontend/src/components/common/OrganizationSearchSelect.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch } from "vue";
+import { ref, computed, watch, useId } from "vue";
 import { watchDebounced } from "@vueuse/core";
 import type { PropType } from "vue";
 import type { OrganizationDto } from "@/client/types.gen";
@@ -38,6 +38,9 @@ const emit = defineEmits<{
 }>();
 
 const organizationStore = useOrganizationStore();
+
+// RGAA-039 (11.5) : regrouper le champ de recherche et le select de résultats (même nature).
+const groupLabelId = useId();
 
 const searchQuery = ref("");
 const organizations = ref<OrganizationDto[]>([]);
@@ -139,7 +142,8 @@ watchDebounced(searchQuery, searchOrganizations, { debounce: 300 });
 </script>
 
 <template>
-  <div>
+  <div role="group" :aria-labelledby="groupLabelId">
+    <p :id="groupLabelId" class="fr-sr-only">{{ searchLabel }}</p>
     <div class="fr-form-group">
       <DsfrInputGroup
         v-model.trim="searchQuery"

--- a/frontend/src/components/form/ApplicationForm.vue
+++ b/frontend/src/components/form/ApplicationForm.vue
@@ -725,8 +725,8 @@ Aucun espace en début ou en fin."
         data-testid="application-priority-restart"
       />
 
-      <div class="fr-form-group fr-mt-3w">
-        <legend class="fr-label">Populations</legend>
+      <fieldset class="fr-fieldset fr-mt-3w">
+        <legend class="fr-fieldset__legend fr-label">Populations</legend>
         <p class="fr-hint-text">Indiquez ici le public cible concerné (ex. : RH, agents publics, entreprises...)</p>
         <div class="fr-mt-2w">
           <div v-for="(_targetPopulation, index) in form.targetPopulations" :key="index" class="fr-grid-row fr-grid-row--gutters fr-mb-2w">
@@ -765,10 +765,10 @@ Aucun espace en début ou en fin."
             @click="addPopulation"
           />
         </div>
-      </div>
+      </fieldset>
 
-      <div class="fr-form-group fr-mt-3w">
-        <legend class="fr-label">Objectifs</legend>
+      <fieldset class="fr-fieldset fr-mt-3w">
+        <legend class="fr-fieldset__legend fr-label">Objectifs</legend>
         <div class="fr-mt-2w">
           <div v-for="(_purpose, index) in form.purposes" :key="index" class="fr-grid-row fr-grid-row--gutters fr-mb-2w">
             <div class="fr-col">
@@ -806,14 +806,14 @@ Aucun espace en début ou en fin."
             @click="addPurpose"
           />
         </div>
-      </div>
+      </fieldset>
 
-      <div class="fr-form-group fr-mt-3w autocomplete-tags">
-        <legend class="fr-label">Tags</legend>
+      <fieldset class="fr-fieldset fr-mt-3w autocomplete-tags">
+        <legend class="fr-fieldset__legend fr-label">Tags</legend>
         <div class="fr-mt-2w fr-col">
           <TagSearchSelect v-model:tags="form.tags" />
         </div>
-      </div>
+      </fieldset>
     </div>
 
     <!-- Step 3: MOA Section -->

--- a/frontend/src/components/search/ApplicationFilter.vue
+++ b/frontend/src/components/search/ApplicationFilter.vue
@@ -13,8 +13,10 @@ const { filters, setFilter } = useApplicationSearch();
       data-testid="application-filter-label"
       @update:model-value="setFilter({ search: $event?.toString(), page: 0 })"
     />
-    <legend class="fr-label">Tags</legend>
-    <TagSearchSelect :tags="filters.tag" data-testid="application-filter-tag" @update:tags="setFilter({ tag: $event, page: 0 })" />
+    <fieldset class="fr-fieldset">
+      <legend class="fr-fieldset__legend fr-label">Tags</legend>
+      <TagSearchSelect :tags="filters.tag" data-testid="application-filter-tag" @update:tags="setFilter({ tag: $event, page: 0 })" />
+    </fieldset>
     <DsfrInput
       :model-value="filters.link"
       label-visible

--- a/frontend/src/components/search/ComplianceFilter.vue
+++ b/frontend/src/components/search/ComplianceFilter.vue
@@ -57,7 +57,8 @@ function setState(criterion: ComplianceFilterCriterion, state: string | number) 
 </script>
 
 <template>
-  <div data-testid="compliance-filter" class="compliance-filters">
+  <fieldset data-testid="compliance-filter" class="fr-fieldset compliance-filters">
+    <legend class="fr-fieldset__legend fr-label">Conformité</legend>
     <DsfrSelect
       v-for="criterion in complianceFilterCriteria"
       :key="criterion"
@@ -68,7 +69,7 @@ function setState(criterion: ComplianceFilterCriterion, state: string | number) 
       :data-testid="`compliance-option-${criterion}`"
       @update:model-value="(state: string | number) => setState(criterion, state)"
     />
-  </div>
+  </fieldset>
 </template>
 
 <style scoped>

--- a/frontend/src/components/search/QualityFilter.vue
+++ b/frontend/src/components/search/QualityFilter.vue
@@ -28,8 +28,8 @@ function updateMax(value: string | number | undefined) {
 </script>
 
 <template>
-  <div data-testid="quality-filter">
-    <legend class="fr-label fr-mb-2w">
+  <fieldset class="fr-fieldset" data-testid="quality-filter">
+    <legend class="fr-fieldset__legend fr-label fr-mb-2w">
       Indice de qualité<br />
       <small>entre {{ filters.iqGte ?? 0 }}% et {{ filters.iqLte ?? 100 }}%</small>
     </legend>
@@ -57,5 +57,5 @@ function updateMax(value: string | number | undefined) {
         @update:model-value="updateMax"
       />
     </DsfrInputGroup>
-  </div>
+  </fieldset>
 </template>


### PR DESCRIPTION
Closes #1776 — Audit RGAA 4.1.2 (v1.75.0), **lot F** : regroupements de champs (`fieldset`/`legend`, critères 11.5/11.6). Sous-issue de #1767.

> ⚠️ **PR empilée sur #1930 (lot I)** : base = `1779-rgaa-lot-i-aria-live`, car les lots F et I modifient tous deux `OrganizationSearchSelect.vue` et `UserActions.vue`. À merger après #1930 (ou rebaser sur `main` une fois #1930 mergée).

## Corrections (6 tickets)

| Ticket | Critère | Fichier | Correctif |
|---|---|---|---|
| RGAA-023 | 11.5 | `search/QualityFilter.vue`, `ApplicationFilter.vue`, `ComplianceFilter.vue` | `<legend>` orphelines / groupes sans regroupement → `<fieldset class="fr-fieldset">` + `<legend class="fr-fieldset__legend">` |
| RGAA-033 | 11.5 | `form/ApplicationForm.vue` | Populations, Objectifs (+ Tags, même motif) : `div.fr-form-group` + legend orpheline → `<fieldset>`/`<legend>` |
| RGAA-039 | 11.5 | `common/OrganizationSearchSelect.vue` | champ de recherche + select regroupés via `role="group"` + `aria-labelledby` (libellé `fr-sr-only`, `useId`) |
| RGAA-044 | 11.6 | `ColumnCustomization.vue` | texte d'intro sorti du `<p>` externe → porté dans la `legend` du `DsfrCheckboxSet` (plus de `legend=""` vide) |
| RGAA-057 | 11.5 | `actor/ActorForm.vue` | Prénom/Nom regroupés dans un `<fieldset>` « Identité de l'acteur » |
| RGAA-086 | 11.5 | `admin/UserActions.vue` | les 2 champs organisation (rattachement + périmètre) regroupés dans un `<fieldset>` « Organisations » |

## Notes

- **Déjà conformes sur `main`** (code refactorisé depuis l'audit) : `PriorityRestartFilter.vue` et `StatusFilter.vue` utilisent désormais `DsfrCheckboxSet`, qui rend un vrai `<fieldset>`/`<legend>` → pas de changement.
- L'exemple RGAA-023 de l'issue intégrait aussi RGAA-024 (séparation `label`/`for`) qui n'appartient **pas** à ce lot → non traité ici pour éviter un doublon avec un autre lot.
- RGAA-086 : le champ « périmètre » (conditionnel `v-show`) a été remonté auprès du champ « rattachement » pour permettre le regroupement (conforme à la proposition de l'issue) ; son `data-testid` devient `user-organization-search-scope` (levée d'un doublon d'identifiant, aucun test impacté).

## Vérifications

- ✅ `pnpm exec eslint` sur les 8 fichiers (0 erreur)
- ✅ Aucune erreur de **template** vue-tsc dans les fichiers modifiés (édits markup uniquement). _NB : erreurs de type résiduelles = client généré/swagger désynchronisé sur l'env local (nullabilité, cf. #1925) — sans rapport avec ce lot ; la CI régénère le client._
- ⏳ **DoD #1785** : re-test manuel NVDA + inspecteur (regroupements annoncés).
