### PR TITLE
fix(admin): le modal d'édition d'un utilisateur ne se ferme plus tout seul

### DIFF
--- a/e2e/fixtures/api-client.ts
+++ b/e2e/fixtures/api-client.ts
@@ -600,6 +600,7 @@ export interface UserAdmin {
   email: string;
   role: string;
   additionalPermissions: string[];
+  organizationId?: string | null;
 }
 
 /** Champs de conformité utiles aux tests (sous-ensemble du DTO backend). */

--- a/e2e/pom/admin.page.ts
+++ b/e2e/pom/admin.page.ts
@@ -79,6 +79,38 @@ export class AdminPage extends BasePage {
     await expect(
       this.editModal().getByTestId("admin-save-perms-btn"),
     ).toBeVisible();
+    // DsfrModal pose son focus initial ~100 ms APRÈS l'ouverture (setTimeout interne de
+    // vue-dsfr) : interagir avant se fait voler le focus en pleine saisie — et Espace/Entrée
+    // sur le bouton « Fermer » fermerait le modal « tout seul » (#1830). On attend que le
+    // focus soit posé QUELQUE PART dans le modal (sans figer la cible exacte, interne à la lib).
+    await expect
+      .poll(() =>
+        this.editModal().evaluate((el) => el.contains(document.activeElement)),
+      )
+      .toBe(true);
+  }
+
+  /**
+   * Édite l'organisation d'un utilisateur via la recherche du modal et enregistre (#1830 :
+   * la saisie ne doit pas perdre le focus et le modal doit rester ouvert pendant tout le flux).
+   */
+  async editUserOrganizationAndSave(
+    email: string,
+    orgSearch: string,
+    orgPath: string,
+  ): Promise<void> {
+    await this.openEditUser(email);
+    const orgField = this.editModal().getByTestId("user-organization-search");
+    const input = orgField.locator("input").first();
+    await input.click();
+    await input.pressSequentially(orgSearch, { delay: 50 });
+    // La saisie complète est bien dans le champ (aucun vol de focus pendant la frappe).
+    await expect(input).toHaveValue(orgSearch);
+    // Les résultats alimentent le select ; on choisit l'organisation par son chemin exact.
+    await orgField.getByRole("combobox").selectOption({ label: orgPath });
+    // Anti-#1830 : le modal est TOUJOURS ouvert après recherche + sélection.
+    await expect(this.editModal()).toBeVisible();
+    await this.saveUserEdit();
   }
 
   /**

--- a/e2e/tests/scope-acteurs.spec.ts
+++ b/e2e/tests/scope-acteurs.spec.ts
@@ -5,6 +5,7 @@ import { ApiClient } from "../fixtures/api-client";
 import { DataFeature } from "../fixtures/datafeature";
 
 // Ids fixes des organisations du seed QA (cf. backend/prisma/seed-qa.ts).
+const ORG_TOTO_ID = "a0000000-0000-4000-8000-000000000001";
 const ORG_TOTO_TUTU_ID = "a0000000-0000-4000-8000-000000000002";
 const ORG_ABCD_ID = "a0000000-0000-4000-8000-000000000003";
 
@@ -80,9 +81,14 @@ test.describe("Périmètres admin & groupes d'acteurs", () => {
     await admin.editUserRoleWithinScopeAndSave("qa-target@example.com");
   });
 
-  // Note : la frontière de périmètre se vérifie au niveau de l'autorisation (cœur de #14/#15). L'édition
-  // via l'UI est instable (le modal d'édition se ferme au rafraîchissement de la liste, #1830) et un
-  // payload partiel déclenche une 500 (#1831) → on valide la règle via l'endpoint, token du requérant scopé.
+  // Le volet « autorisé » se joue via l'UI réelle (modal d'édition + recherche d'organisation),
+  // réactivé après le fix #1830 (le modal ne se ferme plus au rafraîchissement de la liste et le
+  // POM absorbe le focus initial différé de DsfrModal). Le volet « refusé » reste au niveau de
+  // l'autorisation API : c'est le garde-fou serveur qu'on veut verrouiller (le trajet UI existe —
+  // la liste n'est pas filtrée par périmètre — mais aboutirait au même contrôle serveur).
+  // Cible du changement : TOTO (≠ TOTO/TUTU, l'org du seed) — l'option n'est PAS pré-alimentée
+  // par `initial-organization`, la sélection prouve donc que la recherche a réellement abouti,
+  // et l'assertion finale n'est pas satisfaite d'avance. Restauration en `finally`.
   test("SCP-04 - changer l'organisation dans le périmètre est autorisé, éditer un user hors périmètre est refusé", async ({
     page,
   }) => {
@@ -92,19 +98,26 @@ test.describe("Périmètres admin & groupes d'acteurs", () => {
     const outside = await api.userByEmail("qa-outside@example.com");
     test.skip(!target || !outside, SEED_HINT);
 
-    // Payload complet (rôle + permissions + périmètre), comme l'UI, sur un user DANS le périmètre TOTO/.
-    const base = {
-      role: target!.role,
-      additionalPermissions: target!.additionalPermissions,
-      scopeOrganizationId: null,
-    };
-
-    // Affecter une organisation du périmètre (TOTO/TUTU) → autorisé.
-    const within = await api.setUser(target!.id, {
-      ...base,
-      organizationId: ORG_TOTO_TUTU_ID,
-    });
-    expect(within).not.toBeNull();
+    // Affecter une AUTRE organisation du périmètre (TOTO) via le MODAL → autorisé (toast succès).
+    const admin = new AdminPage(page);
+    await admin.open();
+    try {
+      await admin.editUserOrganizationAndSave(
+        "qa-target@example.com",
+        "TOTO",
+        "TOTO",
+      );
+      const updated = await api.userByEmail("qa-target@example.com");
+      expect(updated?.organizationId ?? null).toBe(ORG_TOTO_ID);
+    } finally {
+      // Restaure l'état du seed (TOTO/TUTU) pour les runs suivants et les autres cas SCP.
+      await api.setUser(target!.id, {
+        role: target!.role,
+        additionalPermissions: target!.additionalPermissions,
+        scopeOrganizationId: null,
+        organizationId: ORG_TOTO_TUTU_ID,
+      });
+    }
 
     // Éditer un utilisateur HORS du périmètre (organisation ABCD/) → refusé par le contrôle de périmètre.
     const denied = await api.setUser(outside!.id, {

--- a/frontend/src/components/RefAppTable.vue
+++ b/frontend/src/components/RefAppTable.vue
@@ -9,6 +9,13 @@ import type { DataTableSortEvent, DataTablePageEvent } from "primevue/datatable"
 export interface Props<T extends Record<string, any> = Record<string, any>> {
   items: T[];
   columns: TableColumn[];
+  /**
+   * Champ identifiant de ligne, transmis au `dataKey` PrimeVue. Sans lui, les lignes sont
+   * keyées par INDEX : lors d'un refetch qui réordonne/filtre, les composants des cellules
+   * (modals inclus) sont réutilisés avec les données d'une AUTRE ligne (#1830). À fournir
+   * dès qu'un slot de cellule porte un état local.
+   */
+  dataKey?: string;
   loading?: boolean;
   totalRecords?: number;
   rows?: number;
@@ -22,6 +29,7 @@ export interface Props<T extends Record<string, any> = Record<string, any>> {
 }
 
 const props = withDefaults(defineProps<Props>(), {
+  dataKey: undefined,
   loading: false,
   totalRecords: 0,
   rows: 10,
@@ -120,6 +128,7 @@ watch(
   <section class="fr-table" :aria-label="`Tableau de ${totalRecords} éléments`">
     <DataTable
       :value="items"
+      :data-key="dataKey"
       :lazy="lazy"
       :total-records="totalRecords"
       :rows="rows"

--- a/frontend/src/components/admin/AdminUsersTab.vue
+++ b/frontend/src/components/admin/AdminUsersTab.vue
@@ -51,6 +51,11 @@ const tableColumns: TableColumn[] = headers.map((h) => ({
 }));
 
 const isLoading = ref(false);
+// Ne démonter la table qu'au chargement INITIAL : le `v-if isLoading` historique remplaçait la
+// table par l'alerte de chargement à CHAQUE refetch, démontant les `UserActions` des lignes et
+// fermant donc tout modal d'édition ouvert (#1830). Les refetchs suivants passent par l'état
+// `loading` de RefAppTable, qui garde la table (et ses modals) montée.
+const hasLoadedOnce = ref(false);
 const errorKeySet = ref<Set<ErrorKey>>(new Set());
 const searchQuery = ref("");
 
@@ -88,6 +93,7 @@ async function fetchUsers() {
     if (response.response.ok && response.data) {
       data.value = response.data;
       errorKeySet.value.delete("ERR_LOAD_USERS");
+      hasLoadedOnce.value = true;
     } else {
       errorKeySet.value.add("ERR_LOAD_USERS");
       console.error(response.error);
@@ -113,6 +119,7 @@ watch([sortColumn, isSortDescending], () => {
 
 const tableRows = computed(() =>
   data.value.results.map((user) => ({
+    id: user.id,
     email: user.email,
     organisation: user.organization?.path || "-",
     additionalPermissions: user.additionalPermissions,
@@ -157,20 +164,24 @@ onMounted(fetchUsers);
       <p>{{ statusMessage }}</p>
     </div>
 
-    <div v-if="isLoading" class="fr-alert fr-alert--info" data-testid="admin-users-loading">
-      <p>Chargement des utilisateurs...</p>
-    </div>
-
-    <div v-else-if="errorKeySet.size" class="fr-alert fr-alert--error" data-testid="admin-users-error">
+    <!-- Bannière (pas un remplacement) : une erreur de refetch ne doit pas démonter la table
+         déjà chargée — ni les modals d'édition ouverts dans ses lignes (#1830). -->
+    <div v-if="errorKeySet.size" class="fr-alert fr-alert--error fr-mb-2w" data-testid="admin-users-error">
       <p v-for="errorKey in Array.from(errorKeySet.keys())" :key="errorKey">
         {{ errorMessages[errorKey] }}
       </p>
     </div>
 
-    <div v-else>
+    <div v-if="isLoading && !hasLoadedOnce" class="fr-alert fr-alert--info" data-testid="admin-users-loading">
+      <p>Chargement des utilisateurs...</p>
+    </div>
+
+    <div v-else-if="hasLoadedOnce">
       <RefAppTable
         :items="tableRows"
         :columns="tableColumns"
+        data-key="id"
+        :loading="isLoading"
         :paginator="true"
         :lazy="true"
         :rows="itemsPerPage"

--- a/frontend/src/components/admin/UserActions.vue
+++ b/frontend/src/components/admin/UserActions.vue
@@ -43,6 +43,11 @@ async function impersonate() {
 const isEditModalOpen = ref(false);
 const isSaving = ref(false);
 const isSyncingFromMaia = ref(false);
+// Snapshot de l'utilisateur au moment de l'ouverture : si l'instance est réutilisée par la
+// table avec un AUTRE utilisateur pendant que le modal est ouvert (refetch qui réordonne),
+// l'enregistrement doit viser l'utilisateur AFFICHÉ à l'ouverture, jamais `props.user`
+// courant — sinon on écrirait le formulaire d'un compte sur l'id d'un autre (#1830).
+const editingUser = ref<Required<UserEntity> | null>(null);
 const editingUserRole = ref<RolesType>(Roles.VISITOR);
 const editingOrganizationId = ref<string>("");
 const editingAdditionalPermissions = ref<Permission[]>([]);
@@ -51,6 +56,7 @@ const maiaSuggestion = ref<MaiaOrganizationSuggestionDto | null>(null);
 const isFetchingMaiaSuggestion = ref(false);
 
 async function openEditModal() {
+  editingUser.value = props.user;
   editingUserRole.value = props.user.role;
   editingOrganizationId.value = props.user.organizationId || "";
   editingAdditionalPermissions.value = props.user.additionalPermissions ? [...props.user.additionalPermissions] : [];
@@ -80,6 +86,7 @@ async function fetchMaiaSuggestion() {
 
 function closeEditModal() {
   isEditModalOpen.value = false;
+  editingUser.value = null;
   editingUserRole.value = Roles.VISITOR;
   editingOrganizationId.value = "";
   editingScopePermissions.value = "";
@@ -98,10 +105,12 @@ function focusOpener() {
 }
 
 async function saveUser() {
+  const target = editingUser.value;
+  if (!target) return;
   isSaving.value = true;
   try {
     const response = await api.userControllerUpdate({
-      path: { id: props.user.id },
+      path: { id: target.id },
       body: {
         role: editingUserRole.value,
         organizationId: editingOrganizationId.value === "" ? null : editingOrganizationId.value,
@@ -226,7 +235,7 @@ const isScopeDisabled = computed(() => {
     </div>
 
     <DsfrModal :opened="isEditModalOpen" title="Modifier l'utilisateur" data-testid="admin-edit-user-modal" @close="closeEditModal">
-      <p><strong>Utilisateur :</strong> {{ user.email }}</p>
+      <p><strong>Utilisateur :</strong> {{ editingUser?.email ?? user.email }}</p>
 
       <!-- RGAA-086 (11.5) : regroupement des champs organisation de même nature. -->
       <fieldset class="fr-fieldset">

--- a/qa/protocoles/scope-acteurs.md
+++ b/qa/protocoles/scope-acteurs.md
@@ -6,10 +6,10 @@
 > `QA-SCOPE-*` et `QA-GROUP-*`. Signal « est admin / est acteur » sur une application = bouton
 > d'édition des informations actif.
 
-| Légende           |                                                                          |
-| :---------------- | :----------------------------------------------------------------------- |
-| **Automatisé** ✅ | `e2e/tests/scope-acteurs.spec.ts`                                        |
-| **Statut**        | ✅ 100 % des cas automatisés (POM strict + seed QA). SCP-04 : voir note. |
+| Légende           |                                                      |
+| :---------------- | :--------------------------------------------------- |
+| **Automatisé** ✅ | `e2e/tests/scope-acteurs.spec.ts`                    |
+| **Statut**        | ✅ 100 % des cas automatisés (POM strict + seed QA). |
 
 ---
 
@@ -34,8 +34,15 @@
 ### SCP-04 — Édition dans le périmètre autorisée, édition hors périmètre refusée ✅
 
 - **Datafeature** : `scope-admin`, `qa-target` (org `TOTO/TUTU`, dans le périmètre), `qa-outside` (org `ABCD`, hors périmètre).
-- **Action** : en `scope-admin`, affecter à `qa-target` une organisation du périmètre (`TOTO/TUTU`) ; tenter d'éditer `qa-outside`.
-- **Résultat attendu** : l'édition de `qa-target` réussit ; l'édition de `qa-outside` est refusée par le contrôle de périmètre.
+- **Action** : en `scope-admin`, ouvrir le **modal d'édition** de `qa-target`, rechercher « TOTO » dans le champ
+  organisation, sélectionner `TOTO` (≠ organisation du seed : l'assertion ne peut pas être vraie d'avance),
+  enregistrer, puis restaurer `TOTO/TUTU` ; tenter d'éditer `qa-outside` via l'API — c'est le **garde-fou
+  serveur** qu'on verrouille (la liste des utilisateurs n'est pas filtrée par périmètre, le trajet UI existe
+  mais aboutit au même contrôle serveur).
+- **Résultat attendu** : la saisie n'est pas interrompue et le **modal reste ouvert** pendant recherche + sélection
+  (non-régression #1830 : plus de fermeture au rafraîchissement de la liste, ni de vol de focus après le focus
+  initial différé de DsfrModal) ; toast de succès et organisation mise à jour (vérifiée via l'API) ; l'édition
+  de `qa-outside` est refusée par le contrôle de périmètre.
 
 ### SCP-05 — Un membre de `TOTO/TUTU` est acteur via un groupe `TOTO/` ✅
 


### PR DESCRIPTION
## Contexte

Closes #1830 (bug du backlog). Le modal « Modifier l'utilisateur » se fermait / perdait la saisie. Diagnostic **reproduit et prouvé au navigateur** — deux causes distinctes :

1. **Démontage au rafraîchissement de la liste** (le titre de l'issue) : le `v-if isLoading / v-else` d'`AdminUsersTab` remplaçait la table par l'alerte de chargement à CHAQUE refetch — démontant les `UserActions` des lignes et donc tout modal ouvert.
2. **Course de focus de 100 ms** : `DsfrModal` (vue-dsfr) focalise son bouton « Fermer » `setTimeout(…, 100)` après l'ouverture. Interagir dans cette fenêtre se fait voler le focus en pleine saisie (lettres perdues) — et Espace/Entrée activerait le bouton : fermeture « toute seule ». C'est ce qui rendait le volet UI de SCP-04 instable.

## Fix

- **AdminUsersTab** : la table reste montée après le premier chargement réussi (`hasLoadedOnce`) ; les refetchs passent par l'état `loading` de RefAppTable ; une erreur de refetch devient une **bannière au-dessus** de la table (plus un remplacement).
- **RefAppTable** : nouvelle prop `dataKey` transmise à PrimeVue. Sans elle, les lignes sont keyées par **index** : une fois la table maintenue montée, un refetch qui réordonne pouvait réutiliser l'instance du modal avec les données d'un AUTRE utilisateur — et **enregistrer le formulaire d'un compte sur l'id d'un autre** (finding majeur de la revue adversariale du diff). Les utilisateurs sont keyés par `id` ; une ligne qui sort des résultats démonte son modal proprement (vérifié au navigateur).
- **UserActions** : l'enregistrement vise un **snapshot** de l'utilisateur pris à l'ouverture du modal, jamais la prop courante (défense en profondeur).
- **E2E** : `openEditUser` attend que le focus initial différé de DsfrModal soit posé dans le modal (neutralise la course pour TOUS les tests du modal : SCP-03/04, PRM-04/05) ; **SCP-04 UI réactivé** (definition of done de l'issue) — recherche « TOTO » (≠ org du seed : l'assertion ne peut pas être vraie d'avance), sélection, enregistrement, vérification API, restauration en `finally`. Le volet « refusé » reste au niveau API : c'est le garde-fou serveur qu'on verrouille (la liste n'est pas filtrée par périmètre — la justification du protocole a été corrigée).

## Vérifications

- Preuves navigateur : modal **survit** à un refetch de la liste ✓ ; saisie organisation complète sans perte de focus ✓ ; ligne exclue des résultats → modal démonté proprement, jamais de bascule de compte ✓.
- E2E chromium : **SCP ×2 = 12 verts** (la restauration `finally` tient sur run répété) ; SCP + PRM + ADM + impersonation = **47 verts**.
- Revue adversariale multi-agents du diff : 5 findings confirmés, tous corrigés (dont le `dataKey` majeur ci-dessus).
- ESLint 0 erreur ; tsc e2e et vue-tsc propres sur les fichiers touchés.

Réf. #1830.