### PR TITLE
fix(ui): homogénéiser matrice des droits et onglets de la fiche (libellés, ordre, en-tête sticky)

### DIFF
--- a/backend/src/actorType/actorType.service.ts
+++ b/backend/src/actorType/actorType.service.ts
@@ -4,28 +4,30 @@ import { BaseService } from "src/common/base.service";
 import { PrismaService } from "src/prisma/prisma.service";
 import { AppPermsDto } from "./dto/app-perms-matrix.dto";
 
+// Libellés des lignes d'historique, dans l'ordre d'affichage de la matrice (= ordre des
+// onglets de la fiche, #2083).
 const PERM_FIELDS: Record<string, string> = {
   AppRead: "Informations - Lecture",
   AppWrite: "Informations - Écriture",
   AppWritePriority: "Prioritisation et redémarrage",
-  ActorRead: "Acteurs - Lecture",
-  ActorWrite: "Acteurs - Écriture",
-  ComplianceRead: "Conformités - Lecture",
-  ComplianceWrite: "Conformités - Écriture",
   HostingRead: "Hébergements - Lecture",
   HostingWrite: "Hébergements - Écriture",
-  MetadataRead: "Historique - Lecture",
-  DataRead: "Données - Lecture",
-  DataWrite: "Données - Écriture",
-  TechnologyRead: "Technologies - Lecture",
-  TechnologyWrite: "Technologies - Écriture",
-  RelationRead: "Relations - Lecture",
-  RelationWrite: "Relations - Écriture",
   LinkRead: "Liens - Lecture",
   LinkWrite: "Liens - Écriture",
+  ComplianceRead: "Conformités - Lecture",
+  ComplianceWrite: "Conformités - Écriture",
+  ActorRead: "Acteurs - Lecture",
+  ActorWrite: "Acteurs - Écriture",
+  TechnologyRead: "Technologie - Lecture",
+  TechnologyWrite: "Technologie - Écriture",
+  RelationRead: "Relations - Lecture",
+  RelationWrite: "Relations - Écriture",
+  DataRead: "Données - Lecture",
+  DataWrite: "Données - Écriture",
   ReportRead: "Signalements - Lecture",
   ReportPost: "Signalements - Publication",
   ReportManage: "Signalements - Gestion",
+  MetadataRead: "Historique - Lecture",
 };
 
 @Injectable()

--- a/e2e/tests/fiche-application.spec.ts
+++ b/e2e/tests/fiche-application.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "../fixtures/test";
+import { test, expect } from "../fixtures/test";
 import { ApplicationPage, SearchPage, loginAs } from "../pom";
 
 const USER_EMAIL = "user@example.com";
@@ -242,11 +242,11 @@ test.describe("Fiche application", () => {
     await fiche.sortModificationsColumn("Date");
     await fiche.sortModificationsColumn("Titre");
   });
-  // FIC-22 (#2088) — l'onglet Stack technique suit les droits, comme les autres onglets
+  // FIC-22 (#2088) — l'onglet Technologie (ex-« Stack technique », #2083) suit les droits, comme les autres onglets
   // (défait la « lecture pour tous » de #2027) : un Visiteur (aucun droit Technologie) ne
   // doit pas le voir ; un Lecteur le retrouve via la projection de rôle par application.
   // CONTEXTE navigateur séparé pour la session `user` ; rôle restauré en `finally`.
-  test("FIC-22 - l'onglet Stack technique est masqué pour un Visiteur", async ({
+  test("FIC-22 - l'onglet Technologie est masqué pour un Visiteur", async ({
     browser,
     data,
   }) => {
@@ -261,16 +261,23 @@ test.describe("Fiche application", () => {
       await loginAs(userPage, "user");
       const fiche = new ApplicationPage(userPage);
 
-      // Visiteur : la fiche se rend (témoin AppRead du socle) mais SANS l'onglet Stack
-      // technique — le bouton d'onglet n'est pas rendu du tout.
-      await fiche.open(app.id);
-      await fiche.expectTabButtonVisible("Informations générales");
-      await fiche.expectTabButtonAbsent("Stack technique");
+      // Visiteur : la fiche se rend (témoin AppRead du socle) mais SANS l'onglet
+      // Technologie — le bouton d'onglet n'est pas rendu du tout. Les workers parallèles
+      // (PRM-04/05) peuvent restaurer le rôle Lecteur au même moment → re-poser le rôle
+      // avant chaque tentative (pattern PRM-10).
+      await expect(async () => {
+        await data.setUserRole(USER_EMAIL, "VISITOR");
+        await fiche.open(app.id);
+        await fiche.expectTabButtonVisible("Informations générales");
+        await fiche.expectTabButtonAbsent("Technologie");
+      }).toPass({ timeout: 45000 });
 
       // Lecteur : l'onglet revient via la projection de rôle (READ_APP_PERMISSIONS).
-      await data.resetUser(USER_EMAIL);
-      await fiche.open(app.id);
-      await fiche.expectTabButtonVisible("Stack technique");
+      await expect(async () => {
+        await data.resetUser(USER_EMAIL);
+        await fiche.open(app.id);
+        await fiche.expectTabButtonVisible("Technologie");
+      }).toPass({ timeout: 45000 });
     } finally {
       await ctx.close();
       await data.removeApplication(app.id);

--- a/frontend/src/components/ApplicationOverview.vue
+++ b/frontend/src/components/ApplicationOverview.vue
@@ -82,7 +82,7 @@ const tabs = ref<
     requiredPerms: [Permission.ACTOR_READ],
   },
   {
-    title: "Stack technique",
+    title: "Technologie",
     icon: "ri-stack-line",
     tabId: "tab-technologies",
     panelId: "panel-technologies",

--- a/frontend/src/components/RefAppTable.vue
+++ b/frontend/src/components/RefAppTable.vue
@@ -193,12 +193,30 @@ watch(
   color: var(--text-title-grey) !important;
 }
 
+/* #2112 : en-tête épinglé — la zone de contenu PrimeVue devient la boîte de défilement
+   verticale (bornée). PrimeVue v4 pose déjà `position: sticky` sur `.p-datatable-thead`
+   mais sans `top` (inerte hors mode scrollable natif) : on fixe le point d'ancrage ici.
+   Ne PAS épingler les `th` : le mode colonnes redimensionnables les force en
+   `position: relative` (ancrage des poignées de resize) et gagnerait la cascade. */
+:deep(.p-datatable-table-container) {
+  max-height: 70vh;
+  overflow: auto;
+}
+
+:deep(.p-datatable-thead) {
+  top: 0;
+  z-index: 2;
+}
+
 :deep(.p-datatable-thead > tr > th) {
   background-color: var(--background-alt-grey) !important;
   font-weight: 700;
   padding: 1rem;
   text-align: left;
-  border-bottom: 2px solid var(--border-default-grey);
+  /* box-shadow plutôt que border-bottom : avec `border-collapse: collapse`, la bordure d'un
+     `th` sticky reste collée au corps et disparaît au défilement. */
+  border-bottom: none;
+  box-shadow: inset 0 -2px 0 var(--border-default-grey);
   color: var(--text-default-grey) !important;
 }
 

--- a/frontend/src/components/admin/AppPermsMatrix.vue
+++ b/frontend/src/components/admin/AppPermsMatrix.vue
@@ -184,21 +184,6 @@ function saveAppPermsMatrix() {
   padding: 0.5rem !important;
 }
 
-/* En-tête sticky (#2083). En DSFR legacy la `table` est ELLE-MÊME la boîte de défilement
-   (`.fr-table > table { display: block; overflow: auto }`) : c'est donc sa hauteur qu'on
-   borne — un max-height posé sur `.fr-table` ferait défiler l'en-tête avec le corps, le
-   sticky s'épinglant au scrollport le plus proche (la table). Le fond est porté par `thead`,
-   pas par `th` — un `th` sticky doit redéclarer fond opaque thémé et liseré bas.
-   `table` appartient au template interne de DsfrTable (pas au slot) → :deep obligatoire. */
-.fr-table :deep(> table) {
-  max-height: 70vh;
-}
-
-.fr-table > table thead th {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  background-color: var(--background-alt-grey);
-  box-shadow: inset 0 -1px 0 var(--border-plain-grey);
-}
+/* En-tête sticky : porté par la règle GLOBALE de main.css (#2112), qui couvre toutes les
+   tables DSFR legacy (`.fr-table > table`), celle-ci comprise. */
 </style>

--- a/frontend/src/components/admin/AppPermsMatrix.vue
+++ b/frontend/src/components/admin/AppPermsMatrix.vue
@@ -18,6 +18,8 @@ onMounted(async () => {
   await actorTypeStore.fetchAll();
 });
 
+// Colonnes dans l'ordre des onglets de la fiche application (#2083) — « Priorit. Redémarr. »
+// et « Héberg. » n'ont pas d'onglet propre et restent accolées à « Infos » dont elles relèvent.
 const permissionSuffixes = {
   App: { label: "Infos", title: "Informations" },
   PriorityRestart: { label: "Priorit. Redémarr.", title: "Prioritisation et redémarrage" },
@@ -25,12 +27,15 @@ const permissionSuffixes = {
   Link: { label: "Liens", title: "Liens" },
   Compliance: { label: "Conformités", title: "Conformités" },
   Actor: { label: "Acteurs", title: "Acteurs" },
+  Technology: { label: "Techno.", title: "Technologie" },
   Relation: { label: "Relations", title: "Relations" },
   Data: { label: "Données", title: "Données" },
-  Technology: { label: "Techno.", title: "Technologies" },
   Metadata: { label: "Modifications", title: "Modifications" },
 } as const satisfies Record<string, { label: string; title: string }>;
 const permissionKeys = Object.keys(permissionSuffixes) as (keyof typeof permissionSuffixes)[];
+// « Modifications » (Metadata) est rendue à part, APRÈS la colonne Signalements, pour suivre
+// l'ordre des onglets de la fiche (Signalements avant Modifications).
+const gridKeys = permissionKeys.filter((k) => k !== "Metadata");
 
 const updatedMatrix = ref<AppPermsDto[]>(unref(props.appPermsMatrix));
 
@@ -82,15 +87,16 @@ function saveAppPermsMatrix() {
     <template #header>
       <tr>
         <th scope="col">Type d'acteur</th>
-        <th v-for="perm in permissionSuffixes" :key="perm.label" scope="col" style="min-width: 6rem" :title="perm.title">
-          {{ perm.label }}
+        <th v-for="key in gridKeys" :key="key" scope="col" style="min-width: 6rem" :title="permissionSuffixes[key].title">
+          {{ permissionSuffixes[key].label }}
         </th>
         <th scope="col">Signalements</th>
+        <th scope="col" style="min-width: 6rem" title="Modifications">Modifications</th>
       </tr>
     </template>
     <tr v-for="perms in updatedMatrix as AppPermsDto[]" :key="perms.actorTypeId" :data-testid="`app-perms-row-${perms.actorTypeId}`">
       <td>{{ actorTypeStore.actorTypes.find((at) => at.id === perms.actorTypeId)?.label ?? perms.actorTypeId }}</td>
-      <td v-for="perm in permissionKeys" :key="perm">
+      <td v-for="perm in gridKeys" :key="perm">
         <PermissionSelect
           v-if="perm === 'App'"
           :id="`${perms.actorTypeId}-${perm}`"
@@ -98,15 +104,6 @@ function saveAppPermsMatrix() {
           :read="perms[`${perm}Read`] || false"
           :write="perms[`${perm}Write`] || false"
           :perm-order="['Read', 'Write']"
-          :data-testid="`app-perms-select-${perms.actorTypeId}-${perm}`"
-          @update:model-value="(value: PermissionValue) => updateMatrix(perms.actorTypeId, perm as keyof typeof permissionSuffixes, value)"
-        />
-        <PermissionSelect
-          v-else-if="perm === 'Metadata'"
-          :id="`${perms.actorTypeId}-${perm}`"
-          class="permission-select"
-          :read="perms[`${perm}Read`] || false"
-          :perm-order="['none', 'Read']"
           :data-testid="`app-perms-select-${perms.actorTypeId}-${perm}`"
           @update:model-value="(value: PermissionValue) => updateMatrix(perms.actorTypeId, perm as keyof typeof permissionSuffixes, value)"
         />
@@ -147,6 +144,16 @@ function saveAppPermsMatrix() {
           @update:model-value="(value: ReportPermissionValue[]) => updateReportMatrix(perms.actorTypeId, value)"
         />
       </td>
+      <td>
+        <PermissionSelect
+          :id="`${perms.actorTypeId}-Metadata`"
+          class="permission-select"
+          :read="perms.MetadataRead || false"
+          :perm-order="['none', 'Read']"
+          :data-testid="`app-perms-select-${perms.actorTypeId}-Metadata`"
+          @update:model-value="(value: PermissionValue) => updateMatrix(perms.actorTypeId, 'Metadata', value)"
+        />
+      </td>
     </tr>
   </DsfrTable>
   <!-- Positionner à droite -->
@@ -175,5 +182,23 @@ function saveAppPermsMatrix() {
 <style scoped>
 .fr-table > table td {
   padding: 0.5rem !important;
+}
+
+/* En-tête sticky (#2083). En DSFR legacy la `table` est ELLE-MÊME la boîte de défilement
+   (`.fr-table > table { display: block; overflow: auto }`) : c'est donc sa hauteur qu'on
+   borne — un max-height posé sur `.fr-table` ferait défiler l'en-tête avec le corps, le
+   sticky s'épinglant au scrollport le plus proche (la table). Le fond est porté par `thead`,
+   pas par `th` — un `th` sticky doit redéclarer fond opaque thémé et liseré bas.
+   `table` appartient au template interne de DsfrTable (pas au slot) → :deep obligatoire. */
+.fr-table :deep(> table) {
+  max-height: 70vh;
+}
+
+.fr-table > table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: var(--background-alt-grey);
+  box-shadow: inset 0 -1px 0 var(--border-plain-grey);
 }
 </style>

--- a/frontend/src/components/technology/TechnologyTab.vue
+++ b/frontend/src/components/technology/TechnologyTab.vue
@@ -151,7 +151,7 @@ function cancelDelete() {
   <p class="fr-sr-only" aria-live="polite" aria-atomic="true" data-testid="technology-status">{{ statusMessage }}</p>
   <div class="fr-grid-row fr-grid-row--middle fr-mb-3w" v-bind="$attrs" data-testid="technology-tab">
     <div class="fr-col">
-      <h3 class="fr-mb-0">Stack technique</h3>
+      <h3 class="fr-mb-0">Technologie</h3>
     </div>
     <div class="fr-col-auto">
       <DsfrButton

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -118,3 +118,24 @@ body,
 .a11y-text-spacing-test p {
   margin-bottom: 2em !important;
 }
+
+/*
+ * #2112 : en-têtes de tableaux épinglés (sticky) pendant le défilement.
+ * Tables DSFR legacy (`.fr-table > table`) : la table est SA PROPRE boîte de défilement
+ * (`display: block; overflow: auto`), on borne donc sa hauteur pour que les `th` s'épinglent
+ * à son scrollport — un max-height posé sur `.fr-table` ferait défiler l'en-tête avec le
+ * corps. Le fond DSFR étant porté par `thead` (qui défile), les `th` redéclarent un fond
+ * opaque thémé + liseré bas. Les tableaux PrimeVue passent par `RefAppTable`, qui porte
+ * les règles équivalentes (`.p-datatable-table-container`).
+ */
+.fr-table > table {
+  max-height: 70vh;
+}
+
+.fr-table > table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: var(--background-alt-grey);
+  box-shadow: inset 0 -1px 0 var(--border-plain-grey);
+}

--- a/qa/protocoles/fiche-application.md
+++ b/qa/protocoles/fiche-application.md
@@ -109,13 +109,13 @@
   recherche ; ce cas vérifie uniquement le trajet clic (fiche) → navigation (URL avec le bon
   paramètre tag).
 
-### FIC-22 — Onglet Stack technique masqué sans droits Technologie ✅
+### FIC-22 — Onglet Technologie masqué sans droits Technologie ✅
 
 - **Datafeature** : application de test jetable (l'utilisateur `user` n'y est pas acteur : ni
   matrice ni rôle projeté, seul le socle global s'applique) ; rôle de `user` posé à Visiteur,
   restauré Lecteur en fin de test.
 - **Action** : connecté en `user` (Visiteur), ouvrir la fiche ; puis repasser Lecteur et recharger.
-- **Résultat attendu** : en Visiteur, l'onglet **Stack technique** n'est pas rendu du tout (le
+- **Résultat attendu** : en Visiteur, l'onglet **Technologie** n'est pas rendu du tout (le
   bouton d'onglet est absent) alors que « Informations générales » reste visible ; en Lecteur,
   l'onglet réapparaît via la projection de rôle par application. Défait la « lecture pour tous »
   de #2027 — l'onglet suit désormais les droits comme les autres onglets (cf. #2088).


### PR DESCRIPTION
## Contexte

Closes #2083. Trois choses, la troisième en bonus demandé :

1. **Libellé unifié « Technologie »** : l'onglet de la fiche (ex-« Stack technique »), son titre interne, l'infobulle de colonne de la matrice et les libellés des lignes d'historique parlent désormais tous de « Technologie ».
2. **Ordre des colonnes de la matrice = ordre des onglets de la fiche** : Infos (avec Priorit. Redémarr. et Héberg. qui n'ont pas d'onglet propre et restent accolées), Liens, Conformités, Acteurs, **Techno.**, Relations, Données, **Signalements puis Modifications** (la colonne Modifications est rendue après Signalements, comme les onglets). L'ordre des lignes du changelog d'historique (`PERM_FIELDS`) suit le même ordre.
3. **En-tête sticky** : la table DSFR legacy étant sa propre boîte de défilement (`.fr-table > table { display: block; overflow: auto }`), c'est sa hauteur qui est bornée (70vh) et les `th` s'épinglent à son scrollport avec fond opaque thémé + liseré (le fond DSFR est porté par `thead`, pas par `th`).

~~PR empilée~~ → **rebasée sur `main`** après les merges de #2086 et #2089 ; les conflits (`AppPermsMatrix.vue` : réordonnancement vs retrait de la colonne Admin ; `actorType.service.ts`) sont résolus — le composant final est la version sans colonne Admin, réordonnée et sticky.

## Vérifications (après rebase)

- E2E chromium : **PRM + FIC + ADM = 55 verts** ; FIC-22 renommé et durci contre les courses de rôle inter-workers (pattern `toPass` de PRM-10).
- Sticky et ordre vérifiés au navigateur réel post-rebase : sonde géométrique après 2000 px de scroll, en-têtes = Type d'acteur · Infos · Priorit. Redémarr. · Héberg. · Liens · Conformités · Acteurs · Techno. · Relations · Données · Signalements · Modifications.
- Backend : specs `check-permissions` + `role-to-permissions` vertes ; vue-tsc : zéro erreur dans les fichiers touchés ; ESLint 0 erreur.

Réf. #2083.