### PR TITLE
chore(security): monter nodemailer 7 → 9 (phase 2b, #1937)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -64,7 +64,7 @@
     "moment": "^2.30.1",
     "nestjs-pino": "^4.6.0",
     "nestjs-prisma": "^0.23.0",
-    "nodemailer": "^7.0.13",
+    "nodemailer": "^9.0.1",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.20.0",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -125,8 +125,8 @@ importers:
         specifier: ^0.23.0
         version: 0.23.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@prisma/client@6.3.0(prisma@6.3.0(typescript@5.9.3))(typescript@5.9.3))(chokidar@3.6.0)(prisma@6.3.0(typescript@5.9.3))
       nodemailer:
-        specifier: ^7.0.13
-        version: 7.0.13
+        specifier: ^9.0.1
+        version: 9.0.3
       passport:
         specifier: ^0.6.0
         version: 0.6.0
@@ -3363,8 +3363,8 @@ packages:
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
-  nodemailer@7.0.13:
-    resolution: {integrity: sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==}
+  nodemailer@9.0.3:
+    resolution: {integrity: sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==}
     engines: {node: '>=6.0.0'}
 
   nopt@5.0.0:
@@ -8451,7 +8451,7 @@ snapshots:
 
   node-releases@2.0.36: {}
 
-  nodemailer@7.0.13: {}
+  nodemailer@9.0.3: {}
 
   nopt@5.0.0:
     dependencies:


### PR DESCRIPTION
## Contexte

Phase 2b du traitement des alertes Dependabot (#1937). Traite la montée **majeure** `nodemailer` 7 → 9, qui résout l'alerte **high** restante côté backend.

> Empilée sur #1941 (phase 2a) car elles modifient le même lockfile. À rebaser sur `main` une fois #1941 mergée.

## Changement
- `backend/package.json` : `nodemailer` `^7.0.13` → `^9.0.1` (résolu en 9.0.3).

## Pourquoi c'est sûr malgré le major
Analyse de l'usage réel (`src/email/email.service.ts`) : uniquement `nodemailer.createTransport({ host, port, secure, tls })` + `transporter.sendMail({ from, to, subject, text, html })`. Ces API sont **inchangées** de nodemailer 7 à 9 (les breaking changes 8/9 portent sur les versions Node supportées et des options avancées non utilisées ici).

## Validation locale
- ✅ `pnpm install` — runtime nodemailer entièrement en **9.0.3** (aucune transitive 7 résiduelle ; `@types/nodemailer` reste en 7, non concerné par la sécurité et compatible).
- ✅ `pnpm install --frozen-lockfile`.
- ✅ `pnpm build` (`nest build`) — aucune erreur de types.
- ⏳ Tests Jest (envoi d'e-mails) : en CI.

## Reste de la phase 2b (toujours différé dans #1937)
Ces montées exigent une **migration + validation par les tests** (Docker/Postgres) qui ne peut pas se faire en local ici :
- **@nestjs/core 10 → 11** (migration coordonnée de tout l'écosystème `@nestjs/*` + Express 5).
- **tar 6 → 7** (ESM), **glob** (multi-majors anciens), **file-type 17/20 → 21** (ESM), **lodash → 4.18.0**, **picomatch**, **@tootallnate/once 1 → 2**.

Refs #1937.