### PR TITLE
fix(a11y): RGAA lot L — contraste couleurs & éléments graphiques (#1782)

### DIFF
--- a/frontend/src/chart/time-chart.builder.ts
+++ b/frontend/src/chart/time-chart.builder.ts
@@ -223,7 +223,7 @@ export class TimeChartBuilder {
       .attr("fill", (d) => color(d.technicalDebtInfo?.costContainment ?? 0))
       .attr("opacity", 0.9)
       .attr("stroke", "#9F0126")
-      .attr("stroke-width", 0.6)
+      .attr("stroke-width", 1)
       .attr("cursor", "pointer")
       .attr("data-testid", "technical-debt-point")
       .on("mouseenter", (_, d) => {

--- a/frontend/src/components/search/SidebarFilter.vue
+++ b/frontend/src/components/search/SidebarFilter.vue
@@ -184,7 +184,7 @@ const total = computed(() => {
 
 .sidebar {
   width: 280px;
-  border-right: 1px solid #e5e7eb;
+  border-right: 1px solid var(--border-contrast-grey);
   box-shadow: 2px 0 8px rgba(0, 0, 0, 0.03);
   max-height: 100%;
   position: relative;
@@ -207,7 +207,7 @@ const total = computed(() => {
     overflow-y: auto;
     z-index: 1000;
     border-right: none;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid var(--border-contrast-grey);
     padding: 1rem;
   }
 
@@ -224,14 +224,14 @@ const total = computed(() => {
   left: 0;
   transform: translateY(-50%);
   background: white;
-  border: 1px solid #dcdfe3;
+  border: 1px solid var(--border-contrast-grey);
   border-radius: 0 6px 6px 0;
   width: 32px;
   height: 48px;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #555;
+  color: #3a3a3a;
   box-shadow: 2px 2px 6px rgba(0, 0, 0, 0.08);
   cursor: pointer;
   transition: all 0.2s ease;

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -68,11 +68,11 @@ body,
   border: none;
   font-size: 1rem;
   cursor: pointer;
-  color: #555;
+  color: #3a3a3a;
   line-height: 1;
 }
 .tag-remove:hover {
-  color: #d60000;
+  color: var(--text-default-error);
 }
 
 .checkbox-list {

--- a/frontend/src/views/MetadataDetailPage.vue
+++ b/frontend/src/views/MetadataDetailPage.vue
@@ -177,15 +177,15 @@ onMounted(() => {
 <style scoped>
 .add {
   background-color: #e6f8ea;
-  color: #1aa779;
+  color: #0a6c4d;
 }
 .update {
   background-color: #f8f3e6;
-  color: #a7791a;
+  color: #6d4e0f;
 }
 .delete {
   background-color: #f8e6e6;
-  color: #a71a1a;
+  color: #8e1212;
 }
 
 .metadata-description {

--- a/frontend/src/views/MetadataPage.vue
+++ b/frontend/src/views/MetadataPage.vue
@@ -282,14 +282,14 @@ const metadataTableRows = computed(() =>
 <style scoped>
 .add {
   background-color: #e6f8ea;
-  color: #1aa779;
+  color: #0a6c4d;
 }
 .update {
   background-color: #f8f3e6;
-  color: #a7791a;
+  color: #6d4e0f;
 }
 .delete {
   background-color: #f8e6e6;
-  color: #a71a1a;
+  color: #8e1212;
 }
 </style>


### PR DESCRIPTION
Closes #1782 — RGAA lot L (Couleurs & contraste).

Corrige les critères **3.2** (contraste des textes, seuil 4.5:1) et **3.3** (contraste des éléments graphiques, seuil 3:1), circonscrits aux couleurs/bordures **custom** hors variables DSFR.

## RGAA-001 — Contraste des textes (≥ 4.5:1)

Tags de statut (`MetadataPage.vue`, `MetadataDetailPage.vue`) et contrôles de la sidebar :

| Élément | Avant | Après | Ratio |
|---|---|---|---|
| `.add` (vert) | `#1aa779` | `#0a6c4d` | 2.77 → **5.81:1** |
| `.update` (orange) | `#a7791a` | `#6d4e0f` | 3.51 → **6.9:1** |
| `.delete` (rouge) | `#a71a1a` | `#8e1212` | 6.22 → **7.77:1** |
| `.sidebar-toggle` / `.tag-remove` | `#555` | `#3a3a3a` | 7.46 → **11.37:1** |
| `.tag-remove:hover` | `#d60000` | `var(--text-default-error)` | **5.76:1** |

> `.add` et `.update` étaient réellement sous le seuil ; les autres sont assombris pour la marge/cohérence demandée par l'audit.

## RGAA-002 — Contraste des éléments graphiques (≥ 3:1)

- **Bordures des filtres** (`SidebarFilter.vue`) : `#e5e7eb` / `#dcdfe3` (≈ 1.2:1) → **`var(--border-contrast-grey)`** (⇒ `#666` en thème clair, **5.74:1**, et theme-aware).
- **Graphe Time** (`time-chart.builder.ts`) : contour des bulles `stroke-width` **0.6 → 1** — chaque bulle est désormais délimitée par un stroke foncé `#9F0126` (~10:1) qui garantit le 3:1 quelle que soit la couleur de remplissage.

## Écarts assumés vs le ticket

- Le ticket suggérait `var(--border-default-grey)` : ce token résout en **`#ddd` (1.36:1)** en thème clair → il **ne corrigeait pas** le contraste. J'ai utilisé **`--border-contrast-grey`** (`#666`, conforme + theme-aware).
- Graphe : je **n'ai pas décalé** le domaine de l'échelle couleur (`interpolateYlOrRd`, déjà `[1, 5]` et non `[0, 5]`) pour ne pas modifier l'encodage visuel des données ; le contraste requis est assuré par le stroke épaissi. À ajuster si l'équipe design préfère l'approche par couleur.

Tous les ratios ont été vérifiés (formule WCAG 2.1) ; les valeurs partent des variables DSFR quand c'est pertinent.

