### PR TITLE
fix(qa): campagne — éviter la limite de débit de /search/issues (débloque la release 1.82.1)

### DIFF
--- a/qa/scripts/campaign.mjs
+++ b/qa/scripts/campaign.mjs
@@ -177,13 +177,31 @@ async function gh(path, init = {}) {
 
 const titleFor = (label) => `[QA][v${version}] ${label}`;
 
-/** Cherche une issue ouverte par titre exact. */
+// Cache des issues QA ouvertes : évite d'interroger l'API `/search/issues` (plafonnée à ~30
+// req/min) une fois par domaine, ce qui déclenchait des 403 « rate limit exceeded ». On liste
+// les issues QA ouvertes UNE seule fois via l'API REST (plafond 5000/h) et on matche en mémoire.
+let openQaIssuesCache = null;
+
+async function listOpenQaIssues() {
+  if (openQaIssuesCache) return openQaIssuesCache;
+  const issues = [];
+  for (let page = 1; page <= 10; page += 1) {
+    const batch = await gh(
+      `/repos/${owner}/${name}/issues?state=open&labels=qa&per_page=100&page=${page}`,
+    );
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    // L'endpoint `issues` renvoie aussi les PR : on les exclut.
+    issues.push(...batch.filter((i) => !i.pull_request));
+    if (batch.length < 100) break;
+  }
+  openQaIssuesCache = issues;
+  return issues;
+}
+
+/** Cherche une issue QA ouverte par titre exact (via la liste REST en cache, sans `/search`). */
 async function findOpenIssue(title) {
-  const q = encodeURIComponent(
-    `repo:${owner}/${name} is:issue is:open in:title "${title}"`,
-  );
-  const res = await gh(`/search/issues?q=${q}`);
-  return res.items?.find((i) => i.title === title) ?? null;
+  const issues = await listOpenQaIssues();
+  return issues.find((i) => i.title === title) ?? null;
 }
 
 /** Extrait les étapes (id, titre, action, attendu) du protocole d'un domaine. */


### PR DESCRIPTION
## Contexte

La **campagne de non-régression** de la release **1.82.1** (PR #2022) échoue à l'étape « Ouvrir / réutiliser les issues de campagne », **avant** tout test ([job](https://github.com/dnum-mi/referentiel-applications/actions/runs/29508924114/job/87656992167)) :

```
GitHub API /search/issues?q=…[QA][v1.82.1] Diagramme Time… → 403
"API rate limit exceeded for installation"
  at gh (qa/scripts/campaign.mjs:174)
  at findOpenIssue (campaign.mjs:185)
  at open (campaign.mjs:259)
```

## Cause

`findOpenIssue` interroge l'API **`/search/issues`** (plafonnée à ~**30 req/min**), et `open()`/`close()` l'appellent **une fois par domaine** (~19). En rafale → **403 rate limit**. Ce n'est ni un test ni du code applicatif : c'est une faiblesse du script de campagne.

## Correctif

Lister les issues QA ouvertes **une seule fois** via l'API REST `/repos/…/issues?state=open&labels=qa` (plafond **5000/h**), les mettre en cache, et matcher par titre en mémoire. Plus aucun appel `/search`.

- `findOpenIssue(title)` → lookup dans la liste en cache.
- Toutes les issues de campagne portent le label `qa` (créées avec `labels: ["qa", …]`), donc le filtre les retrouve toutes ; les PR sont exclues (`!pull_request`).

Aucun changement de comportement fonctionnel — uniquement la façon de retrouver les issues. Débloque la campagne release #2022.
