### PR TITLE
fix(data-catalog): ajouter la fréquence de mise à jour « Jamais » (NEVER)

### DIFF
--- a/backend/prisma/migrations/20260724130000_add_never_update_frequency/migration.sql
+++ b/backend/prisma/migrations/20260724130000_add_never_update_frequency/migration.sql
@@ -1,0 +1,4 @@
+-- #2055 : ajoute la fréquence de mise à jour « Jamais » (donnée figée).
+-- PostgreSQL ≥ 12 accepte ALTER TYPE ... ADD VALUE dans la transaction de migration
+-- tant que la nouvelle valeur n'y est pas utilisée (aucun usage ici).
+ALTER TYPE "DataUpdateFrequency" ADD VALUE 'NEVER';

--- a/backend/prisma/schema/data.prisma
+++ b/backend/prisma/schema/data.prisma
@@ -131,6 +131,8 @@ enum DataUpdateFrequency {
   YEARLY
   /// Mise à jour à la demande uniquement
   ON_DEMAND
+  /// Donnée jamais mise à jour (figée)
+  NEVER
 }
 
 /// Statut d'exposition d'une donnée en open data.

--- a/backend/tests/data-catalog.e2e-spec.ts
+++ b/backend/tests/data-catalog.e2e-spec.ts
@@ -391,6 +391,36 @@ describe("DataCatalog", () => {
         isReference: true,
       });
     });
+
+    // #2055 : la fréquence « Jamais » (NEVER) fait partie de l'enum de bout en bout —
+    // son absence faisait échouer les requêtes Prisma la mentionnant (500).
+    it("accepts the NEVER update frequency and returns it", async () => {
+      const description = await DataDescriptionFaker.create();
+
+      const response = await request(app().getHttpServer())
+        .post(`/data-catalog/applications/${application.id}`)
+        .set("Authorization", `Bearer ${WRITER_TOKEN}`)
+        .send({
+          dataDescriptionId: description.id,
+          updateFrequency: "NEVER",
+        })
+        .expect(201);
+
+      expect(response.body).toMatchObject({ updateFrequency: "NEVER" });
+    });
+
+    it("rejects an unknown update frequency with 400 (never a Prisma 500)", async () => {
+      const description = await DataDescriptionFaker.create();
+
+      await request(app().getHttpServer())
+        .post(`/data-catalog/applications/${application.id}`)
+        .set("Authorization", `Bearer ${WRITER_TOKEN}`)
+        .send({
+          dataDescriptionId: description.id,
+          updateFrequency: "SOMETIMES",
+        })
+        .expect(400);
+    });
   });
 
   describe("PATCH /data-catalog/applications/:applicationId/:dataApplicationId", () => {

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -7125,6 +7125,7 @@ components:
         - MONTHLY
         - YEARLY
         - ON_DEMAND
+        - NEVER
     DataExposureDto:
       type: object
       properties:

--- a/frontend/src/constants/data-catalog.constants.ts
+++ b/frontend/src/constants/data-catalog.constants.ts
@@ -13,6 +13,7 @@ export const UPDATE_FREQUENCY_LABELS = {
   MONTHLY: "Mensuelle",
   YEARLY: "Annuelle",
   ON_DEMAND: "À la demande",
+  NEVER: "Jamais",
 } as const satisfies Record<UpdateFrequency, string>;
 
 export const OPEN_DATA_BADGE_CLASS = {


### PR DESCRIPTION
## Contexte

Closes #2055 (bug du backlog). L'enum `DataUpdateFrequency` ne contenait pas `NEVER` : toute requête la mentionnant explosait dans Prisma en 500 non géré (le log de prod de l'issue). La valeur manquait de bout en bout.

## Fix

- **Prisma** : `NEVER` ajouté à l'enum + migration `ALTER TYPE … ADD VALUE` (PG ≥ 12 l'accepte dans la transaction de migration tant que la valeur n'y est pas utilisée — elle ne l'est pas).
- **Front** : libellé « Jamais » dans `UPDATE_FREQUENCY_LABELS` — les options du select du modal dérivent de l'enum du client généré, et la map de libellés est verrouillée par un `satisfies Record<UpdateFrequency, string>` (toute valeur d'enum sans libellé casse le type-check).
- **Tests backend** : création avec `NEVER` → 201 et valeur restituée ; fréquence inconnue → **400** par la validation DTO (jamais un 500 Prisma).
- Docs Prisma, swagger et client front régénérés.

## Vérifications

- Backend : jest **41/41 suites** (310 tests, dont les 2 nouveaux) ; migration appliquée sur base réelle, enum vérifiée en base (`DAILY,…,ON_DEMAND,NEVER`).
- Navigateur réel : « Jamais » apparaît dans le select du modal de rattachement d'une donnée.
- E2E chromium : suite DAT **16/16 verte**.
- ESLint 0 erreur ; vue-tsc propre sur les fichiers touchés.

## Remarque hors périmètre

Les suites e2e DAT-13/14 laissent des familles `DataFamily` dupliquées en base à chaque run local (résidus non nettoyés, noms hors du pattern de nettoyage E2E) — c'est la 2ᵉ fois que je dois dédupliquer la base de dev à la main. Je vais ouvrir une issue dédiée.

Réf. #2055.