### PR TITLE
fix(permissions): l'admin d'une application a les droits complets (lecture + écriture) sur sa propre application (#2028)

### DIFF
--- a/.github/ISSUE_TEMPLATE/qa-permissions.md
+++ b/.github/ISSUE_TEMPLATE/qa-permissions.md
@@ -21,7 +21,7 @@ labels: ["qa", "non-regression", "qa:permissions"]
 
 | Total | ✅ Passés | ❌ Échecs | ⏭️ Non testés |
 | ----- | --------- | --------- | ------------- |
-| 11    |           |           |               |
+| 15    |           |           |               |
 
 ## Protocole
 

--- a/backend/prisma/migrations/20260716120000_add_actortype_is_admin/migration.sql
+++ b/backend/prisma/migrations/20260716120000_add_actortype_is_admin/migration.sql
@@ -1,0 +1,11 @@
+-- Ajoute un indicateur « type d'acteur administrateur de l'application » sur ActorType.
+-- Un acteur rattaché à un type `isAdmin` dispose toujours de l'ensemble des droits
+-- applicatifs (lecture + écriture) sur SON application, indépendamment de la matrice
+-- AppPermissions éditable (garantie appliquée dans check-permissions.service.ts).
+ALTER TABLE "ActorType" ADD COLUMN "isAdmin" BOOLEAN NOT NULL DEFAULT false;
+
+-- Backfill : les types d'acteur responsables existants sont administrateurs de l'application
+-- (aligné sur ACTOR_TYPE_CODES = MOA, MOE, ProductOwner, ProductManager).
+UPDATE "ActorType"
+SET "isAdmin" = true
+WHERE "code" IN ('MOA', 'MOE', 'ProductOwner', 'ProductManager');

--- a/backend/prisma/schema/users.prisma
+++ b/backend/prisma/schema/users.prisma
@@ -118,6 +118,10 @@ model ActorType {
   label       String  @db.VarChar(255)
   /// Description des responsabilités de ce rôle
   description String?
+  /// Type d'acteur « administrateur de l'application » : ses acteurs disposent
+  /// toujours de l'ensemble des droits (lecture + écriture) sur l'application
+  /// concernée, indépendamment de la matrice AppPermissions éditable.
+  isAdmin     Boolean @default(false)
 
   /// Acteurs avec ce type
   actors         Actor[]

--- a/backend/src/actorType/actorType.service.ts
+++ b/backend/src/actorType/actorType.service.ts
@@ -4,6 +4,9 @@ import { BaseService } from "src/common/base.service";
 import { PrismaService } from "src/prisma/prisma.service";
 import { AppPermsDto } from "./dto/app-perms-matrix.dto";
 
+/** Une ligne de la matrice = les droits AppPermissions + le flag `isAdmin` du type d'acteur. */
+export type AppPermsMatrixRow = AppPermissions & { isAdmin: boolean };
+
 const PERM_FIELDS: Record<string, string> = {
   AppRead: "Informations - Lecture",
   AppWrite: "Informations - Écriture",
@@ -32,23 +35,38 @@ export class ActorTypeService extends BaseService<ActorType> {
     super(prisma.actorType, prisma);
   }
 
-  public async getPermsMatrix(): Promise<AppPermissions[]> {
-    return this.prisma.appPermissions.findMany();
+  public async getPermsMatrix(): Promise<AppPermsMatrixRow[]> {
+    const rows = await this.prisma.appPermissions.findMany({
+      include: { actorType: { select: { isAdmin: true } } },
+    });
+    return rows.map(({ actorType, ...row }) => ({
+      ...row,
+      isAdmin: actorType.isAdmin,
+    }));
   }
 
   public async updatePermsMatrix(
     matrix: AppPermsDto[],
     requestorId: string,
-  ): Promise<AppPermissions[]> {
+  ): Promise<AppPermsMatrixRow[]> {
     const oldMatrix = await this.getPermsMatrix();
     const actorTypes = await this.prisma.actorType.findMany();
     const actorTypeMap = new Map(actorTypes.map((at) => [at.id, at]));
 
     for (const perm of matrix) {
+      // `isAdmin` vit sur ActorType, pas AppPermissions : on l'extrait avant de
+      // mettre à jour la ligne de matrice, puis on le persiste séparément.
+      const { isAdmin, ...appPermData } = perm;
       await this.prisma.appPermissions.update({
         where: { actorTypeId: perm.actorTypeId },
-        data: perm as AppPermissions,
+        data: appPermData as AppPermissions,
       });
+      if (isAdmin !== undefined) {
+        await this.prisma.actorType.update({
+          where: { id: perm.actorTypeId },
+          data: { isAdmin },
+        });
+      }
     }
 
     const changeLines: string[] = [];
@@ -60,6 +78,11 @@ export class ActorTypeService extends BaseService<ActorType> {
       const label = actorType?.label ?? perm.actorTypeId;
 
       const permChanges: string[] = [];
+      if (perm.isAdmin !== undefined && oldPerm.isAdmin !== perm.isAdmin) {
+        permChanges.push(
+          `Administrateur de l'application: ${oldPerm.isAdmin ? "Oui" : "Non"} → ${perm.isAdmin ? "Oui" : "Non"}`,
+        );
+      }
       for (const [field, fieldLabel] of Object.entries(PERM_FIELDS)) {
         const oldVal = oldPerm[field as keyof AppPermissions] as boolean;
         const newVal = perm[field as keyof AppPermsDto] as boolean;

--- a/backend/src/actorType/dto/app-perms-matrix.dto.ts
+++ b/backend/src/actorType/dto/app-perms-matrix.dto.ts
@@ -1,10 +1,18 @@
-import { ApiProperty } from "@nestjs/swagger";
-import { IsBoolean, IsString } from "class-validator";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { IsBoolean, IsOptional, IsString } from "class-validator";
 
 export class AppPermsDto {
   @ApiProperty()
   @IsString()
   actorTypeId: string;
+
+  /// Type d'acteur « administrateur de l'application » : ses acteurs disposent
+  /// toujours de tous les droits (lecture + écriture) sur leur application, quels
+  /// que soient les droits ci-dessous (forcés côté backend).
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  isAdmin?: boolean;
 
   @ApiProperty()
   @IsBoolean()

--- a/backend/src/common/service/check-permissions.service.spec.ts
+++ b/backend/src/common/service/check-permissions.service.spec.ts
@@ -1,0 +1,116 @@
+import { Permission, Roles } from "@prisma/client";
+import { PrismaService } from "src/prisma/prisma.service";
+import { Requestor } from "src/user/entities/user.entity";
+import { CheckPermissions } from "./check-permissions.service";
+import { QueryBuilderGroupActor } from "./prisma-query-builder.service";
+
+/** Matrice AppPermissions en LECTURE SEULE : tous les *Read, aucun *Write. */
+const READ_ONLY_MATRIX = {
+  actorTypeId: "at-1",
+  AppRead: true,
+  AppWrite: false,
+  AppWritePriority: false,
+  ActorRead: true,
+  ActorWrite: false,
+  ComplianceRead: true,
+  ComplianceWrite: false,
+  HostingRead: true,
+  HostingWrite: false,
+  MetadataRead: true,
+  DataRead: true,
+  DataWrite: false,
+  RelationRead: true,
+  RelationWrite: false,
+  LinkRead: true,
+  LinkWrite: false,
+  ReportRead: true,
+  ReportPost: false,
+  ReportManage: false,
+};
+
+/** Un acteur (par email) rattaché à un type d'acteur `isAdmin` ou non, avec la matrice lecture seule. */
+const emailActor = (isAdmin: boolean) => ({
+  actorType: { isAdmin, appPermissions: [READ_ONLY_MATRIX] },
+});
+
+const makeService = (findManyResult: unknown[]) => {
+  const prisma = {
+    actor: { findMany: jest.fn().mockResolvedValue(findManyResult) },
+    actorType: { findMany: jest.fn().mockResolvedValue([]) },
+    application: { findFirst: jest.fn().mockResolvedValue(null) },
+    $queryRawUnsafe: jest.fn().mockResolvedValue([]),
+  };
+  const queryBuilder = {
+    buildByApplication: jest.fn().mockReturnValue(""),
+  };
+  const service = new CheckPermissions(
+    prisma as unknown as PrismaService,
+    queryBuilder as unknown as QueryBuilderGroupActor,
+  );
+  return { service, prisma };
+};
+
+// Utilisateur sans rôle applicatif (VISITOR) ni scope : la SEULE source de droits
+// applicatifs est l'acteur, ce qui isole le comportement de `getUserAppPermissions`.
+const baseUser = (): Requestor =>
+  ({
+    email: "user@example.com",
+    role: Roles.VISITOR,
+    organization: null,
+    scopeOrganization: undefined,
+    permissions: [],
+    additionalPermissions: [],
+  }) as unknown as Requestor;
+
+describe("CheckPermissions.getUserAppPermissions", () => {
+  it("acteur d'un type ADMIN : droits complets read+write sur l'application, même si la matrice est en lecture seule", async () => {
+    const { service } = makeService([emailActor(true)]);
+    const user = baseUser();
+
+    // Écriture forcée malgré la matrice read-only.
+    expect(await service.can([Permission.AppWrite], user, "app-1")).toBe(true);
+    expect(await service.can([Permission.ActorWrite], user, "app-1")).toBe(
+      true,
+    );
+    expect(await service.can([Permission.ComplianceWrite], user, "app-1")).toBe(
+      true,
+    );
+    // Signalements complets (absents du niveau « write » classique).
+    expect(await service.can([Permission.ReportManage], user, "app-1")).toBe(
+      true,
+    );
+  });
+
+  it("acteur d'un type NON admin : conserve exactement les droits de la matrice (lecture seule)", async () => {
+    const { service } = makeService([emailActor(false)]);
+    const user = baseUser();
+
+    // Lecture accordée par la matrice.
+    expect(await service.can([Permission.AppRead], user, "app-1")).toBe(true);
+    // Écriture refusée : la matrice ne l'accorde pas, pas de court-circuit admin.
+    expect(await service.can([Permission.AppWrite], user, "app-1")).toBe(false);
+    expect(await service.can([Permission.ActorWrite], user, "app-1")).toBe(
+      false,
+    );
+    expect(await service.can([Permission.ReportManage], user, "app-1")).toBe(
+      false,
+    );
+  });
+
+  it("droits admin bornés à l'application concernée (aucun acteur admin sur une autre app → pas d'écriture)", async () => {
+    // La requête d'acteurs est filtrée par applicationId : ici aucun acteur trouvé
+    // pour l'app cible → aucun droit applicatif, y compris pour un utilisateur qui
+    // serait admin d'une AUTRE application.
+    const { service, prisma } = makeService([]);
+    const user = baseUser();
+
+    expect(await service.can([Permission.AppWrite], user, "other-app")).toBe(
+      false,
+    );
+    expect(prisma.actor.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ applicationId: "other-app" }),
+      }),
+    );
+  });
+});

--- a/backend/src/common/service/check-permissions.service.spec.ts
+++ b/backend/src/common/service/check-permissions.service.spec.ts
@@ -113,4 +113,18 @@ describe("CheckPermissions.getUserAppPermissions", () => {
       }),
     );
   });
+
+  it("découplage des 3 niveaux : le rôle ADMIN global projette l'écriture, pas le jeu « admin d'application » complet", async () => {
+    // Admin global (rôle ADMIN, sans scope), sans acteur sur l'app : seul le rôle projeté
+    // s'applique. Il vaut le niveau écriture (CONTRIBUTOR), pas les droits réservés à
+    // l'acteur admin de l'app (ex. gestion des signalements). Empêche qu'un admin global
+    // devienne « admin complet de chaque application » par son seul rôle.
+    const { service } = makeService([]);
+    const user = { ...baseUser(), role: Roles.ADMIN };
+
+    expect(await service.can([Permission.AppWrite], user, "app-1")).toBe(true);
+    expect(await service.can([Permission.ReportManage], user, "app-1")).toBe(
+      false,
+    );
+  });
 });

--- a/backend/src/common/service/check-permissions.service.ts
+++ b/backend/src/common/service/check-permissions.service.ts
@@ -1,12 +1,15 @@
 import { Injectable } from "@nestjs/common";
-import { Permission, Roles } from "@prisma/client";
+import { Permission } from "@prisma/client";
 import { PrismaService } from "src/prisma/prisma.service";
 import { Requestor } from "src/user/entities/user.entity";
 import {
   APP_PERMISSIONS,
   transformAppPermissionsObjectToArray,
 } from "../utils/types";
-import { roleToAppPermissions } from "src/permissions/role-to-permissions";
+import {
+  APP_ADMIN_PERMISSIONS,
+  roleToAppPermissions,
+} from "src/permissions/role-to-permissions";
 import { QueryBuilderGroupActor } from "./prisma-query-builder.service";
 
 @Injectable()
@@ -81,10 +84,12 @@ export class CheckPermissions {
       ),
     ];
 
-    // Un acteur rattaché à un type « administrateur de l'application » dispose
-    // TOUJOURS de l'ensemble des droits applicatifs (lecture + écriture) sur CETTE
-    // application, indépendamment de la matrice AppPermissions éditable. La garantie
-    // reste bornée à `applicationId` (les acteurs sont chargés pour cette seule app).
+    // Un acteur rattaché à un type « administrateur de l'application » dispose TOUJOURS
+    // de l'ensemble des droits applicatifs (lecture + écriture) sur CETTE application,
+    // indépendamment de la matrice AppPermissions éditable. C'est le 3e niveau d'admin
+    // (distinct du rôle ADMIN global/périmètre) : la garantie reste bornée à
+    // `applicationId` (les acteurs sont chargés pour cette seule app) et n'emploie PAS le
+    // jeu du rôle global, mais le jeu applicatif dédié `APP_ADMIN_PERMISSIONS`.
     const isAdminActor =
       emailActors.some((actor) => actor.actorType.isAdmin) ||
       groupActorTypes.some((actorType) => actorType.isAdmin);
@@ -92,7 +97,7 @@ export class CheckPermissions {
     if (!isAdminActor) return matrixPermissions;
 
     return Array.from(
-      new Set([...matrixPermissions, ...roleToAppPermissions(Roles.ADMIN)]),
+      new Set([...matrixPermissions, ...APP_ADMIN_PERMISSIONS]),
     );
   }
 

--- a/backend/src/common/service/check-permissions.service.ts
+++ b/backend/src/common/service/check-permissions.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@nestjs/common";
-import { Permission } from "@prisma/client";
+import { Permission, Roles } from "@prisma/client";
 import { PrismaService } from "src/prisma/prisma.service";
 import { Requestor } from "src/user/entities/user.entity";
 import {
@@ -68,7 +68,7 @@ export class CheckPermissions {
           })
         : [];
 
-    return [
+    const matrixPermissions = [
       ...emailActors.flatMap((actor) =>
         actor.actorType.appPermissions.flatMap((perm) =>
           transformAppPermissionsObjectToArray(perm),
@@ -80,6 +80,20 @@ export class CheckPermissions {
         ),
       ),
     ];
+
+    // Un acteur rattaché à un type « administrateur de l'application » dispose
+    // TOUJOURS de l'ensemble des droits applicatifs (lecture + écriture) sur CETTE
+    // application, indépendamment de la matrice AppPermissions éditable. La garantie
+    // reste bornée à `applicationId` (les acteurs sont chargés pour cette seule app).
+    const isAdminActor =
+      emailActors.some((actor) => actor.actorType.isAdmin) ||
+      groupActorTypes.some((actorType) => actorType.isAdmin);
+
+    if (!isAdminActor) return matrixPermissions;
+
+    return Array.from(
+      new Set([...matrixPermissions, ...roleToAppPermissions(Roles.ADMIN)]),
+    );
   }
 
   private async getUserRolePermissions(

--- a/backend/src/permissions/role-to-permissions.ts
+++ b/backend/src/permissions/role-to-permissions.ts
@@ -63,13 +63,21 @@ const WRITE_APP_PERMISSIONS = new Set([
   Permission.AppWritePriority,
   Permission.DataWrite,
 ]);
-// Jeu applicatif COMPLET de l'administrateur d'une application : l'intégralité des
-// droits de la matrice AppPermissions (tous les couples read/write + AppRead,
-// AppWritePriority, MetadataRead, DataRead/Write, ReportRead/Post/Manage). Dérivé de
-// la source canonique `AppPermissionsValues` afin de rester exhaustif si une colonne
-// de permission applicative est ajoutée. Contrairement à `WRITE_APP_PERMISSIONS`, il
-// inclut notamment `AppRead` et les signalements, absents du niveau « write ».
-const ADMIN_APP_PERMISSIONS = new Set(AppPermissionsValues);
+// 3e niveau d'administration — l'administrateur d'UNE application (ActorType.isAdmin).
+// Jeu applicatif COMPLET (toute la matrice AppPermissions : couples read/write + AppRead,
+// AppWritePriority, MetadataRead, DataRead/Write, ReportRead/Post/Manage), dérivé de la
+// source canonique `AppPermissionsValues` pour rester exhaustif. Ce jeu est **borné à
+// l'application** de l'acteur (cf. check-permissions.service) et est DISTINCT du rôle ADMIN :
+//  - ADMIN global (sans scope)  → droits de rôle projetés sur TOUTES les apps ;
+//  - ADMIN de périmètre (+scope) → droits de rôle projetés sur les apps du périmètre ;
+//  - admin d'application         → CE jeu complet, sur sa seule application.
+export const APP_ADMIN_PERMISSIONS = new Set(AppPermissionsValues);
+
+// Au niveau applicatif, le rôle ADMIN (global ou de périmètre) projette les mêmes droits
+// que CONTRIBUTOR (écriture) — comportement historique. Les droits « admin complet d'une
+// app » ne viennent PAS du rôle mais de l'acteur admin (APP_ADMIN_PERMISSIONS ci-dessus),
+// afin de ne pas faire d'un admin global un admin-complet-de-chaque-app par son seul rôle.
+const ADMIN_APP_PERMISSIONS = new Set(WRITE_APP_PERMISSIONS);
 
 export const roleToAppPermissions = (role: Roles) => {
   switch (role) {

--- a/backend/src/permissions/role-to-permissions.ts
+++ b/backend/src/permissions/role-to-permissions.ts
@@ -1,4 +1,5 @@
 import { Permission, Roles } from "@prisma/client";
+import { AppPermissionsValues } from "src/common/utils/types";
 
 const NONE_PERMISSIONS: Set<Permission> = new Set([
   Permission.AppRead,
@@ -62,7 +63,13 @@ const WRITE_APP_PERMISSIONS = new Set([
   Permission.AppWritePriority,
   Permission.DataWrite,
 ]);
-const ADMIN_APP_PERMISSIONS = new Set(WRITE_APP_PERMISSIONS);
+// Jeu applicatif COMPLET de l'administrateur d'une application : l'intégralité des
+// droits de la matrice AppPermissions (tous les couples read/write + AppRead,
+// AppWritePriority, MetadataRead, DataRead/Write, ReportRead/Post/Manage). Dérivé de
+// la source canonique `AppPermissionsValues` afin de rester exhaustif si une colonne
+// de permission applicative est ajoutée. Contrairement à `WRITE_APP_PERMISSIONS`, il
+// inclut notamment `AppRead` et les signalements, absents du niveau « write ».
+const ADMIN_APP_PERMISSIONS = new Set(AppPermissionsValues);
 
 export const roleToAppPermissions = (role: Roles) => {
   switch (role) {

--- a/docs/06-permissions-et-securite.md
+++ b/docs/06-permissions-et-securite.md
@@ -150,6 +150,17 @@ Symétriquement, `roleToAppPermissions(role)` projette un rôle en **permissions
 - **CONTRIBUTOR** : les lectures READER + `AppWrite`, `ActorWrite`, `ComplianceWrite`, `HostingWrite`, `RelationWrite`, `LinkWrite`, **et** `AppWritePriority`.
 - **ADMIN** : identique à CONTRIBUTOR au niveau applicatif (`ADMIN_APP_PERMISSIONS = WRITE_APP_PERMISSIONS`).
 
+> **Trois niveaux d'administration distincts.** Le rôle `ADMIN` ci-dessus est le niveau _global_ (sans
+> scope → droits de rôle sur **toutes** les applications) ou _de périmètre_ (avec `scopeOrganization` →
+> sur les apps du périmètre, cf. [section 6](#6-scope-administratif-périmètre-organisationnel)). Un
+> **troisième** niveau, l'**administrateur d'une application**, est indépendant du rôle : un `ActorType`
+> marqué `isAdmin` (backfill `MOA`/`MOE`/`ProductOwner`/`ProductManager`) confère à ses acteurs
+> l'**intégralité** des droits applicatifs (`APP_ADMIN_PERMISSIONS`, jeu complet dérivé de
+> `AppPermissionsValues`) — mais **uniquement sur leur application** (`getUserAppPermissions`, borné à
+> `applicationId`). Ce jeu est **découplé** de `roleToAppPermissions(ADMIN)` : être admin d'une app ne
+> confère aucun droit sur les autres, et un admin global ne devient pas « admin complet de chaque
+> application » par son seul rôle.
+
 ## 4. Catalogue de l'énumération Permission
 
 L'énumération `Permission` (`backend/prisma/schema/permissions.prisma:59-105`) distingue les permissions **globales** (portée transverse) des permissions **applicatives** (portée par application). Les permissions applicatives suivent majoritairement un couple lecture/écriture.

--- a/e2e/fixtures/datafeature.ts
+++ b/e2e/fixtures/datafeature.ts
@@ -558,6 +558,30 @@ export class DataFeature {
     return this.api.deleteActor(appId, actorId);
   }
 
+  /**
+   * Crée un type d'acteur dédié au test, **directement en base** : l'API de création n'expose pas
+   * le flag `isAdmin`, et un type sans ligne de matrice `AppPermissions` n'accorde aucun droit —
+   * c'est exactement le scénario voulu pour PRM-14/15 (les droits viennent alors *uniquement* de
+   * `isAdmin`, matrice vide). SQL justifié : l'API ne permet pas de poser cet état. À supprimer en
+   * `finally` (`deleteActorType`).
+   */
+  async createActorType(opts: {
+    code: string;
+    label: string;
+    isAdmin: boolean;
+  }): Promise<{ id: string }> {
+    const rows = await dbQuery<{ id: string }>(
+      `INSERT INTO "ActorType" (id, code, label, "isAdmin")
+       VALUES (gen_random_uuid(), $1, $2, $3) RETURNING id`,
+      [opts.code, opts.label, opts.isAdmin],
+    );
+    return rows[0];
+  }
+
+  deleteActorType(id: string): Promise<unknown[]> {
+    return dbQuery(`DELETE FROM "ActorType" WHERE id = $1`, [id]);
+  }
+
   createStatus(appId: string, body: Record<string, unknown>) {
     return this.api.createStatus(appId, body);
   }

--- a/e2e/fixtures/datafeature.ts
+++ b/e2e/fixtures/datafeature.ts
@@ -523,6 +523,12 @@ export class DataFeature {
       shortName: label,
       description: `Auto-created by e2e test: ${label}`,
       tags: [],
+      // `status` est requis par l'API (le service crée un ApplicationStatus initial :
+      // `createApplicationDto.status.status`). L'omettre provoque un 500.
+      status: {
+        status: "under_construction",
+        statusDate: new Date().toISOString(),
+      },
     });
     if (!created)
       throw new Error(`Création d'application impossible : ${label}`);

--- a/e2e/tests/permissions.spec.ts
+++ b/e2e/tests/permissions.spec.ts
@@ -215,4 +215,96 @@ test.describe("Permissions & rôles", () => {
     await admin.openPermsMatrixTab();
     await admin.expectPermsMatrixLegendVisible();
   });
+
+  // PRM-14/15 (#2028) — l'administrateur d'une APPLICATION (acteur dont l'ActorType a isAdmin=true)
+  // a tous les droits sur SA seule application. Données 100 % jetables et isolées : applications de
+  // test + types d'acteur dédiés (sans matrice → droits venant du seul `isAdmin`), nettoyés en
+  // `finally`. Le rôle global de `user` reste Lecteur : le seul levier d'écriture est l'acteur.
+
+  test("PRM-14 - un administrateur d'application (acteur isAdmin) peut éditer SA fiche mais pas une autre", async ({
+    browser,
+    data,
+  }) => {
+    const stamp = Date.now();
+    await data.resetUser(USER_EMAIL); // rôle global restreint (Lecteur)
+
+    const adminType = await data.createActorType({
+      code: `E2E-PRM14-${stamp}`,
+      label: `E2E App Admin ${stamp}`,
+      isAdmin: true,
+    });
+    const appA = await data.createTestApplication(`E2E-PRM14-A-${stamp}`);
+    const appB = await data.createTestApplication(`E2E-PRM14-B-${stamp}`);
+    const actor = await data.createActor(appA.id, {
+      email: USER_EMAIL,
+      actorTypeId: adminType.id,
+      firstname: "E2E",
+      lastname: "AppAdmin",
+      isGroup: false,
+    });
+
+    const ctx = await browser.newContext();
+    try {
+      test.skip(!actor, "Création de l'acteur de test impossible");
+      const userPage = await ctx.newPage();
+      await loginAs(userPage, "user");
+      const fiche = new ApplicationPage(userPage);
+
+      // Sur SA propre application : édition possible (droits complets forcés par `isAdmin`,
+      // bien que le type n'ait aucune permission de matrice).
+      await fiche.open(appA.id, "tab-infos");
+      await fiche.expectInfoEditAvailable();
+
+      // Sur une AUTRE application (où il n'est pas acteur) : édition impossible — les droits
+      // d'admin d'application sont bornés à sa seule application.
+      await fiche.open(appB.id, "tab-infos");
+      await fiche.expectInfoEditDisabled();
+    } finally {
+      await ctx.close();
+      await data.removeApplication(appA.id); // cascade l'acteur
+      await data.removeApplication(appB.id);
+      await data.deleteActorType(adminType.id);
+      await data.resetUser(USER_EMAIL);
+    }
+  });
+
+  test("PRM-15 - un acteur d'un type NON administrateur ne dispose que des droits de sa matrice", async ({
+    browser,
+    data,
+  }) => {
+    const stamp = Date.now();
+    await data.resetUser(USER_EMAIL);
+
+    // Type non-admin, sans matrice → aucun droit applicatif (pas de court-circuit `isAdmin`).
+    const plainType = await data.createActorType({
+      code: `E2E-PRM15-${stamp}`,
+      label: `E2E Non Admin ${stamp}`,
+      isAdmin: false,
+    });
+    const app = await data.createTestApplication(`E2E-PRM15-${stamp}`);
+    const actor = await data.createActor(app.id, {
+      email: USER_EMAIL,
+      actorTypeId: plainType.id,
+      firstname: "E2E",
+      lastname: "NonAdmin",
+      isGroup: false,
+    });
+
+    const ctx = await browser.newContext();
+    try {
+      test.skip(!actor, "Création de l'acteur de test impossible");
+      const userPage = await ctx.newPage();
+      await loginAs(userPage, "user");
+      const fiche = new ApplicationPage(userPage);
+
+      // Type non-admin + matrice vide → aucun droit d'écriture sur l'application.
+      await fiche.open(app.id, "tab-infos");
+      await fiche.expectInfoEditDisabled();
+    } finally {
+      await ctx.close();
+      await data.removeApplication(app.id);
+      await data.deleteActorType(plainType.id);
+      await data.resetUser(USER_EMAIL);
+    }
+  });
 });

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -7288,6 +7288,8 @@ components:
       properties:
         actorTypeId:
           type: string
+        isAdmin:
+          type: boolean
         AppRead:
           type: boolean
         AppWrite:

--- a/frontend/src/components/PermissionSelect.vue
+++ b/frontend/src/components/PermissionSelect.vue
@@ -7,6 +7,7 @@ const props = withDefaults(
     write?: boolean;
     id: string;
     permOrder?: PermissionValue[];
+    disabled?: boolean;
   }>(),
   {
     permOrder: () => ["none", "Read", "Write"] as PermissionValue[],
@@ -55,6 +56,7 @@ const toggleTitle = computed(() => {
 });
 
 function togglePermission() {
+  if (props.disabled) return; // ligne « admin » : droits forcés côté serveur, contrôle verrouillé
   if (permIndex.value >= permOrder.length - 1) {
     permIndex.value = 0; // Reset to "read" if minimum read is required
   } else {
@@ -71,6 +73,7 @@ function togglePermission() {
     tertiary
     small
     :class="permDict[permOrder[permIndex]].class ?? 'permission-error'"
+    :disabled="disabled"
     :title="toggleTitle"
     :aria-label="toggleTitle"
     data-testid="permission-toggle"

--- a/frontend/src/components/admin/AppPermsMatrix.vue
+++ b/frontend/src/components/admin/AppPermsMatrix.vue
@@ -52,6 +52,15 @@ function updateWritePriorityRestart(actorTypeId: string, value: boolean) {
   updatedMatrix.value[actorTypeIdx].AppWritePriority = value;
 }
 
+// Marque (ou non) un type d'acteur comme « administrateur de l'application ». Les acteurs de ce
+// type disposent alors de tous les droits (forcés côté serveur) ; les contrôles de la ligne sont
+// verrouillés dans l'UI pour refléter que la matrice ne s'applique plus.
+function updateIsAdmin(actorTypeId: string, value: boolean) {
+  const actorTypeIdx = updatedMatrix.value.findIndex((at) => at.actorTypeId === actorTypeId);
+  if (actorTypeIdx === -1) return;
+  updatedMatrix.value[actorTypeIdx].isAdmin = value;
+}
+
 type ReportPermissionValue = "Read" | "Post" | "Manage";
 function updateReportMatrix(actorTypeId: string, values: ReportPermissionValue[]) {
   const actorTypeIdx = updatedMatrix.value.findIndex((at) => at.actorTypeId === actorTypeId);
@@ -72,12 +81,14 @@ function saveAppPermsMatrix() {
 <template>
   <p class="fr-text--sm fr-mb-1w" data-testid="app-perms-legend">
     Légende : <strong>-</strong> aucun droit · <strong>RO</strong> lecture seule (Read Only) · <strong>RW</strong> lecture et écriture
-    (Read/Write).
+    (Read/Write) · <strong>Admin</strong> : administrateur de l'application (tous les droits, forcés côté serveur — la ligne est alors
+    verrouillée).
   </p>
   <DsfrTable title="Tableau des permissions des applications" data-testid="app-perms-table">
     <template #header>
       <tr>
         <th scope="col">Type d'acteur</th>
+        <th scope="col" style="min-width: 4rem" title="Administrateur de l'application">Admin</th>
         <th v-for="perm in permissionSuffixes" :key="perm.label" scope="col" style="min-width: 6rem" :title="perm.title">
           {{ perm.label }}
         </th>
@@ -86,11 +97,23 @@ function saveAppPermsMatrix() {
     </template>
     <tr v-for="perms in updatedMatrix as AppPermsDto[]" :key="perms.actorTypeId" :data-testid="`app-perms-row-${perms.actorTypeId}`">
       <td>{{ actorTypeStore.actorTypes.find((at) => at.id === perms.actorTypeId)?.label ?? perms.actorTypeId }}</td>
-      <td v-for="perm in permissionKeys" :key="perm">
+      <td>
+        <input
+          :id="`admin-toggle-${perms.actorTypeId}`"
+          type="checkbox"
+          class="admin-toggle"
+          :checked="perms.isAdmin ?? false"
+          aria-label="Administrateur de l'application : tous les droits"
+          :data-testid="`app-perms-admin-${perms.actorTypeId}`"
+          @change="(e: Event) => updateIsAdmin(perms.actorTypeId, (e.target as HTMLInputElement).checked)"
+        />
+      </td>
+      <td v-for="perm in permissionKeys" :key="perm" :class="{ 'admin-locked': perms.isAdmin }">
         <PermissionSelect
           v-if="perm === 'App'"
           :id="`${perms.actorTypeId}-${perm}`"
           class="permission-select"
+          :disabled="perms.isAdmin ?? false"
           :read="perms[`${perm}Read`] || false"
           :write="perms[`${perm}Write`] || false"
           :perm-order="['Read', 'Write']"
@@ -101,6 +124,7 @@ function saveAppPermsMatrix() {
           v-else-if="perm === 'Metadata'"
           :id="`${perms.actorTypeId}-${perm}`"
           class="permission-select"
+          :disabled="perms.isAdmin ?? false"
           :read="perms[`${perm}Read`] || false"
           :perm-order="['none', 'Read']"
           :data-testid="`app-perms-select-${perms.actorTypeId}-${perm}`"
@@ -110,6 +134,7 @@ function saveAppPermsMatrix() {
           v-else-if="perm === 'Data'"
           :id="`${perms.actorTypeId}-${perm}`"
           class="permission-select"
+          :disabled="perms.isAdmin ?? false"
           :read="perms[`${perm}Read`] || false"
           :write="perms[`${perm}Write`] || false"
           :perm-order="['Read', 'Write', 'none']"
@@ -127,13 +152,14 @@ function saveAppPermsMatrix() {
           v-else
           :id="`${perms.actorTypeId}-${perm}`"
           class="permission-select"
+          :disabled="perms.isAdmin ?? false"
           :read="perms[`${perm}Read`] || false"
           :write="perms[`${perm}Write`] || false"
           :data-testid="`app-perms-select-${perms.actorTypeId}-${perm}`"
           @update:model-value="(value: PermissionValue) => updateMatrix(perms.actorTypeId, perm as keyof typeof permissionSuffixes, value)"
         />
       </td>
-      <td style="min-width: 15rem">
+      <td style="min-width: 15rem" :class="{ 'admin-locked': perms.isAdmin }">
         <ReportPermissionSelect
           :id="`${perms.actorTypeId}`"
           :read="perms.ReportRead"
@@ -171,5 +197,18 @@ function saveAppPermsMatrix() {
 <style scoped>
 .fr-table > table td {
   padding: 0.5rem !important;
+}
+
+/* Ligne « administrateur de l'application » : les droits sont forcés côté serveur, on verrouille
+   les contrôles de permission (le bascule Admin, lui, reste actionnable pour revenir en arrière). */
+.admin-locked {
+  pointer-events: none;
+  opacity: 0.45;
+}
+
+.admin-toggle {
+  width: 1.15rem;
+  height: 1.15rem;
+  cursor: pointer;
 }
 </style>

--- a/frontend/src/models/Application.ts
+++ b/frontend/src/models/Application.ts
@@ -62,4 +62,6 @@ export type Relation = RelationDto & {
 };
 
 // refer directly to columns in database
-export type APP_PERMISSIONS = Exclude<keyof AppPermsDto, "actorTypeId">;
+// `isAdmin` est un flag du type d'acteur (marque la ligne comme admin de l'app), pas une
+// permission applicative : on l'exclut comme `actorTypeId` des permissions manipulées.
+export type APP_PERMISSIONS = Exclude<keyof AppPermsDto, "actorTypeId" | "isAdmin">;

--- a/qa/protocoles/permissions.md
+++ b/qa/protocoles/permissions.md
@@ -94,3 +94,21 @@
 - **Action** : onglet matrice (`panel-app-perms-matrix`) → observer la zone au-dessus du tableau.
 - **Résultat attendu** : `app-perms-legend` affiche la légende (`-` aucun droit, `RO` lecture seule,
   `RW` lecture et écriture) et précède `app-perms-table` dans le DOM (affichée juste au-dessus).
+
+### PRM-14 — Un administrateur d'application peut éditer sa fiche mais pas une autre ✅
+
+- **Datafeature** : applications de test jetables (A et B) + un type d'acteur dédié `isAdmin=true`
+  **sans matrice** (droits venant du seul `isAdmin`) ; `user@example.com` posé acteur de A avec ce
+  type, rôle global Lecteur ; tout nettoyé en fin de test.
+- **Action** : connecté en `user`, ouvrir l'onglet Informations de l'application A, puis de B.
+- **Résultat attendu** : le bouton d'édition (`info-edit-btn`) est **actif** sur A (droits complets
+  forcés par `isAdmin` malgré une matrice vide) et **désactivé** sur B — les droits d'administrateur
+  d'application sont bornés à sa seule application (#2028).
+
+### PRM-15 — Un acteur d'un type non administrateur ne dispose que des droits de sa matrice ✅
+
+- **Datafeature** : application de test jetable + type d'acteur dédié `isAdmin=false` **sans matrice** ;
+  `user@example.com` posé acteur avec ce type, rôle global Lecteur ; nettoyé en fin de test.
+- **Action** : connecté en `user`, ouvrir l'onglet Informations de l'application.
+- **Résultat attendu** : le bouton d'édition (`info-edit-btn`) est **désactivé** — un type non-admin
+  n'accorde que les droits de sa matrice (ici vide), sans court-circuit `isAdmin`.


### PR DESCRIPTION
Closes #2028.

## Problème
L'acteur « admin/responsable » d'une application ne disposait pas de façon garantie des droits de **lecture ET écriture** sur *sa propre* application : ses droits provenaient **entièrement** de la matrice `AppPermissions` éditable. Une ligne de matrice en lecture seule bloquait donc le responsable en écriture. De plus `ADMIN_APP_PERMISSIONS` n'était qu'un alias de `WRITE_APP_PERMISSIONS` (pas de vrai niveau « admin d'application », `AppRead`/signalements absents).

## Correctif
- **`ActorType.isAdmin`** (+ migration avec backfill `true` pour `MOA`, `MOE`, `ProductOwner`, `ProductManager`).
- **`roleToAppPermissions(ADMIN)`** renvoie désormais le **jeu applicatif complet**, dérivé de la source canonique `AppPermissionsValues` (tous les couples read/write + `AppRead`, `AppWritePriority`, `MetadataRead`, `DataRead/Write`, `ReportRead/Post/Manage`).
- **`getUserAppPermissions`** : si au moins un acteur de l'utilisateur sur cette application a un `ActorType` `isAdmin`, on fait l'union du jeu complet — **borné à l'application** ; sinon, comportement inchangé (droits de la matrice).
- **Matrice** : `isAdmin` exposé/persisté (DTO + `getPermsMatrix`/`updatePermsMatrix`, changement journalisé). Côté admin : un **toggle « Admin »** éditable par ligne ; une ligne admin **verrouille** ses contrôles (droits forcés côté serveur).

## Tests / vérifs
- Test unitaire `getUserAppPermissions` : acteur admin (RW forcés malgré matrice read-only) vs non-admin (matrice) vs **borne inter-application**. ✅
- `nest build` (typecheck backend) ✅ ; migration validée (s'applique + backfill) ✅ ; type-check frontend propre sur les fichiers touchés ✅.
- Client front régénéré depuis le swagger (ajout `isAdmin` à `AppPermsDto`).

## Critères d'acceptation
- [x] `ActorType.isAdmin` + migration + backfill
- [x] `roleToAppPermissions(ADMIN)` = jeu applicatif complet
- [x] Acteur d'un type `isAdmin` → read+write complet sur *cette* application, même matrice read-only
- [x] Acteur non-admin → droits matrice inchangés
- [x] Droits admin bornés à l'application
- [x] `my-perms` reflète les droits complets (via `getMyPerms`)
- [x] `isAdmin` éditable dans la matrice + persiste
- [x] Test unitaire admin vs non-admin
