### PR TITLE
fix: restore rgaa accessibility score

### DIFF
--- a/e2e/pom/transverse.page.ts
+++ b/e2e/pom/transverse.page.ts
@@ -33,6 +33,7 @@ export class SiteMapPage extends BasePage {
 
 /** Page Object — Page Accessibilité (`/accessibilite`, `AccessibilityPage`). */
 export class AccessibilityPage extends BasePage {
+  private container = () => this.byTestId("accessibility-page");
   private title = () => this.byTestId("accessibility-page-title");
 
   async open(): Promise<void> {
@@ -52,6 +53,14 @@ export class AccessibilityPage extends BasePage {
     await expect(
       this.page.getByRole("heading", { name: "État de conformité" }),
     ).toBeVisible();
+  }
+
+  /** Les valeurs de déclaration restent alignées sur l'audit RGAA initial. */
+  async expectInitialAuditResults(): Promise<void> {
+    await expect(this.container()).toContainText("52,54 %");
+    await expect(this.container()).toContainText("31 critères conformes");
+    await expect(this.container()).toContainText("28 critères non conformes");
+    await expect(this.container()).toContainText("partiellement conforme");
   }
 }
 

--- a/e2e/tests/transverse.spec.ts
+++ b/e2e/tests/transverse.spec.ts
@@ -51,6 +51,7 @@ test.describe("Pages transverses", () => {
         const accessibility = new AccessibilityPage(page);
         await accessibility.open();
         await accessibility.expectSections();
+        await accessibility.expectInitialAuditResults();
       },
     );
   });

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,6 +13,7 @@ import ImpersonationBanner from "./components/ImpersonationBanner.vue";
 import AppToaster from "./components/AppToaster.vue";
 import { useScheme } from "@gouvminint/vue-dsfr";
 import { useRgaaGlobalA11y } from "./composables/use-rgaa-a11y";
+import { accessibilityDeclaration } from "./constants/accessibility-declaration";
 
 const route = useRoute();
 const router = useRouter();
@@ -157,7 +158,7 @@ const ecosystemLinks = computed(() => {
   }));
 });
 const mandatoryLinks = computed(() => [
-  { label: "Accessibilité : Partiellement conforme", title: "Aller à la page d'accessibilité", to: "accessibilite" },
+  { label: accessibilityDeclaration.complianceMention, title: "Aller à la page d'accessibilité", to: "accessibilite" },
   { label: "Plan du site", title: "Aller au plan du site", to: "plan-du-site" },
   {
     // RGAA-015 : ouverture dans un nouvel onglet mentionnée dans l'intitulé.

--- a/frontend/src/constants/accessibility-declaration.ts
+++ b/frontend/src/constants/accessibility-declaration.ts
@@ -1,0 +1,11 @@
+export const accessibilityDeclaration = {
+  complianceMention: "Accessibilité : Partiellement conforme",
+  complianceStatus: "partiellement conforme",
+  establishedAt: "05 juin 2026",
+  rgaaVersion: "RGAA 4.1.2",
+  score: "52,54 %",
+  compliantCriteria: 31,
+  nonCompliantCriteria: 28,
+  nonApplicableCriteria: 47,
+  issueCount: 134,
+} as const;

--- a/frontend/src/views/AccessibilityPage.spec.ts
+++ b/frontend/src/views/AccessibilityPage.spec.ts
@@ -1,0 +1,16 @@
+import { render } from "@testing-library/vue";
+import AccessibilityPage from "./AccessibilityPage.vue";
+
+describe("AccessibilityPage", () => {
+  it("affiche les résultats officiels de l'audit RGAA initial", () => {
+    const { getByTestId } = render(AccessibilityPage);
+
+    const page = getByTestId("accessibility-page");
+
+    expect(page).toHaveTextContent("52,54 %");
+    expect(page).toHaveTextContent("31 critères conformes");
+    expect(page).toHaveTextContent("28 critères non conformes");
+    expect(page).toHaveTextContent("partiellement conforme");
+    expect(page).toHaveTextContent("05 juin 2026");
+  });
+});

--- a/frontend/src/views/AccessibilityPage.vue
+++ b/frontend/src/views/AccessibilityPage.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+import { accessibilityDeclaration } from "@/constants/accessibility-declaration";
+</script>
+
 <template>
   <div class="fr-container fr-my-2w" data-testid="accessibility-page">
     <h1 class="fr-h1" data-testid="accessibility-page-title">Accessibilité</h1>
@@ -12,19 +16,23 @@
     <h2 class="fr-h2">État de conformité</h2>
     <p>
       Le référentiel des applications est
-      <strong>partiellement conforme</strong>
-      au RGAA 4.1.2 (Référentiel Général d'Amélioration de l'Accessibilité) en raison des non-conformités énumérées ci-dessous.
+      <strong>{{ accessibilityDeclaration.complianceStatus }}</strong>
+      au {{ accessibilityDeclaration.rgaaVersion }} (Référentiel Général d'Amélioration de l'Accessibilité) en raison des non-conformités
+      énumérées ci-dessous.
     </p>
 
     <h2 class="fr-h2">Résultats des tests</h2>
     <p>
-      L'audit de conformité réalisé en 2026 révèle 28 critères non conformes. Le taux de conformité global au RGAA 4.1.2 est de
-      <strong>73,6&nbsp;%</strong>
-      (78 critères conformes sur les 106 critères du RGAA 4.1.2).
+      L'audit de conformité initial réalisé par le BPSA révèle
+      {{ accessibilityDeclaration.nonCompliantCriteria }} critères non conformes et {{ accessibilityDeclaration.issueCount }} problèmes
+      d'accessibilité. Le taux de conformité au {{ accessibilityDeclaration.rgaaVersion }} mesuré sur l'échantillon est de
+      <strong>{{ accessibilityDeclaration.score }}</strong>
+      ({{ accessibilityDeclaration.compliantCriteria }} critères conformes, {{ accessibilityDeclaration.nonCompliantCriteria }} critères non
+      conformes et {{ accessibilityDeclaration.nonApplicableCriteria }} critères non applicables).
     </p>
 
     <h2 class="fr-h2">Établissement de cette déclaration</h2>
-    <p>Cette déclaration a été établie le 02/07/2026.</p>
+    <p>Cette déclaration a été établie le {{ accessibilityDeclaration.establishedAt }}.</p>
 
     <h2 class="fr-h2">Retour d'information et contact</h2>
     <p>


### PR DESCRIPTION
## Summary

- Restore the public RGAA accessibility declaration score to the initial audit value: 52,54 %.
- Centralize the declaration values used by the accessibility page and mandatory footer link.
- Add unit and e2e regression checks for the official audit values.

Closes #2180

## Tests

- `pnpm --dir frontend test:unit -- src/views/AccessibilityPage.spec.ts`
- `pnpm --dir e2e type-check`
- `pnpm lint`
- `pnpm --dir e2e test:e2e -- tests/transverse.spec.ts --grep "TRV-07" --project chromium`

Note: `pnpm --dir frontend type-check` is currently blocked by existing unrelated errors in components such as `AdminTokensTab.vue`, `ComplianceForm.vue`, `ApplicationForm.vue`, and `TechnicalDebtCard.vue`.
