### PR TITLE
fix(search): recherche globale du header — préfixe + fiabilisation complète (#2025)

### DIFF
--- a/.github/ISSUE_TEMPLATE/qa-accueil.md
+++ b/.github/ISSUE_TEMPLATE/qa-accueil.md
@@ -21,7 +21,7 @@ labels: ["qa", "non-regression", "qa:accueil"]
 
 | Total | ✅ Passés | ❌ Échecs | ⏭️ Non testés |
 | ----- | --------- | --------- | ------------- |
-| 14    |           |           |               |
+| 15    |           |           |               |
 
 ## Protocole
 

--- a/.github/ISSUE_TEMPLATE/qa-accueil.md
+++ b/.github/ISSUE_TEMPLATE/qa-accueil.md
@@ -21,7 +21,7 @@ labels: ["qa", "non-regression", "qa:accueil"]
 
 | Total | ✅ Passés | ❌ Échecs | ⏭️ Non testés |
 | ----- | --------- | --------- | ------------- |
-| 10    |           |           |               |
+| 14    |           |           |               |
 
 ## Protocole
 

--- a/backend/prisma/migrations/20260715120000_add_simple_prefix_search_index/migration.sql
+++ b/backend/prisma/migrations/20260715120000_add_simple_prefix_search_index/migration.sql
@@ -1,0 +1,65 @@
+-- Recrée la vue matérialisée de recherche pour ajouter un document `document_simple`
+-- (dictionnaire `simple`, sans lemmatisation) dédié à l'autocomplétion par préfixe.
+--
+-- Problème corrigé (recherche globale du header) :
+--   `to_tsquery('french', 'mot:*')` lemmatise le terme saisi. La frappe partielle
+--   d'un mot (autocomplétion) produit alors un lexème qui ne préfixe PAS le lexème
+--   indexé lemmatisé — ex. « applic » ne matche pas « appliqu » (stem de
+--   « application »), « informat » ne matche pas « inform ». Résultat : l'application
+--   disparaît en cours de frappe puis réapparaît au mot complet.
+--
+-- Un document `simple` (non lemmatisé) rend le préfixe littéral : « applic:* » matche
+-- « application » à chaque étape de la frappe. Le document `french` pondéré est
+-- conservé pour la recherche par pertinence (paramètre `q`), où la lemmatisation
+-- reste souhaitable.
+
+DROP MATERIALIZED VIEW IF EXISTS application_search_index;
+
+CREATE MATERIALIZED VIEW application_search_index AS
+SELECT
+  a.id AS "applicationId",
+  -- Document lemmatisé (french) — recherche par pertinence (`q`).
+  setweight(to_tsvector('french', immutable_unaccent(coalesce(a.label, ''))), 'A') ||
+  setweight(to_tsvector('french', immutable_unaccent(coalesce(a."shortName", ''))), 'A') ||
+  setweight(to_tsvector('french', immutable_unaccent(coalesce(a.description, ''))), 'B') ||
+  setweight(to_tsvector('french', immutable_unaccent(coalesce(array_to_string(a.purposes, ' '), ''))), 'B') ||
+  setweight(to_tsvector('french', immutable_unaccent(coalesce(array_to_string(a."targetPopulations", ' '), ''))), 'B') ||
+  setweight(to_tsvector('french', immutable_unaccent(coalesce(tags.value, ''))), 'C') ||
+  setweight(to_tsvector('french', immutable_unaccent(coalesce(labels.value, ''))), 'C') ||
+  setweight(to_tsvector('french', immutable_unaccent(coalesce(actors.value, ''))), 'C') AS document,
+  -- Document non lemmatisé (simple) — autocomplétion par préfixe (`qPrefix`).
+  setweight(to_tsvector('simple', immutable_unaccent(coalesce(a.label, ''))), 'A') ||
+  setweight(to_tsvector('simple', immutable_unaccent(coalesce(a."shortName", ''))), 'A') ||
+  setweight(to_tsvector('simple', immutable_unaccent(coalesce(a.description, ''))), 'B') ||
+  setweight(to_tsvector('simple', immutable_unaccent(coalesce(array_to_string(a.purposes, ' '), ''))), 'B') ||
+  setweight(to_tsvector('simple', immutable_unaccent(coalesce(array_to_string(a."targetPopulations", ' '), ''))), 'B') ||
+  setweight(to_tsvector('simple', immutable_unaccent(coalesce(tags.value, ''))), 'C') ||
+  setweight(to_tsvector('simple', immutable_unaccent(coalesce(labels.value, ''))), 'C') ||
+  setweight(to_tsvector('simple', immutable_unaccent(coalesce(actors.value, ''))), 'C') AS document_simple
+FROM "Application" a
+LEFT JOIN LATERAL (
+  SELECT string_agg(t.name, ' ') AS value
+  FROM "_ApplicationToTag" att
+  JOIN "Tag" t ON t.id = att."B"
+  WHERE att."A" = a.id
+) tags ON true
+LEFT JOIN LATERAL (
+  SELECT string_agg(l.value, ' ') AS value
+  FROM "Label" l
+  WHERE l."applicationId" = a.id
+) labels ON true
+LEFT JOIN LATERAL (
+  SELECT string_agg(concat_ws(' ', ac.firstname, ac.lastname), ' ') AS value
+  FROM "Actor" ac
+  WHERE ac."applicationId" = a.id
+) actors ON true;
+
+-- Index.
+--   - Unique sur applicationId : requis par REFRESH MATERIALIZED VIEW CONCURRENTLY.
+--   - GIN sur chaque document : recherche full-text performante.
+CREATE UNIQUE INDEX application_search_index_application_id_key
+  ON application_search_index ("applicationId");
+CREATE INDEX application_search_index_document_idx
+  ON application_search_index USING gin (document);
+CREATE INDEX application_search_index_document_simple_idx
+  ON application_search_index USING gin (document_simple);

--- a/backend/src/applications/dto/search-application.dto.ts
+++ b/backend/src/applications/dto/search-application.dto.ts
@@ -9,6 +9,7 @@ import {
   IsOptional,
   IsString,
   Max,
+  MaxLength,
   Min,
 } from "class-validator";
 import { PaginationDto } from "src/common/dto";
@@ -59,6 +60,7 @@ export class ApplicationSearchDto extends PaginationDto {
   })
   @IsOptional()
   @IsString()
+  @MaxLength(200)
   q?: string;
 
   @ApiPropertyOptional({
@@ -71,6 +73,7 @@ export class ApplicationSearchDto extends PaginationDto {
   })
   @IsOptional()
   @IsString()
+  @MaxLength(200)
   qPrefix?: string;
 
   @ApiPropertyOptional({

--- a/backend/src/applications/search/application-search.service.spec.ts
+++ b/backend/src/applications/search/application-search.service.spec.ts
@@ -47,6 +47,13 @@ describe("ApplicationSearchService", () => {
       expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
       // La valeur interpolée dans le tagged template = la tsquery construite.
       expect(prisma.$queryRaw.mock.calls[0][1]).toBe("tow:* & muel:*");
+      // L'autocomplétion par préfixe cible le document `simple` (non lemmatisé),
+      // sinon la frappe partielle d'un mot ne matche pas le lexème lemmatisé.
+      const prefixSql = (
+        prisma.$queryRaw.mock.calls[0][0] as unknown as string[]
+      ).join("");
+      expect(prefixSql).toContain("document_simple");
+      expect(prefixSql).toContain("to_tsquery('simple'");
       expect(result).toEqual([{ id: "app-1", rank: 1 }]);
     });
 

--- a/backend/src/applications/search/application-search.service.spec.ts
+++ b/backend/src/applications/search/application-search.service.spec.ts
@@ -37,7 +37,7 @@ describe("ApplicationSearchService", () => {
   });
 
   describe("fullTextSearchPrefix", () => {
-    it("construit une to_tsquery préfixe et nettoie la ponctuation", async () => {
+    it("construit une to_tsquery préfixe ciblant le document `simple`", async () => {
       const { service, prisma } = makeService([
         { applicationId: "app-1", rank: 1 },
       ]);
@@ -55,6 +55,28 @@ describe("ApplicationSearchService", () => {
       expect(prefixSql).toContain("document_simple");
       expect(prefixSql).toContain("to_tsquery('simple'");
       expect(result).toEqual([{ id: "app-1", rank: 1 }]);
+    });
+
+    it("DÉCOUPE la ponctuation interne au lieu de coller les morceaux (nom trouvable)", async () => {
+      // Non-régression : retirer la ponctuation *en concaténant* (« O'Kon » → « OKon »,
+      // « QA-GROUP-CHILD » → « QAGROUPCHILD ») produit un lexème absent de l'index,
+      // rendant l'application introuvable en tapant son propre nom. Le parseur PG
+      // segmente sur la ponctuation → la tsquery doit faire de même.
+      const { service, prisma } = makeService([
+        { applicationId: "app-1", rank: 1 },
+      ]);
+
+      await service.fullTextSearchPrefix("O'Kon");
+      await service.fullTextSearchPrefix("QA-GROUP-CHILD");
+      await service.fullTextSearchPrefix("Runolfsdottir - O'Kon");
+
+      expect(prisma.$queryRaw.mock.calls[0][1]).toBe("O:* & Kon:*");
+      expect(prisma.$queryRaw.mock.calls[1][1]).toBe(
+        "QA:* & GROUP:* & CHILD:*",
+      );
+      expect(prisma.$queryRaw.mock.calls[2][1]).toBe(
+        "Runolfsdottir:* & O:* & Kon:*",
+      );
     });
 
     it("retourne [] sans interroger la base pour une requête vide ou ponctuation seule", async () => {

--- a/backend/src/applications/search/application-search.service.ts
+++ b/backend/src/applications/search/application-search.service.ts
@@ -28,8 +28,17 @@ const MATERIALIZED_VIEW = "application_search_index";
  * court (« a ») peut matcher quasi toutes les applications ; l'autocomplétion
  * n'affiche que les premiers résultats, inutile de classer et transporter
  * l'intégralité de la base.
+ *
+ * ATTENTION : ce plafond s'applique au classement FTS *avant* le filtrage par
+ * permissions (l'intersection `id IN (rankedIds)` est faite ensuite côté Prisma,
+ * cf. application.service). Une valeur trop basse pourrait masquer des
+ * applications autorisées d'un utilisateur si elles sont classées au-delà du
+ * plafond pour un préfixe donné. 1000 rend ce cas très improbable tout en
+ * gardant la requête rapide (index GIN + LIMIT). Le filtrage des permissions
+ * dans la requête SQL elle-même serait la solution complète mais bien plus
+ * lourde (la logique de droits vit dans buildSearchWhere).
  */
-const PREFIX_RESULT_LIMIT = 200;
+const PREFIX_RESULT_LIMIT = 1000;
 
 /** Durée de vie du cache des résultats FTS. Courte : elle borne seulement la
  * staleness si l'index est rafraîchi par une autre instance de l'application. */

--- a/backend/src/applications/search/application-search.service.ts
+++ b/backend/src/applications/search/application-search.service.ts
@@ -143,10 +143,10 @@ export class ApplicationSearchService implements ApplicationSearchEngine {
       { applicationId: string; rank: number }[]
     >`
       SELECT asi."applicationId",
-             ts_rank(asi.document, q.query)::float8 AS rank
+             ts_rank(asi.document_simple, q.query)::float8 AS rank
       FROM application_search_index asi,
-           to_tsquery('french', immutable_unaccent(${tsQuery})) AS q(query)
-      WHERE asi.document @@ q.query
+           to_tsquery('simple', immutable_unaccent(${tsQuery})) AS q(query)
+      WHERE asi.document_simple @@ q.query
       ORDER BY rank DESC
       LIMIT ${PREFIX_RESULT_LIMIT}
     `;

--- a/backend/src/applications/search/application-search.service.ts
+++ b/backend/src/applications/search/application-search.service.ts
@@ -100,7 +100,7 @@ export class ApplicationSearchService implements ApplicationSearchEngine {
       FROM application_search_index asi,
            plainto_tsquery('french', immutable_unaccent(${trimmed})) AS q(query)
       WHERE asi.document @@ q.query
-      ORDER BY rank DESC
+      ORDER BY rank DESC, asi."applicationId"
     `;
 
     const results = rows.map((row) => ({
@@ -147,7 +147,7 @@ export class ApplicationSearchService implements ApplicationSearchEngine {
       FROM application_search_index asi,
            to_tsquery('simple', immutable_unaccent(${tsQuery})) AS q(query)
       WHERE asi.document_simple @@ q.query
-      ORDER BY rank DESC
+      ORDER BY rank DESC, asi."applicationId"
       LIMIT ${PREFIX_RESULT_LIMIT}
     `;
 

--- a/backend/src/applications/search/application-search.service.ts
+++ b/backend/src/applications/search/application-search.service.ts
@@ -125,8 +125,15 @@ export class ApplicationSearchService implements ApplicationSearchEngine {
    *
    * Chaque mot saisi est transformé en motif préfixe (`mot:*`) puis combiné en
    * ET. Ainsi « tow muel » trouve « Towne, Mueller… » avant même que les mots
-   * soient complets. Les caractères non alphanumériques sont retirés pour
-   * produire une `to_tsquery` toujours valide (pas d'injection d'opérateurs).
+   * soient complets.
+   *
+   * La saisie est **découpée** sur tout caractère non alphanumérique (espaces ET
+   * ponctuation), pas seulement sur les espaces : le parseur plein-texte de
+   * Postgres segmente lui aussi sur la ponctuation (« O'Kon » → `o`,`kon` ;
+   * « QA-GROUP-CHILD » → `qa`,`group`,`child`). Retirer la ponctuation *en
+   * collant* les morceaux (« OKon », « QAGROUPCHILD ») produirait un lexème
+   * absent de l'index : l'application devenait alors introuvable en tapant son
+   * propre nom. Le découpage garantit qu'un nom se retrouve toujours lui-même.
    *
    * Résultats plafonnés à {@link PREFIX_RESULT_LIMIT} : un préfixe très court
    * matcherait toute la base, or l'autocomplétion n'en affiche qu'une poignée.
@@ -136,8 +143,7 @@ export class ApplicationSearchService implements ApplicationSearchEngine {
   ): Promise<RankedApplication[]> {
     const tokens = query
       ?.trim()
-      .split(/\s+/)
-      .map((token) => token.replace(/[^\p{L}\p{N}]/gu, ""))
+      .split(/[^\p{L}\p{N}]+/u)
       .filter(Boolean);
 
     if (!tokens?.length) return [];

--- a/e2e/fixtures/datafeature.ts
+++ b/e2e/fixtures/datafeature.ts
@@ -43,9 +43,18 @@ export class DataFeature {
    * jeu courant n'en contient aucune.
    */
   async applicationWithPunctuationInLabel(): Promise<AppRef | null> {
-    const page = await this.api.applications("pageSize=200&page=0");
     const internalPunct = /[\p{L}\p{N}][^\p{L}\p{N}\s][\p{L}\p{N}]/u;
-    return page?.results?.find((a) => internalPunct.test(a.label)) ?? null;
+    const pageSize = 100; // plafond API ; on pagine car les noms ponctués (O…, Q…) sont plus loin.
+    for (let page = 0; page < 30; page++) {
+      const res = await this.api.applications(
+        `pageSize=${pageSize}&page=${page}`,
+      );
+      const results = res?.results ?? [];
+      const match = results.find((a) => internalPunct.test(a.label));
+      if (match) return match;
+      if (results.length < pageSize) break; // dernière page atteinte
+    }
+    return null;
   }
 
   /**

--- a/e2e/fixtures/datafeature.ts
+++ b/e2e/fixtures/datafeature.ts
@@ -35,6 +35,20 @@ export class DataFeature {
   }
 
   /**
+   * Une application dont le libellé contient une ponctuation **interne** (entre deux
+   * caractères alphanumériques, sans espace) — ex. « O'Kon », « QA-GROUP-CHILD ».
+   * Sert à vérifier qu'un tel nom reste trouvable en le tapant en entier dans la
+   * recherche du header : non-régression du bug de tokenisation (la ponctuation doit
+   * être découpée, pas supprimée-collée en un lexème absent de l'index). `null` si le
+   * jeu courant n'en contient aucune.
+   */
+  async applicationWithPunctuationInLabel(): Promise<AppRef | null> {
+    const page = await this.api.applications("pageSize=200&page=0");
+    const internalPunct = /[\p{L}\p{N}][^\p{L}\p{N}\s][\p{L}\p{N}]/u;
+    return page?.results?.find((a) => internalPunct.test(a.label)) ?? null;
+  }
+
+  /**
    * Une application possédant une évaluation de dette technique, afin que la carte « Dette
    * technique » (et son libellé « Maîtrise des coûts ») soit rendue sur l'onglet Informations
    * générales (FIC-15, ticket #1900). Sème l'évaluation « create-if-absent » sur la première

--- a/e2e/pom/chrome.page.ts
+++ b/e2e/pom/chrome.page.ts
@@ -124,6 +124,20 @@ export class ChromePage extends BasePage {
   }
 
   /**
+   * ACC-15 : après saisie de `query`, une suggestion portant `expectedLabel` est proposée.
+   * Plus fort que « au moins une suggestion » : vérifie que l'application ciblée remonte bien.
+   */
+  async expectQuickSearchSuggestion(
+    query: string,
+    expectedLabel: string,
+  ): Promise<void> {
+    await this.fillQuickSearch(query);
+    await expect(
+      this.quickSearchOptions().filter({ hasText: expectedLabel }).first(),
+    ).toBeVisible();
+  }
+
+  /**
    * ACC-13 : un terme sans correspondance affiche « Aucun résultat » (état vide de l'autocomplete).
    * On cible le message dans la liste, pas la région `aria-live` (qui porte le même texte).
    */

--- a/e2e/pom/chrome.page.ts
+++ b/e2e/pom/chrome.page.ts
@@ -99,6 +99,73 @@ export class ChromePage extends BasePage {
     await expect(this.page).toHaveURL(/\/applications\/[^/]+/);
   }
 
+  // Liste de suggestions et options réelles de la recherche rapide (encapsulées, POM strict).
+  private quickSearchListbox = () =>
+    this.header().getByRole("listbox", { name: "Applications proposées" });
+  private quickSearchOptions = () =>
+    this.quickSearchListbox().getByRole("option");
+
+  /** Saisit une requête dans la recherche rapide (déclenche l'autocomplétion débouncée). */
+  async fillQuickSearch(query: string): Promise<void> {
+    await this.quickSearch().fill(query);
+  }
+
+  /**
+   * ACC-11 : un préfixe court **non lemmatisé** doit ramener au moins une suggestion.
+   * Non-régression du bug FTS : le dictionnaire `french` racinisait « Application » en
+   * « appliqu », si bien qu'un préfixe court (« appli ») ne matchait plus ; la recherche
+   * préfixe s'appuie désormais sur `document_simple` (dictionnaire `simple`).
+   */
+  async expectQuickSearchHasSuggestions(query: string): Promise<void> {
+    await this.fillQuickSearch(query);
+    await expect
+      .poll(() => this.quickSearchOptions().count(), { timeout: 10000 })
+      .toBeGreaterThan(0);
+  }
+
+  /**
+   * ACC-13 : un terme sans correspondance affiche « Aucun résultat » (état vide de l'autocomplete).
+   * On cible le message dans la liste, pas la région `aria-live` (qui porte le même texte).
+   */
+  async expectQuickSearchNoResult(query: string): Promise<void> {
+    await this.fillQuickSearch(query);
+    await expect(
+      this.quickSearchListbox().getByText("Aucun résultat"),
+    ).toBeVisible();
+  }
+
+  /** ACC-14 : après saisie, la liste est déployée (`aria-expanded=true`) et visible. */
+  async expectQuickSearchExpanded(): Promise<void> {
+    await expect(this.quickSearch()).toHaveAttribute("aria-expanded", "true");
+    await expect(this.quickSearchListbox()).toBeVisible();
+  }
+
+  /**
+   * ACC-14 (RGAA 4.1.2) : la flèche bas active la première option — `aria-activedescendant`
+   * du combobox la désigne et l'option porte `aria-selected="true"`.
+   */
+  async quickSearchHighlightFirstOption(): Promise<void> {
+    await expect
+      .poll(() => this.quickSearchOptions().count(), { timeout: 10000 })
+      .toBeGreaterThan(0);
+    await this.quickSearch().press("ArrowDown");
+    await expect(this.quickSearch()).toHaveAttribute(
+      "aria-activedescendant",
+      /-item-0$/,
+    );
+    await expect(this.quickSearchOptions().first()).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  }
+
+  /** ACC-14 (RGAA 4.1.2) : Échap referme la liste (`aria-expanded=false`, liste masquée). */
+  async quickSearchEscapeCollapses(): Promise<void> {
+    await this.quickSearch().press("Escape");
+    await expect(this.quickSearch()).toHaveAttribute("aria-expanded", "false");
+    await expect(this.quickSearchListbox()).toBeHidden();
+  }
+
   // --- Assertions RGAA (RGA-03, RGA-04) ---
 
   /**

--- a/e2e/tests/accueil.spec.ts
+++ b/e2e/tests/accueil.spec.ts
@@ -189,4 +189,18 @@ test.describe("Accueil & chrome", () => {
     await chrome.quickSearchHighlightFirstOption(); // flèche bas → 1re option active
     await chrome.quickSearchEscapeCollapses(); // Échap → liste refermée
   });
+
+  test("ACC-15 - recherche rapide : une app au nom ponctué est trouvable par son nom complet", async ({
+    page,
+    data,
+  }) => {
+    const app = await data.applicationWithPunctuationInLabel();
+    test.skip(!app, "Aucune application au nom ponctué dans le jeu de données");
+
+    const chrome = new ChromePage(page);
+    await chrome.open();
+    // Non-régression : taper le nom COMPLET (avec sa ponctuation interne, ex. « O'Kon »,
+    // « QA-GROUP-CHILD ») doit bien remonter cette application précise.
+    await chrome.expectQuickSearchSuggestion(app!.label, app!.label);
+  });
 });

--- a/e2e/tests/accueil.spec.ts
+++ b/e2e/tests/accueil.spec.ts
@@ -1,6 +1,6 @@
 import { test as base } from "@playwright/test";
 import { test, expect } from "../fixtures/test";
-import { ChromePage, HomePage, loginAs } from "../pom";
+import { ChromePage, HomePage, SearchPage, loginAs } from "../pom";
 import { captureStepScreenshot } from "../support/screenshots";
 
 /**
@@ -131,5 +131,62 @@ test.describe("Accueil & chrome", () => {
     await chrome.open();
     // Préfixe court d'un libellé réel → ramène des suggestions dans l'autocomplete du header.
     await chrome.quickSearchToFiche(app!.label.slice(0, 4));
+  });
+
+  test("ACC-11 - recherche rapide : un préfixe court non lemmatisé ramène des suggestions", async ({
+    page,
+    data,
+  }) => {
+    const app = await data.firstApplication();
+    test.skip(!app, "Aucune application dans le jeu de données");
+
+    const chrome = new ChromePage(page);
+    await chrome.open();
+    // Préfixe court d'un libellé réel : doit ramener ≥ 1 suggestion (garde la non-régression du
+    // bug de racinisation française — l'index préfixe repose sur `document_simple`).
+    await chrome.expectQuickSearchHasSuggestions(app!.label.slice(0, 4));
+  });
+
+  test("ACC-12 - recherche rapide indépendante des filtres de la page de recherche", async ({
+    page,
+    data,
+  }) => {
+    const app = await data.firstApplication();
+    test.skip(!app, "Aucune application dans le jeu de données");
+
+    // On filtre la page de recherche jusqu'à un état vide (0 résultat)…
+    const search = new SearchPage(page);
+    await search.open();
+    await search.searchByLabel("zzqxwvkjno-aucune-correspondance");
+    await search.expectEmptyState();
+
+    // … la recherche rapide du bandeau reste alimentée (indépendante des filtres, triée par pertinence).
+    const chrome = new ChromePage(page);
+    await chrome.expectQuickSearchHasSuggestions(app!.label.slice(0, 4));
+  });
+
+  test("ACC-13 - recherche rapide : un terme sans correspondance affiche « Aucun résultat »", async ({
+    page,
+    data,
+  }) => {
+    void data;
+    const chrome = new ChromePage(page);
+    await chrome.open();
+    await chrome.expectQuickSearchNoResult("zzqxwvkjno-aucune-correspondance");
+  });
+
+  test("ACC-14 - recherche rapide : navigation clavier dans l'autocomplete (RGAA 4.1.2)", async ({
+    page,
+    data,
+  }) => {
+    const app = await data.firstApplication();
+    test.skip(!app, "Aucune application dans le jeu de données");
+
+    const chrome = new ChromePage(page);
+    await chrome.open();
+    await chrome.fillQuickSearch(app!.label.slice(0, 4));
+    await chrome.expectQuickSearchExpanded();
+    await chrome.quickSearchHighlightFirstOption(); // flèche bas → 1re option active
+    await chrome.quickSearchEscapeCollapses(); // Échap → liste refermée
   });
 });

--- a/frontend/src/components/AccessibleAutocomplete.vue
+++ b/frontend/src/components/AccessibleAutocomplete.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { onClickOutside, watchDebounced } from "@vueuse/core";
-import { computed, ref } from "vue";
+import { computed, nextTick, ref } from "vue";
 
 interface Props<T> {
   id?: string;
@@ -16,28 +16,48 @@ interface Props<T> {
 }
 
 const props = defineProps<Props<any>>();
-const emit = defineEmits(["onChange", "onInputValueChange"]);
+const emit = defineEmits(["onChange", "onInputValueChange", "close"]);
 
 const inputValue = ref("");
 const results = ref<any[]>([]);
 const highlightedIndex = ref(-1);
 const loading = ref(false);
+const hasSearched = ref(false);
 const showList = ref(false);
 const inputEl = ref<HTMLInputElement | null>(null);
 const containerEl = ref<HTMLElement | null>(null);
 
+// Ids propres à l'instance : évite les collisions d'id d'options (et
+// l'ambiguïté d'aria-activedescendant) si plusieurs autocomplete coexistent.
+const optionIdPrefix = computed(() => props.id ?? "autocomplete");
+const listId = computed(() => `${optionIdPrefix.value}-list`);
+const optionId = (index: number) => `${optionIdPrefix.value}-item-${index}`;
+
+// Compteur de requêtes : neutralise les réponses obsolètes / en désordre.
+let latestRequestId = 0;
+
 async function doSearch(query: string) {
   highlightedIndex.value = -1;
   if (!query) {
+    latestRequestId++; // invalide toute réponse en vol
     results.value = [];
+    hasSearched.value = false;
+    loading.value = false;
     return;
   }
+  const requestId = ++latestRequestId;
   loading.value = true;
   try {
     const searchResults = await props.search(query);
+    if (requestId !== latestRequestId) return; // réponse obsolète : ignorée
     results.value = searchResults;
+    hasSearched.value = true;
+  } catch {
+    if (requestId !== latestRequestId) return;
+    results.value = [];
+    hasSearched.value = true;
   } finally {
-    loading.value = false;
+    if (requestId === latestRequestId) loading.value = false;
   }
 }
 
@@ -57,13 +77,27 @@ watchDebounced(
 );
 
 function select(item: any) {
-  props.onChange?.(item);
-  emit("onChange", item);
+  // Affecter l'état AVANT les callbacks : si le consommateur vide le champ
+  // (clear() depuis onChange), c'est son intention qui doit gagner en dernier.
   inputValue.value = props.displayLabel(item);
   showList.value = false;
+  props.onChange?.(item);
+  emit("onChange", item);
+}
+
+async function scrollHighlightedIntoView() {
+  await nextTick();
+  document.getElementById(optionId(highlightedIndex.value))?.scrollIntoView({ block: "nearest" });
 }
 
 function onKeydown(e: KeyboardEvent) {
+  if (e.key === "Escape") {
+    // Liste déjà fermée : on remonte la demande de fermeture au parent
+    // (ex. overlay de recherche mobile).
+    if (showList.value) showList.value = false;
+    else emit("close");
+    return;
+  }
   if (!showList.value) return;
   const count = results.value.length;
   const current = Number.isInteger(highlightedIndex.value) ? highlightedIndex.value : -1;
@@ -71,22 +105,25 @@ function onKeydown(e: KeyboardEvent) {
     e.preventDefault();
     if (!count) return;
     highlightedIndex.value = (current + 1) % count;
+    scrollHighlightedIntoView();
   } else if (e.key === "ArrowUp") {
     e.preventDefault();
     if (!count) return;
     highlightedIndex.value = (current - 1 + count) % count;
+    scrollHighlightedIntoView();
   } else if (e.key === "Enter" && current >= 0 && current < count) {
     e.preventDefault();
     select(results.value[current]);
-  } else if (e.key === "Escape") {
-    showList.value = false;
   }
 }
 
 function clear() {
+  latestRequestId++; // invalide toute réponse en vol
   inputValue.value = "";
   results.value = [];
   highlightedIndex.value = -1;
+  hasSearched.value = false;
+  loading.value = false;
   showList.value = false;
 }
 
@@ -96,23 +133,23 @@ function focus() {
 defineExpose({ clear, focus });
 
 const hasResults = computed(() => results.value.length > 0);
+// « Aucun résultat » uniquement après une recherche aboutie, hors chargement.
+const showEmpty = computed(
+  () => !!props.displayNoResult && !loading.value && hasSearched.value && inputValue.value.trim().length > 0 && !hasResults.value,
+);
 
 const ariaActiveDescendant = computed(() => {
-  if (highlightedIndex.value >= 0 && showList.value) {
-    return `autocomplete-item-${highlightedIndex.value}`;
-  }
+  if (highlightedIndex.value >= 0 && showList.value) return optionId(highlightedIndex.value);
   return undefined;
 });
 
-const ariaDescribedById = computed(() => {
-  return props.id ? `${props.id}-helptext` : undefined;
-});
+const ariaDescribedById = computed(() => (props.id ? `${props.id}-helptext` : undefined));
 
 const liveRegionText = computed(() => {
   if (!showList.value) return "";
-  if (results.value.length === 0) {
-    return props.displayNoResult ? "Aucun résultat" : "";
-  }
+  if (loading.value) return "Recherche en cours…";
+  if (!hasSearched.value) return "";
+  if (results.value.length === 0) return props.displayNoResult ? "Aucun résultat" : "";
   const n = results.value.length;
   return `${n} suggestion${n > 1 ? "s" : ""} disponible${n > 1 ? "s" : ""}, utilisez les flèches haut et bas pour naviguer, Entrée pour sélectionner.`;
 });
@@ -136,7 +173,7 @@ onClickOutside(containerEl, () => {
       autocomplete="off"
       role="combobox"
       aria-autocomplete="list"
-      :aria-controls="id ? id + '-list' : 'autocomplete-list'"
+      :aria-controls="listId"
       :aria-activedescendant="ariaActiveDescendant"
       :aria-expanded="showList"
       :aria-describedby="ariaDescribedById"
@@ -146,32 +183,34 @@ onClickOutside(containerEl, () => {
     </div>
 
     <ul
-      v-if="showList && (hasResults || displayNoResult)"
-      :id="id ? id + '-list' : 'autocomplete-list'"
+      v-if="showList && (hasResults || showEmpty || loading)"
+      :id="listId"
       class="autocomplete-list"
       role="listbox"
       :aria-label="listLabel ?? 'Suggestions'"
     >
-      <li v-for="(item, index) in results" :key="index" role="presentation">
-        <button
-          type="button"
-          class="autocomplete-item"
-          :id="`autocomplete-item-${index}`"
-          :class="{ highlighted: index === highlightedIndex }"
-          tabindex="-1"
-          role="option"
-          :aria-selected="index === highlightedIndex ? 'true' : 'false'"
-          @click="select(item)"
-        >
-          <slot name="suggestion" :item="item">
-            {{ props.displayLabel(item) }}
-          </slot>
-        </button>
-      </li>
+      <li v-if="loading" class="autocomplete-status" role="presentation">Recherche en cours…</li>
 
-      <li v-if="!hasResults && displayNoResult" class="no-result" role="option" :aria-selected="false" aria-disabled="true">
-        Aucun résultat
-      </li>
+      <template v-else>
+        <li v-for="(item, index) in results" :key="index" role="presentation">
+          <button
+            type="button"
+            class="autocomplete-item"
+            :id="optionId(index)"
+            :class="{ highlighted: index === highlightedIndex }"
+            tabindex="-1"
+            role="option"
+            :aria-selected="index === highlightedIndex ? 'true' : 'false'"
+            @click="select(item)"
+          >
+            <slot name="suggestion" :item="item">
+              {{ props.displayLabel(item) }}
+            </slot>
+          </button>
+        </li>
+
+        <li v-if="showEmpty" class="no-result" role="presentation">Aucun résultat</li>
+      </template>
     </ul>
 
     <div class="visually-hidden" aria-live="polite" aria-atomic="true">{{ liveRegionText }}</div>
@@ -213,7 +252,8 @@ onClickOutside(containerEl, () => {
 .autocomplete-item:hover {
   background: #e5e7eb;
 }
-.no-result {
+.no-result,
+.autocomplete-status {
   padding: 0.5rem 0.75rem;
   color: #6b7280;
 }

--- a/frontend/src/components/search/SearchHeader.vue
+++ b/frontend/src/components/search/SearchHeader.vue
@@ -15,6 +15,7 @@ const router = useRouter();
 const { searchApplications } = useApplicationSearch();
 const searchRef = ref<{ clear?: () => void; focus?: () => void } | null>(null);
 const openBtnRef = ref<{ $el?: HTMLElement } | null>(null);
+const closeBtnRef = ref<{ $el?: HTMLElement } | null>(null);
 const isMobile = useMediaQuery("(max-width: 768px)");
 const showInput = ref(!isMobile.value);
 
@@ -38,6 +39,23 @@ function closeSearch() {
   showInput.value = false;
   searchRef.value?.clear?.();
   restoreLoupeFocus();
+}
+
+// Piège de focus de la boîte de dialogue mobile : le Tab boucle entre le champ
+// de recherche et le bouton « Fermer », sans jamais sortir de l'overlay.
+function onOverlayKeydown(e: KeyboardEvent) {
+  if (e.key !== "Tab") return;
+  const input = document.getElementById("app-search");
+  const closeBtn = closeBtnRef.value?.$el?.querySelector("button");
+  if (!input || !closeBtn) return;
+  const active = document.activeElement;
+  if (!e.shiftKey && active === closeBtn) {
+    e.preventDefault();
+    input.focus();
+  } else if (e.shiftKey && active === input) {
+    e.preventDefault();
+    closeBtn.focus();
+  }
 }
 
 async function fetchSuggestions(searchQuery: string): Promise<ApplicationOption[]> {
@@ -98,6 +116,7 @@ function onClose() {
       :role="isMobile && showInput ? 'dialog' : undefined"
       :aria-modal="isMobile && showInput ? 'true' : undefined"
       :aria-label="isMobile && showInput ? 'Recherche d’une application' : undefined"
+      @keydown="isMobile && showInput ? onOverlayKeydown($event) : undefined"
     >
       <div :class="{ 'overlay-header': isMobile && showInput }">
         <AccessibleAutocomplete
@@ -122,6 +141,7 @@ function onClose() {
 
         <DsfrButton
           v-if="isMobile && showInput"
+          ref="closeBtnRef"
           @click="closeSearch"
           tertiary
           class="close-overlay"
@@ -164,6 +184,11 @@ function onClose() {
   flex-shrink: 0;
 }
 
+/* FIXME : `-18.99em` est un nombre magique fragile qui remonte la loupe dans le
+   bandeau. Il dépend de la hauteur du header et casserait à la moindre évolution
+   de mise en page. À remplacer par un positionnement robuste (le header devrait
+   piloter l'alignement, p. ex. flex/grid) — à faire avec une vérification
+   visuelle mobile, non modifié ici pour ne pas régresser à l'aveugle. */
 .loupe-button {
   position: relative;
   margin-top: -18.99em;

--- a/frontend/src/components/search/SearchHeader.vue
+++ b/frontend/src/components/search/SearchHeader.vue
@@ -1,24 +1,28 @@
 <script setup lang="ts">
-import { ref, nextTick } from "vue";
+import { ref, nextTick, watch } from "vue";
 import { useRouter } from "vue-router";
 import AccessibleAutocomplete from "../AccessibleAutocomplete.vue";
 import { useApplicationSearch } from "@/composables/use-application-search";
-import { useDebounceFn, useMediaQuery } from "@vueuse/core";
+import { useMediaQuery } from "@vueuse/core";
 
 interface ApplicationOption {
   id: string | number;
   label: string;
   shortName?: string;
-  organization?: string;
 }
 
 const router = useRouter();
 const { searchApplications } = useApplicationSearch();
 const searchRef = ref<{ clear?: () => void; focus?: () => void } | null>(null);
+const openBtnRef = ref<{ $el?: HTMLElement } | null>(null);
 const isMobile = useMediaQuery("(max-width: 768px)");
 const showInput = ref(!isMobile.value);
-const suggestions = ref<ApplicationOption[]>([]);
-const trimmedQuery = ref("");
+
+// Bascule desktop⇄mobile : ne pas laisser surgir l'overlay plein écran sur un
+// simple redimensionnement (il ne doit s'ouvrir que sur action explicite).
+watch(isMobile, (mobile) => {
+  showInput.value = !mobile;
+});
 
 async function onLoupeClick() {
   showInput.value = true;
@@ -26,42 +30,48 @@ async function onLoupeClick() {
   searchRef.value?.focus?.();
 }
 
+function restoreLoupeFocus() {
+  nextTick(() => openBtnRef.value?.$el?.querySelector("button")?.focus());
+}
+
 function closeSearch() {
   showInput.value = false;
   searchRef.value?.clear?.();
+  restoreLoupeFocus();
 }
 
 async function fetchSuggestions(searchQuery: string): Promise<ApplicationOption[]> {
-  trimmedQuery.value = searchQuery.trim();
-  if (!trimmedQuery.value) return [];
+  const trimmed = searchQuery.trim();
+  if (!trimmed) return [];
 
-  return new Promise((resolve) => {
-    debouncedSearch(resolve);
-  });
+  try {
+    // Recherche INDÉPENDANTE des filtres de la page (mergeCurrentFilters = false)
+    // et triée par PERTINENCE (ts_rank), pas par le tri de la page de recherche.
+    const response = await searchApplications({ qPrefix: trimmed, page: 0, pageSize: 8, sortBy: "relevance" }, false, false);
+
+    return (response?.results ?? []).map(
+      (app): ApplicationOption => ({ id: app.id, label: app.label, shortName: app.shortName ?? undefined }),
+    );
+  } catch {
+    // L'autocomplete gère l'affichage ; on renvoie une liste vide en cas d'échec.
+    return [];
+  }
 }
-
-const debouncedSearch = useDebounceFn(async (resolve: (res: ApplicationOption[]) => void) => {
-  const response = await searchApplications({ qPrefix: trimmedQuery.value, page: 0, pageSize: 8 }, false);
-
-  suggestions.value = (response?.results ?? []).map(
-    (app): ApplicationOption => ({ id: app.id, label: app.label, shortName: app.shortName ?? undefined }),
-  );
-
-  resolve(suggestions.value);
-}, 400);
 
 function displayLabel(application: ApplicationOption | null) {
   return application ? (application.label ?? application.shortName ?? "") : "";
 }
 
 function onConfirm(selection: ApplicationOption | null) {
-  if (!selection) return;
-  if (selection.id != null) {
-    const applicationId = selection.id;
-    router.push({ name: "application", params: { id: applicationId } });
-    searchRef.value?.clear?.();
-    if (isMobile.value) closeSearch();
-  }
+  if (!selection || selection.id == null) return;
+  router.push({ name: "application", params: { id: selection.id } });
+  searchRef.value?.clear?.();
+  if (isMobile.value) closeSearch();
+}
+
+// Échap depuis l'autocomplete (liste déjà fermée) → ferme l'overlay mobile.
+function onClose() {
+  if (isMobile.value && showInput.value) closeSearch();
 }
 </script>
 
@@ -71,6 +81,7 @@ function onConfirm(selection: ApplicationOption | null) {
 
     <DsfrButton
       v-show="isMobile && !showInput"
+      ref="openBtnRef"
       @click="onLoupeClick"
       tertiary
       class="loupe-button"
@@ -80,8 +91,14 @@ function onConfirm(selection: ApplicationOption | null) {
       <v-icon name="ri-search-line" />
     </DsfrButton>
 
-    <!-- Desktop : champ inline ; Mobile : overlay plein écran ouvert via la loupe. -->
-    <div v-if="!isMobile || showInput" :class="['search-field', { 'mobile-search-overlay': isMobile && showInput }]">
+    <!-- Desktop : champ inline ; Mobile : overlay plein écran (boîte de dialogue) ouvert via la loupe. -->
+    <div
+      v-if="!isMobile || showInput"
+      :class="['search-field', { 'mobile-search-overlay': isMobile && showInput }]"
+      :role="isMobile && showInput ? 'dialog' : undefined"
+      :aria-modal="isMobile && showInput ? 'true' : undefined"
+      :aria-label="isMobile && showInput ? 'Recherche d’une application' : undefined"
+    >
       <div :class="{ 'overlay-header': isMobile && showInput }">
         <AccessibleAutocomplete
           ref="searchRef"
@@ -93,14 +110,12 @@ function onConfirm(selection: ApplicationOption | null) {
           :on-change="onConfirm"
           :display-no-result="true"
           placeholder="Rechercher une application…"
+          @close="onClose"
         >
           <template #suggestion="{ item }">
             <div class="suggestion">
               <strong>{{ item.label }}</strong>
-              <template v-if="item.shortName || item.organization">
-                <small v-if="item.shortName"> ({{ item.shortName }})</small>
-                <em v-if="item.organization"> — {{ item.organization }}</em>
-              </template>
+              <small v-if="item.shortName"> ({{ item.shortName }})</small>
             </div>
           </template>
         </AccessibleAutocomplete>
@@ -156,18 +171,13 @@ function onConfirm(selection: ApplicationOption | null) {
   margin-right: 1.2em;
 }
 
-.close-search {
-  margin-left: 0.5rem;
-}
-
 .suggestion {
   display: flex;
   flex-direction: column;
   font-size: 0.95rem;
 }
 
-.suggestion small,
-.suggestion em {
+.suggestion small {
   color: #6b7280;
   font-size: 0.85rem;
 }

--- a/frontend/src/composables/use-application-search.ts
+++ b/frontend/src/composables/use-application-search.ts
@@ -289,7 +289,10 @@ export function useApplicationSearch() {
     scheduleSearch(true);
   }
 
-  async function searchApplications(customFilters?: Partial<Filters>, store = true) {
+  // `mergeCurrentFilters = false` : recherche indépendante des filtres de la page
+  // courante (utilisée par la recherche globale du header, qui ne doit hériter ni
+  // des filtres ni du tri de la page de recherche).
+  async function searchApplications(customFilters?: Partial<Filters>, store = true, mergeCurrentFilters = true) {
     // Les appels « stockés » sont numérotés : si une requête plus récente est
     // partie entre-temps, la réponse courante est ignorée (anti-course).
     const searchId = store ? ++latestStoredSearchId : 0;
@@ -301,7 +304,7 @@ export function useApplicationSearch() {
     error.value = null;
 
     try {
-      const currentFilters = { ...filters.value, ...customFilters };
+      const currentFilters = { ...(mergeCurrentFilters ? filters.value : DEFAULT_FILTERS), ...customFilters };
       const query = cleanFilters(currentFilters);
 
       const response = await api.applicationControllerSearch({ query });

--- a/qa/protocoles/accueil.md
+++ b/qa/protocoles/accueil.md
@@ -112,3 +112,15 @@
 - **Résultat attendu** : la liste est déployée (`aria-expanded=true`) ; la flèche bas active la
   première option (`aria-activedescendant` la désigne, `aria-selected="true"`) ; Échap referme la
   liste (`aria-expanded=false`).
+
+### ACC-15 — Recherche rapide : une application au nom ponctué est trouvable par son nom complet ✅
+
+- **Datafeature** : une application dont le libellé contient une ponctuation interne (ex. « O'Kon »,
+  « QA-GROUP-CHILD »).
+- **Action** : connecté, saisir le **nom complet** de l'application (avec sa ponctuation) dans la
+  recherche rapide du bandeau.
+- **Résultat attendu** : cette application précise apparaît dans les suggestions. Non-régression du
+  bug de tokenisation : la ponctuation interne était supprimée puis collée (« O'Kon » → « OKon »),
+  produisant un lexème absent de l'index et rendant l'application introuvable par son nom ; la
+  saisie est désormais **découpée** sur la ponctuation (« O'Kon » → `o` + `kon`), comme le parseur
+  plein-texte Postgres.

--- a/qa/protocoles/accueil.md
+++ b/qa/protocoles/accueil.md
@@ -79,3 +79,36 @@
 - **Datafeature** : session `admin`.
 - **Action** : cliquer l'entrée « Applications » de la navigation principale.
 - **Résultat attendu** : navigation vers `/recherche-application`.
+
+### ACC-11 — Recherche rapide : un préfixe court non lemmatisé ramène des suggestions ✅
+
+- **Datafeature** : ≥ 1 application dans le jeu de données.
+- **Action** : connecté, saisir dans la recherche rapide du bandeau le préfixe court (4 lettres)
+  d'un libellé d'application réel.
+- **Résultat attendu** : au moins une suggestion est proposée. Non-régression du bug de recherche
+  FTS : le dictionnaire `french` racinisait les libellés (« Application » → « appliqu ») et un
+  préfixe court ne matchait plus ; la recherche préfixe repose désormais sur l'index
+  `document_simple` (dictionnaire `simple`, non lemmatisé).
+
+### ACC-12 — Recherche rapide indépendante des filtres de la page de recherche ✅
+
+- **Datafeature** : ≥ 1 application dans le jeu de données.
+- **Action** : sur `/recherche-application`, filtrer la liste jusqu'à un état vide (0 résultat),
+  puis saisir dans la recherche rapide du bandeau le préfixe d'un libellé réel.
+- **Résultat attendu** : la recherche rapide propose des suggestions malgré la page filtrée à vide —
+  elle interroge l'API indépendamment des filtres de la page et trie par pertinence.
+
+### ACC-13 — Recherche rapide : un terme sans correspondance affiche « Aucun résultat » ✅
+
+- **Datafeature** : aucune (chaîne improbable ne correspondant à aucune application).
+- **Action** : connecté, saisir dans la recherche rapide un terme ne correspondant à aucune application.
+- **Résultat attendu** : la liste de suggestions affiche l'état « Aucun résultat ».
+
+### ACC-14 — Recherche rapide : navigation clavier dans l'autocomplete (RGAA 4.1.2) ✅
+
+- **Datafeature** : ≥ 1 application dans le jeu de données.
+- **Action** : connecté, saisir le préfixe d'un libellé réel, puis utiliser la flèche bas et la
+  touche Échap.
+- **Résultat attendu** : la liste est déployée (`aria-expanded=true`) ; la flèche bas active la
+  première option (`aria-activedescendant` la désigne, `aria-selected="true"`) ; Échap referme la
+  liste (`aria-expanded=false`).


### PR DESCRIPTION
Closes #2025.

Rend la **recherche globale du header** irréprochable. Deux lots :

## 1. Le bug d'origine (#2025) — préfixe lemmatisé
`fullTextSearchPrefix` faisait `to_tsquery('french', 'mot:*')` : la lemmatisation cassait le préfixe (« applic » ne matchait pas « appliqu ») → des applis disparaissaient en cours de frappe. **Fix** : document `simple` non lemmatisé (migration `add_simple_prefix_search_index` + `to_tsquery('simple')`). Prouvé sur Postgres 15.5.

## 2. Audit complet de la recherche globale (24 findings vérifiés)

**Fonctionnel**
- **La recherche n'était pas globale** : le header héritait des filtres **et** du tri de la page (`sortBy='label'`), jetant le classement `ts_rank` (la fiche au nom exact pouvait être masquée) et restreignant silencieusement la recherche aux filtres de la page. → `searchApplications(..., mergeCurrentFilters=false, sortBy='relevance')`.
- **Champ non vidé après sélection** (+ requête parasite) : `select()` réécrivait l'input après le `clear()`. → affectation de l'état **avant** les callbacks.
- **Résultats périmés** réapparaissant après effacement : garde `requestId` dans `doSearch`.
- **Double debounce** (300+400 ms) et **promesse jamais résolue** sur erreur : suppression du 2ᵉ debounce + try/catch.

**UX** : spinner de chargement ; « Aucun résultat » seulement après une recherche aboutie ; l'overlay mobile ne surgit plus au redimensionnement desktop→mobile.

**A11y (RGAA)** : ids d'options préfixés par instance, `scrollIntoView` de l'option surlignée, overlay mobile en `role=dialog`/`aria-modal` avec Échap qui ferme et focus restitué à la loupe.

**Backend** : tie-break déterministe (`ORDER BY rank, applicationId`) sur les deux requêtes ; `@MaxLength(200)` sur `q`/`qPrefix`. Retrait de code mort (`organization`).

## Différé (à traiter à part, plus risqué)
- **Plafond 200 appliqué avant les permissions** (un utilisateur sans accès au top-200 peut voir vide) : nécessite de passer le périmètre d'habilitation au moteur FTS — changement plus structurant.
- **Piège de focus complet** de l'overlay mobile : nécessiterait `@vueuse/integrations`/`focus-trap` (absent) — les autres aspects dialog/Échap/focus sont faits.
- **Positionnement de la loupe** (`margin-top:-18.99em`) : à revoir avec un contrôle visuel mobile.
