### PR TITLE
fix(e2e): éditer une ligne de matrice non verrouillée (débloque la release 1.82.1)

### DIFF
--- a/backend/prisma/docs/schema.md
+++ b/backend/prisma/docs/schema.md
@@ -827,6 +827,7 @@ erDiagram
   String(50) code UK "nullable"
   String(255) label
   String description "nullable"
+  Boolean isAdmin
 }
 "_ApplicationToUser" {
   String A FK
@@ -947,6 +948,10 @@ Properties as follows:
 - `code`: Code court pour le rôle
 - `label`: Nom d'affichage du rôle
 - `description`: Description des responsabilités de ce rôle
+- `isAdmin`
+  > Type d'acteur « administrateur de l'application » : ses acteurs disposent
+  > toujours de l'ensemble des droits (lecture + écriture) sur l'application
+  > concernée, indépendamment de la matrice AppPermissions éditable.
 
 ### `_ApplicationToUser`
 

--- a/backend/tests/tag.e2e-spec.ts
+++ b/backend/tests/tag.e2e-spec.ts
@@ -18,10 +18,10 @@ describe("Tags", () => {
   });
 
   it("/POST tags", async () => {
-    const name =
-      faker.word
-        .noun({ length: { min: 2, max: 100 } })
-        .replace(/[^a-z._-]/g, "") || `tag-test-${Date.now()}`;
+    const baseName = faker.word
+      .noun({ length: { min: 2, max: 80 } })
+      .replace(/[^a-z._-]/g, "");
+    const name = `${baseName}-${Date.now()}`;
 
     await request(app().getHttpServer())
       .post("/tags")

--- a/e2e/pom/admin.page.ts
+++ b/e2e/pom/admin.page.ts
@@ -164,10 +164,13 @@ export class AdminPage extends BasePage {
    */
   async editMatrixAndRestore(): Promise<void> {
     // Le testid `app-perms-select-*` (passé par le parent) écrase `permission-toggle`.
-    // On vise un toggle Lecture/Écriture (texte `-` / `RO` / `RW`), pas la case PriorityRestart.
-    // Colonne « App » du 1ᵉʳ type d'acteur : un toggle Lecture/Écriture (`-`/`RO`/`RW`).
+    // On vise un toggle Lecture/Écriture (texte `-` / `RO` / `RW`) de la colonne « App », mais
+    // sur une ligne ÉDITABLE : les lignes d'un type d'acteur « admin d'application » (isAdmin,
+    // ex. MOA/MOE) ont leurs contrôles verrouillés (`disabled`) — les cliquer expirerait.
     const toggle = () =>
-      this.matrixPanel().locator('[data-testid$="-App"]').first();
+      this.matrixPanel()
+        .locator('[data-testid$="-App"]:not([disabled])')
+        .first();
     await expect(toggle()).toBeVisible();
     const original = (await toggle().innerText()).trim();
 
@@ -197,8 +200,12 @@ export class AdminPage extends BasePage {
    * L'appelant restaure via l'API dans son `finally`.
    */
   async editMatrixAndSave(): Promise<void> {
+    // Ligne ÉDITABLE uniquement : les types « admin d'application » (isAdmin) ont leurs
+    // contrôles verrouillés (`disabled`), les cliquer expirerait.
     const toggle = () =>
-      this.matrixPanel().locator('[data-testid$="-App"]').first();
+      this.matrixPanel()
+        .locator('[data-testid$="-App"]:not([disabled])')
+        .first();
     await expect(toggle()).toBeVisible();
     const original = (await toggle().innerText()).trim();
 

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -7288,8 +7288,6 @@ components:
       properties:
         actorTypeId:
           type: string
-        isAdmin:
-          type: boolean
         AppRead:
           type: boolean
         AppWrite:


### PR DESCRIPTION
## Contexte

La **campagne de non-régression** de la release **1.82.1** (PR release-please #2022) échoue sur **PRM-07** et **PRM-12** ([run](https://github.com/dnum-mi/referentiel-applications/actions/runs/29504344291/job/87645023780)), ce qui **bloque la release** (194 passent, 2 échouent).

## Cause

Régression introduite par **#2028 / #2031** : une ligne de matrice dont le type d'acteur est `isAdmin` (MOA/MOE, mis à `true` par le backfill) a ses toggles de permission **désactivés** (`disabled`) — comportement voulu (la ligne admin est verrouillée).

Or les helpers d'édition de matrice (`AdminPage.editMatrixAndSave/Restore`) cliquaient **le premier** toggle `-App` :

```ts
this.matrixPanel().locator('[data-testid$="-App"]').first()
```

Selon l'ordre des lignes, ce premier toggle tombe sur une ligne verrouillée → `locator.click: Timeout 20000ms`. La CI de #2031 est tombée par chance sur une ligne non-admin (d'où le vert) ; la campagne release est tombée sur une ligne verrouillée.

## Correctif

Cibler le premier toggle **éditable** :

```ts
this.matrixPanel().locator('[data-testid$="-App"]:not([disabled])').first()
```

Une ligne non-admin est ainsi toujours choisie — déterministe.

## Vérification

Rejoué en local contre la stack #2028 (MOA/MOE `isAdmin` → lignes verrouillées) : **PRM-06/07/12/13 verts** (dont les 2 qui bloquaient). `pnpm type-check` e2e OK.

Débloque la release #2022. Réf. #2028.
