### PR TITLE
fix(tests): les runs de tests ne polluent plus la base de dev

### DIFF
--- a/backend/tests/jest.setup.ts
+++ b/backend/tests/jest.setup.ts
@@ -1,3 +1,16 @@
+import { getTestDatabaseUrl } from "./test-database.utils";
+
 // Set NODE_ENV to test for all tests
 process.env.NODE_ENV = "test";
 process.env.DISABLE_JWT_VALIDATION = "true"; // Disable JWT verification in tests
+
+// #2117 : redirige les workers vers la base de TEST créée et migrée par `global-setup`.
+// Sans cette ligne, l'app Nest et les fakers utilisaient le DATABASE_URL ambiant — la base
+// de DEV — que chaque run polluait (familles « AAA/ZZZ sort family » dupliquées, users et
+// applications de faker…), pendant que `test_postgres` était créée puis droppée sans servir.
+if (!process.env.DATABASE_URL) {
+  throw new Error(
+    "DATABASE_URL est requis pour les tests (base de test dérivée : test_<db>)",
+  );
+}
+process.env.DATABASE_URL = getTestDatabaseUrl(process.env.DATABASE_URL);

--- a/e2e/fixtures/api-client.ts
+++ b/e2e/fixtures/api-client.ts
@@ -549,6 +549,20 @@ export class ApiClient {
     return this.del(`/data-catalog/descriptions/${id}`);
   }
 
+  /** Recherche des data descriptions par nom (`GET /data-catalog/descriptions?name=`). */
+  dataDescriptions(
+    name: string,
+  ): Promise<{ id: string; name: string }[] | null> {
+    return this.get<{ id: string; name: string }[]>(
+      `/data-catalog/descriptions?name=${encodeURIComponent(name)}`,
+    );
+  }
+
+  /** Supprime une famille métier (nettoyage des familles créées inline par les tests). */
+  deleteDataFamily(id: string): Promise<boolean> {
+    return this.del(`/data-catalog/families/${id}`);
+  }
+
   /** Liste paginée des familles métier du catalogue de données (`GET /data-catalog/families`). */
   dataFamilies(
     query = "",

--- a/e2e/fixtures/datafeature.ts
+++ b/e2e/fixtures/datafeature.ts
@@ -798,6 +798,7 @@ export class DataFeature {
   async provisionAttachedData(): Promise<{
     applicationId: string;
     dataApplicationId: string;
+    descriptionId: string;
   }> {
     const { applicationId, description } =
       await this.provisionUnattachedDataDescription();
@@ -806,12 +807,33 @@ export class DataFeature {
         applicationId,
         description.id,
       );
-      return { applicationId, dataApplicationId: dataApplication.id };
+      return {
+        applicationId,
+        dataApplicationId: dataApplication.id,
+        descriptionId: description.id,
+      };
     } catch (err) {
       await this.deleteDataDescription(description.id);
       await this.removeApplication(applicationId);
       throw err;
     }
+  }
+
+  /**
+   * Supprime une data description créée via l'UI (le formulaire ne restitue pas l'id) en la
+   * retrouvant par son nom exact — les tests utilisent des noms `E2E … <timestamp>` uniques.
+   */
+  async deleteDataDescriptionByName(name: string): Promise<void> {
+    const matches = await this.api.dataDescriptions(name);
+    const found = matches?.find((d) => d.name === name);
+    if (found) await this.api.deleteDataDescription(found.id);
+  }
+
+  /** Supprime une famille métier créée inline via l'UI, retrouvée par son chemin exact. */
+  async deleteDataFamilyByPath(path: string): Promise<void> {
+    const page = await this.api.dataFamilies("pageSize=100&page=0");
+    const found = page?.results?.find((f) => f.path === path);
+    if (found) await this.api.deleteDataFamily(found.id);
   }
 
   // --- Matrice des permissions (PRM-12) ---

--- a/e2e/support/global-cleanup.ts
+++ b/e2e/support/global-cleanup.ts
@@ -76,6 +76,21 @@ export async function sweepE2EData(api: ApiClient): Promise<number> {
     if (E2E.test(a.label ?? "")) await drop(api.deleteApplication(a.id));
   }
 
+  // Catalogue de données : descriptions puis familles `E2E …` (#2117) — créées inline par les
+  // cas DAT ; à balayer APRÈS les applications (le delete d'une description est bloqué tant
+  // qu'un rattachement subsiste, et supprimer l'application hôte lève ce blocage).
+  const descriptions =
+    (await api.dataDescriptions("E2E").catch(() => null)) ?? [];
+  for (const d of descriptions) {
+    if (E2E.test(d.name ?? "")) await drop(api.deleteDataDescription(d.id));
+  }
+  const families = await api
+    .dataFamilies("pageSize=100&page=0")
+    .catch(() => null);
+  for (const f of families?.results ?? []) {
+    if (E2E.test(f.path ?? "")) await drop(api.deleteDataFamily(f.id));
+  }
+
   return removed;
 }
 

--- a/e2e/tests/data-application.spec.ts
+++ b/e2e/tests/data-application.spec.ts
@@ -157,16 +157,14 @@ test.describe("Détail d'une donnée applicative", () => {
       dataApplicationId = await fiche.submitNewDataAttachment();
       await fiche.expectDataRowContainsAll(uniqueName, [familyPath]);
     } finally {
-      // Le résolveur ne renvoyant que l'id de la ligne `DataApplication` (pas celui de la
-      // `DataDescription` créée par le formulaire), seul le rattachement est détaché ici. La
-      // description de catalogue et la famille métier créées inline restent en base : aucun
-      // résolveur de suppression n'est fourni pour ces entités référentielles (même doctrine
-      // « create-if-absent, pas de nettoyage systématique » que `applicationWithTags`/
-      // `applicationWithTechnicalDebt` dans la datafeature). L'application dédiée, elle, est
-      // entièrement jetable et supprimée ici.
+      // Le formulaire ne restitue pas les ids de la description et de la famille créées inline :
+      // on les retrouve par leur nom unique (timestampé) pour les supprimer — sans quoi elles
+      // s'accumulaient en base à chaque run (#2117).
       if (dataApplicationId) {
         await data.detachDataFromApplication(app.id, dataApplicationId);
       }
+      await data.deleteDataDescriptionByName(uniqueName);
+      await data.deleteDataFamilyByPath(familyPath);
       await data.removeApplication(app.id);
     }
   });
@@ -204,7 +202,7 @@ test.describe("Détail d'une donnée applicative", () => {
     data,
   }) => {
     // Application dédiée et jetable (cf. commentaire DAT-07).
-    const { applicationId, dataApplicationId } =
+    const { applicationId, dataApplicationId, descriptionId } =
       await data.provisionAttachedData();
 
     const fiche = new ApplicationPage(page);
@@ -213,10 +211,9 @@ test.describe("Détail d'une donnée applicative", () => {
       await fiche.expectDataSourcesTabLoaded();
       await fiche.deleteDataRow(dataApplicationId);
       await fiche.expectDataRowAbsent(dataApplicationId);
-      // Le détachement est le geste testé lui-même : pas de `detachDataFromApplication` ici. La
-      // `DataDescription` sous-jacente reste orpheline en base — `provisionAttachedData()` ne
-      // renvoie pas son id, seulement `applicationId`/`dataApplicationId` (cf. commentaire DAT-08).
+      // Le détachement est le geste testé lui-même : pas de `detachDataFromApplication` ici.
     } finally {
+      await data.deleteDataDescription(descriptionId); // sinon la description resterait orpheline (#2117)
       await data.removeApplication(applicationId);
     }
   });
@@ -248,7 +245,7 @@ test.describe("Détail d'une donnée applicative", () => {
     data,
   }) => {
     // Application dédiée et jetable (cf. commentaire DAT-07).
-    const { applicationId, dataApplicationId } =
+    const { applicationId, dataApplicationId, descriptionId } =
       await data.provisionAttachedData();
 
     const detail = new DataDetailPage(page);
@@ -259,6 +256,7 @@ test.describe("Détail d'une donnée applicative", () => {
       await detail.expectRedirectedToDataTab(applicationId);
       // Le détachement est le geste testé lui-même (cf. DAT-10) : pas de détachement manuel ici.
     } finally {
+      await data.deleteDataDescription(descriptionId); // sinon la description resterait orpheline (#2117)
       await data.removeApplication(applicationId);
     }
   });
@@ -294,6 +292,9 @@ test.describe("Détail d'une donnée applicative", () => {
       if (dataApplicationId) {
         await data.detachDataFromApplication(app.id, dataApplicationId);
       }
+      // Suppression par noms uniques : description + famille créées inline (#2117).
+      await data.deleteDataDescriptionByName(uniqueName);
+      await data.deleteDataFamilyByPath(newFamilyPath);
       await data.removeApplication(app.id);
     }
   });
@@ -306,7 +307,7 @@ test.describe("Détail d'une donnée applicative", () => {
     test.skip(!family, "Aucune famille métier dans le référentiel");
 
     // Application dédiée et jetable (cf. commentaire DAT-07).
-    const { applicationId, dataApplicationId } =
+    const { applicationId, dataApplicationId, descriptionId } =
       await data.provisionAttachedData();
 
     const fiche = new ApplicationPage(page);
@@ -327,6 +328,7 @@ test.describe("Détail d'une donnée applicative", () => {
       await fiche.expectDataRowNotContains(dataApplicationId, family!.path);
     } finally {
       await data.detachDataFromApplication(applicationId, dataApplicationId);
+      await data.deleteDataDescription(descriptionId); // sinon la description resterait orpheline (#2117)
       await data.removeApplication(applicationId);
     }
   });
@@ -367,6 +369,7 @@ test.describe("Détail d'une donnée applicative", () => {
       if (dataApplicationId) {
         await data.detachDataFromApplication(consumerApp.id, dataApplicationId);
       }
+      await data.deleteDataDescriptionByName(uniqueName); // description créée via l'UI (#2117)
       await data.removeApplication(consumerApp.id);
       await data.removeApplication(sourceApp.id);
     }


### PR DESCRIPTION
## Contexte

Closes #2117. Les familles `DataFamily` dupliquées (« AAA/ZZZ sort family » ×6…) qui faisaient échouer DAT-13/14 en strict-mode n'étaient que la partie visible : **la suite jest backend écrivait l'intégralité de ses données de faker dans la base de dev**.

## Cause racine

`jest.setup.ts` ne redirigeait jamais `DATABASE_URL` vers la base de test : `global-setup` créait et migrait `test_postgres`… qui n'était **jamais utilisée** (créée puis droppée à vide), pendant que l'app Nest et les fakers écrivaient dans la base de dev. Constaté sur ma base locale : **1028 users et 834 applications** de faker accumulés.

## Fix

- **jest.setup.ts** : redirection de `DATABASE_URL` vers la base de test (dérivée `test_<db>`), avec erreur claire si absente. La suite complète est **verte sur la base de test vierge** (migrations seules, aucune dépendance cachée au seed) : 41/41 suites, et **zéro écriture en base de dev** (comptages identiques avant/après run).
- **Playwright (fuite secondaire)** : les cas DAT laissaient des entités référentielles aux noms timestampés uniques — donc accumulées à chaque run :
  - `provisionAttachedData` renvoie désormais `descriptionId` et DAT-10/12/14 suppriment la description en `finally` (le contrat du helper l'exigeait déjà… sans fournir l'id) ;
  - DAT-08/13/15 suppriment la description et la famille créées **via l'UI**, retrouvées par leur nom unique ;
  - le balayage `E2E` du `global-cleanup` ratisse aussi descriptions et familles résiduelles (filet pour les runs interrompus), après les applications pour lever les restrictions de rattachement.

## Vérifications

- Jest : **41/41 suites** vertes sur la base de test ; base de dev intouchée (3 comptages stables).
- DAT : **2 runs consécutifs 16/16 verts**, base **byte-stable** entre les runs (0 résidu E2E, nombre de familles inchangé).
- ESLint 0 erreur, tsc e2e OK.

## Note pour ta base de dev locale

Elle reste chargée de l'historique de pollution (≈1000 users / 800 applications de faker). Si tu veux repartir propre : `docker compose exec backend npm run db:reset` + reseed — à ta main, je n'y ai pas touché (hors dédoublonnage des familles déjà fait).

Réf. #2117.