### PR TITLE
feat(ui): en-têtes sticky pour tous les tableaux de l'application

### DIFF
--- a/frontend/src/components/RefAppTable.vue
+++ b/frontend/src/components/RefAppTable.vue
@@ -193,12 +193,30 @@ watch(
   color: var(--text-title-grey) !important;
 }
 
+/* #2112 : en-tête épinglé — la zone de contenu PrimeVue devient la boîte de défilement
+   verticale (bornée). PrimeVue v4 pose déjà `position: sticky` sur `.p-datatable-thead`
+   mais sans `top` (inerte hors mode scrollable natif) : on fixe le point d'ancrage ici.
+   Ne PAS épingler les `th` : le mode colonnes redimensionnables les force en
+   `position: relative` (ancrage des poignées de resize) et gagnerait la cascade. */
+:deep(.p-datatable-table-container) {
+  max-height: 70vh;
+  overflow: auto;
+}
+
+:deep(.p-datatable-thead) {
+  top: 0;
+  z-index: 2;
+}
+
 :deep(.p-datatable-thead > tr > th) {
   background-color: var(--background-alt-grey) !important;
   font-weight: 700;
   padding: 1rem;
   text-align: left;
-  border-bottom: 2px solid var(--border-default-grey);
+  /* box-shadow plutôt que border-bottom : avec `border-collapse: collapse`, la bordure d'un
+     `th` sticky reste collée au corps et disparaît au défilement. */
+  border-bottom: none;
+  box-shadow: inset 0 -2px 0 var(--border-default-grey);
   color: var(--text-default-grey) !important;
 }
 

--- a/frontend/src/components/admin/AppPermsMatrix.vue
+++ b/frontend/src/components/admin/AppPermsMatrix.vue
@@ -184,21 +184,6 @@ function saveAppPermsMatrix() {
   padding: 0.5rem !important;
 }
 
-/* En-tête sticky (#2083). En DSFR legacy la `table` est ELLE-MÊME la boîte de défilement
-   (`.fr-table > table { display: block; overflow: auto }`) : c'est donc sa hauteur qu'on
-   borne — un max-height posé sur `.fr-table` ferait défiler l'en-tête avec le corps, le
-   sticky s'épinglant au scrollport le plus proche (la table). Le fond est porté par `thead`,
-   pas par `th` — un `th` sticky doit redéclarer fond opaque thémé et liseré bas.
-   `table` appartient au template interne de DsfrTable (pas au slot) → :deep obligatoire. */
-.fr-table :deep(> table) {
-  max-height: 70vh;
-}
-
-.fr-table > table thead th {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  background-color: var(--background-alt-grey);
-  box-shadow: inset 0 -1px 0 var(--border-plain-grey);
-}
+/* En-tête sticky : porté par la règle GLOBALE de main.css (#2112), qui couvre toutes les
+   tables DSFR legacy (`.fr-table > table`), celle-ci comprise. */
 </style>

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -118,3 +118,24 @@ body,
 .a11y-text-spacing-test p {
   margin-bottom: 2em !important;
 }
+
+/*
+ * #2112 : en-têtes de tableaux épinglés (sticky) pendant le défilement.
+ * Tables DSFR legacy (`.fr-table > table`) : la table est SA PROPRE boîte de défilement
+ * (`display: block; overflow: auto`), on borne donc sa hauteur pour que les `th` s'épinglent
+ * à son scrollport — un max-height posé sur `.fr-table` ferait défiler l'en-tête avec le
+ * corps. Le fond DSFR étant porté par `thead` (qui défile), les `th` redéclarent un fond
+ * opaque thémé + liseré bas. Les tableaux PrimeVue passent par `RefAppTable`, qui porte
+ * les règles équivalentes (`.p-datatable-table-container`).
+ */
+.fr-table > table {
+  max-height: 70vh;
+}
+
+.fr-table > table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: var(--background-alt-grey);
+  box-shadow: inset 0 -1px 0 var(--border-plain-grey);
+}


### PR DESCRIPTION
## Contexte

Closes #2112. Généralise à **tous les tableaux** l'en-tête épinglé livré pour la matrice des droits (#2083 / #2090).

## Contenu

Deux familles couvrent l'app :

- **PrimeVue via `RefAppTable`** (~24 écrans : catalogue, historique, onglets de fiche, admin, signalements…) : la zone de contenu (`.p-datatable-table-container`) est bornée à 70vh et devient la boîte de défilement. Subtilité : PrimeVue v4 pose déjà `position: sticky` sur `.p-datatable-thead` mais **sans `top`** (inerte) — il suffit d'ancrer `top: 0`. On n'épingle PAS les `th` : le mode colonnes redimensionnables les force en `position: relative` (ancrage des poignées) et gagne la cascade. La bordure basse de l'en-tête passe en `box-shadow` inset (une bordure `border-collapse` resterait collée au corps et disparaîtrait au défilement).
- **DSFR legacy** (`.fr-table > table` : matrice des droits, batch de données, tokens) : règle **globale** dans `main.css` avec le pattern éprouvé de #2090 (la table est sa propre boîte de scroll ; `th` épinglés avec fond opaque thémé). Le CSS local posé sur la matrice par #2090 est retiré (remplacé par la règle globale).

Tables brutes restantes (profil clé/valeur, transcription TIME) : pas de `thead` ou tableau court — sans effet.

## ⚠️ PR empilée

Basée sur `2083-homogenisation-onglets-matrice` (#2090, CI verte, prête à merger) car elle retire le CSS sticky local que #2090 introduit. À re-cibler sur `main` après le merge de #2090 (aucun conflit attendu).

## Vérifications

- **Suite e2e chromium complète : 204 verts, 0 échec** (8 skips conditionnels habituels).
- Sondes navigateur réelles (géométrie après scroll) : catalogue ✓, historique ✓, matrice des droits ✓ — en-tête épinglé au scrollport dans les trois familles.
- ESLint 0 erreur ; vue-tsc : aucune erreur sur les fichiers touchés.

Réf. #2112.