### PR TITLE
fix: restrict user editing to admin scope

### DIFF
--- a/frontend/src/components/admin/UserActions.spec.ts
+++ b/frontend/src/components/admin/UserActions.spec.ts
@@ -1,0 +1,117 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/vue";
+import { Permission, Roles, type UserEntity } from "@/client/types.gen";
+import UserActions from "./UserActions.vue";
+
+const { hasPermissionsMock, syncOrganizationMock } = vi.hoisted(() => ({
+  hasPermissionsMock: vi.fn(),
+  syncOrganizationMock: vi.fn(),
+}));
+
+vi.mock("@/api/index", () => ({
+  default: {
+    userControllerSyncOrganizationFromMaiaByEmail: (...args: unknown[]) => syncOrganizationMock(...args),
+    userControllerSyncOrganizationFromMaia: vi.fn(),
+    userControllerUpdate: vi.fn(),
+  },
+}));
+
+vi.mock("@/stores/toasterStore", () => ({
+  useToasterStore: () => ({
+    addErrorMessage: vi.fn(),
+    addSuccessMessage: vi.fn(),
+  }),
+}));
+
+vi.mock("@/stores/userStore", () => ({
+  useUserStore: () => ({
+    user: { id: "current-user" },
+    hasPermissions: hasPermissionsMock,
+    startImpersonation: vi.fn(),
+  }),
+}));
+
+const targetUser = {
+  role: Roles.VISITOR,
+  organization: null,
+  scopeOrganization: null,
+  type: "human",
+  emailNotificationsEnabled: true,
+  followedApplications: [],
+  additionalPermissions: [],
+  id: "target-user",
+  email: "target@example.gouv.fr",
+  organizationId: null,
+  scopeOrganizationId: null,
+} satisfies Required<UserEntity>;
+
+const global = {
+  stubs: {
+    DsfrButton: {
+      props: {
+        label: String,
+        disabled: Boolean,
+      },
+      emits: ["click"],
+      template: '<button type="button" :disabled="disabled" @click="$emit(\'click\')">{{ label }}</button>',
+    },
+    DsfrModal: {
+      props: {
+        opened: Boolean,
+      },
+      template: '<div v-if="opened"><slot /><slot name="footer" /></div>',
+    },
+    DsfrCheckboxSet: true,
+    DsfrRadioButtonSet: true,
+    OrganizationSearchSelect: true,
+  },
+};
+
+describe("UserActions", () => {
+  beforeEach(() => {
+    hasPermissionsMock.mockReset();
+    syncOrganizationMock.mockReset();
+    syncOrganizationMock.mockResolvedValue({
+      response: { ok: true },
+      data: null,
+    });
+  });
+
+  afterEach(cleanup);
+
+  it("disables user edition without the administration permission", async () => {
+    hasPermissionsMock.mockReturnValue(false);
+
+    render(UserActions, {
+      props: { user: targetUser },
+      global,
+    });
+
+    const editButton = screen.getByTestId("admin-user-edit-btn");
+    expect(editButton).toBeDisabled();
+
+    await fireEvent.click(editButton);
+
+    expect(screen.queryByTestId("admin-edit-user-modal")).not.toBeInTheDocument();
+    expect(syncOrganizationMock).not.toHaveBeenCalled();
+    expect(hasPermissionsMock).toHaveBeenCalledWith([Permission.ADMIN_PANEL_MANAGE]);
+  });
+
+  it("opens user edition with the administration permission", async () => {
+    hasPermissionsMock.mockReturnValue(true);
+
+    render(UserActions, {
+      props: { user: targetUser },
+      global,
+    });
+
+    const editButton = screen.getByTestId("admin-user-edit-btn");
+    expect(editButton).toBeEnabled();
+
+    await fireEvent.click(editButton);
+
+    await waitFor(() => expect(screen.getByTestId("admin-edit-user-modal")).toBeInTheDocument());
+    expect(syncOrganizationMock).toHaveBeenCalledWith({
+      path: { email: targetUser.email },
+    });
+  });
+});

--- a/frontend/src/components/admin/UserActions.spec.ts
+++ b/frontend/src/components/admin/UserActions.spec.ts
@@ -1,8 +1,14 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/vue";
-import { Permission, Roles, type UserEntity } from "@/client/types.gen";
+import { Permission, Roles, type OrganizationDto, type UserEntity } from "@/client/types.gen";
 import UserActions from "./UserActions.vue";
 
-const { hasPermissionsMock, syncOrganizationMock } = vi.hoisted(() => ({
+const { currentUserMock, hasPermissionsMock, syncOrganizationMock } = vi.hoisted(() => ({
+  currentUserMock: {
+    user: {
+      id: "current-user",
+      scopeOrganization: null as { path: string } | null,
+    },
+  },
   hasPermissionsMock: vi.fn(),
   syncOrganizationMock: vi.fn(),
 }));
@@ -24,7 +30,9 @@ vi.mock("@/stores/toasterStore", () => ({
 
 vi.mock("@/stores/userStore", () => ({
   useUserStore: () => ({
-    user: { id: "current-user" },
+    get user() {
+      return currentUserMock.user;
+    },
     hasPermissions: hasPermissionsMock,
     startImpersonation: vi.fn(),
   }),
@@ -43,6 +51,26 @@ const targetUser = {
   organizationId: null,
   scopeOrganizationId: null,
 } satisfies Required<UserEntity>;
+
+function createOrganization(path: string): OrganizationDto {
+  return {
+    id: path,
+    path,
+    url: null,
+    sigle: null,
+    parentId: null,
+    businessDivisionId: null,
+    maiaReferences: [],
+  };
+}
+
+function createTargetUser(organizationPath: string): Required<UserEntity> {
+  return {
+    ...targetUser,
+    organization: createOrganization(organizationPath),
+    organizationId: organizationPath,
+  };
+}
 
 const global = {
   stubs: {
@@ -70,6 +98,7 @@ describe("UserActions", () => {
   beforeEach(() => {
     hasPermissionsMock.mockReset();
     syncOrganizationMock.mockReset();
+    currentUserMock.user.scopeOrganization = null;
     syncOrganizationMock.mockResolvedValue({
       response: { ok: true },
       data: null,
@@ -96,11 +125,11 @@ describe("UserActions", () => {
     expect(hasPermissionsMock).toHaveBeenCalledWith([Permission.ADMIN_PANEL_MANAGE]);
   });
 
-  it("opens user edition with the administration permission", async () => {
+  it("allows a global administrator to edit any user", async () => {
     hasPermissionsMock.mockReturnValue(true);
 
     render(UserActions, {
-      props: { user: targetUser },
+      props: { user: createTargetUser("/HORS-PERIMETRE") },
       global,
     });
 
@@ -113,5 +142,40 @@ describe("UserActions", () => {
     expect(syncOrganizationMock).toHaveBeenCalledWith({
       path: { email: targetUser.email },
     });
+  });
+
+  it("allows a scoped administrator to edit a user within their scope", async () => {
+    hasPermissionsMock.mockReturnValue(true);
+    currentUserMock.user.scopeOrganization = createOrganization("/MININT/DTNUM");
+
+    render(UserActions, {
+      props: { user: createTargetUser("/MININT/DTNUM/SDAN") },
+      global,
+    });
+
+    const editButton = screen.getByTestId("admin-user-edit-btn");
+    expect(editButton).toBeEnabled();
+
+    await fireEvent.click(editButton);
+
+    await waitFor(() => expect(screen.getByTestId("admin-edit-user-modal")).toBeInTheDocument());
+  });
+
+  it("blocks a scoped administrator from editing a user outside their scope", async () => {
+    hasPermissionsMock.mockReturnValue(true);
+    currentUserMock.user.scopeOrganization = createOrganization("/MININT/DTNUM");
+
+    render(UserActions, {
+      props: { user: createTargetUser("/MININT/DGPN") },
+      global,
+    });
+
+    const editButton = screen.getByTestId("admin-user-edit-btn");
+    expect(editButton).toBeDisabled();
+
+    await fireEvent.click(editButton);
+
+    expect(screen.queryByTestId("admin-edit-user-modal")).not.toBeInTheDocument();
+    expect(syncOrganizationMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/admin/UserActions.vue
+++ b/frontend/src/components/admin/UserActions.vue
@@ -24,6 +24,7 @@ const emit = defineEmits<{
 
 const toaster = useToasterStore();
 const userStore = useUserStore();
+const canEditUser = computed(() => userStore.hasPermissions([Permission.ADMIN_PANEL_MANAGE]));
 
 // On peut impersonner tout utilisateur humain, sauf soi-même.
 const canImpersonate = computed(() => props.user.type !== "bot" && props.user.id !== userStore.user?.id);
@@ -56,6 +57,8 @@ const maiaSuggestion = ref<MaiaOrganizationSuggestionDto | null>(null);
 const isFetchingMaiaSuggestion = ref(false);
 
 async function openEditModal() {
+  if (!canEditUser.value) return;
+
   editingUser.value = props.user;
   editingUserRole.value = props.user.role;
   editingOrganizationId.value = props.user.organizationId || "";
@@ -212,6 +215,7 @@ const isScopeDisabled = computed(() => {
         label="Modifier"
         size="sm"
         secondary
+        :disabled="!canEditUser"
         data-testid="admin-user-edit-btn"
         title="Modifier les permissions de l'utilisateur"
         aria-label="Modifier les permissions de l'utilisateur"

--- a/frontend/src/components/admin/UserActions.vue
+++ b/frontend/src/components/admin/UserActions.vue
@@ -24,7 +24,15 @@ const emit = defineEmits<{
 
 const toaster = useToasterStore();
 const userStore = useUserStore();
-const canEditUser = computed(() => userStore.hasPermissions([Permission.ADMIN_PANEL_MANAGE]));
+const canEditUser = computed(() => {
+  if (!userStore.hasPermissions([Permission.ADMIN_PANEL_MANAGE])) return false;
+
+  const requestorScopePath = userStore.user?.scopeOrganization?.path;
+  if (!requestorScopePath) return true;
+
+  const targetOrganizationPath = props.user.organization?.path;
+  return !targetOrganizationPath || targetOrganizationPath.startsWith(requestorScopePath);
+});
 
 // On peut impersonner tout utilisateur humain, sauf soi-même.
 const canImpersonate = computed(() => props.user.type !== "bot" && props.user.id !== userStore.user?.id);


### PR DESCRIPTION
## Résumé

- désactive le bouton **Modifier** sans la permission `AdminPanelManage`
- conserve l’édition complète pour les super-administrateurs sans périmètre
- limite un administrateur avec périmètre aux utilisateurs dont l’organisation appartient à son arborescence
- protège également l’ouverture de la modale
- couvre les quatre parcours avec des tests de composant

Closes #2205

## Vérifications

- `pnpm lint` (0 erreur, 121 avertissements existants)
- `pnpm exec prettier . --check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test:unit` (27 tests)
- `pnpm --dir frontend build-only`

## Dépendance

Cette PR est temporairement basée sur #2201 afin de conserver le `type-check` global au vert. Son diff propre contient uniquement `UserActions.vue` et son test ; elle pourra être rebasée sur `main` après la fusion de #2201.