### PR TITLE
fix(applications): afficher le libellé de statut même sans date (#2017)

### DIFF
--- a/frontend/src/views/ApplicationPage.vue
+++ b/frontend/src/views/ApplicationPage.vue
@@ -184,9 +184,13 @@ const actions = computed(() => [
       </DsfrButton>
       <div class="status-tags" aria-hidden="false" data-testid="application-tags">
         <DsfrTag
-          v-if="application.currentStatus?.statusDate"
+          v-if="application.currentStatus?.status"
           class="fr-mr-1v"
-          :label="`${statusApplicationDictionary[application.currentStatus.status]} depuis le ${formatDateFR(application.currentStatus.statusDate)}`"
+          :label="
+            application.currentStatus.statusDate
+              ? `${statusApplicationDictionary[application.currentStatus.status]} depuis le ${formatDateFR(application.currentStatus.statusDate)}`
+              : statusApplicationDictionary[application.currentStatus.status]
+          "
           data-testid="application-status-tag"
         />
 


### PR DESCRIPTION
Closes #2017.

## Bug

Sur la fiche application, le libellé du statut (affiché près de la cloche « s'abonner ») **disparaissait** dès que le statut n'avait **pas de date** — visible notamment quand l'application n'a que l'état « Décommissionné », mais valable pour tous les états.

## Cause

Dans `ApplicationPage.vue`, le tag de statut était conditionné à la **date** et non au statut :

```vue
<DsfrTag v-if="application.currentStatus?.statusDate" :label="`${dico[status]} depuis le ${date}`" />
```

Or `statusDate` est optionnel (`currentStatus` peut exister sans date). Sans date → le tag entier n'était pas rendu.

## Correctif

Afficher le libellé dès qu'un **statut** existe ; la mention « depuis le `<date>` » n'est ajoutée que si la date est présente :

```vue
<DsfrTag
  v-if="application.currentStatus?.status"
  :label="
    application.currentStatus.statusDate
      ? `${dico[status]} depuis le ${date}`
      : dico[status]
  "
/>
```

Le nom du statut est désormais toujours visible ; la date reste un complément.

## Tests

`ApplicationPage.vue` est une page à fort couplage (stores Pinia, router, appels API au montage) et le repo n'a qu'un test unitaire de composant simple — un unitaire ciblé serait disproportionné et fragile. La couverture idéale de ce cas est un **e2e Playwright** avec une application au statut « Décommissionné » sans date ; je peux l'ajouter en suivi si souhaité. Le correctif reste un simple conditionnel de template (aucun changement de logique métier).
