### PR TITLE
feat: désactiver les envois automatiques de mails (EMAIL_CRON_ENABLED)

### DIFF
--- a/backend/src/config/configs/email.config.ts
+++ b/backend/src/config/configs/email.config.ts
@@ -9,4 +9,5 @@ export const emailConfig = registerAs("email", () => ({
     process.env.SMTP_ENABLED === "true" &&
     Boolean(process.env.SMTP_HOST) &&
     Boolean(process.env.SMTP_PORT),
+  cronEnabled: process.env.EMAIL_CRON_ENABLED === "true",
 }));

--- a/backend/src/email/cron/application-validation-cron.service.spec.ts
+++ b/backend/src/email/cron/application-validation-cron.service.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from "@nestjs/testing";
 import { Test } from "@nestjs/testing";
 import { Status } from "@prisma/client";
+import { ConfigService } from "@nestjs/config";
 import { ApplicationValidationCronService } from "./application-validation-cron.service";
 import { EmailService } from "../email.service";
 import { PrismaService } from "src/prisma/prisma.service";
@@ -33,6 +34,10 @@ describe("ApplicationValidationCronService", () => {
     debug: jest.fn(),
   };
 
+  const mockConfigService = {
+    get: jest.fn().mockReturnValue(false),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -42,6 +47,7 @@ describe("ApplicationValidationCronService", () => {
         { provide: PrismaService, useValue: mockPrismaService },
         { provide: EmailService, useValue: mockEmailService },
         { provide: LoggerService, useValue: mockLoggerService },
+        { provide: ConfigService, useValue: mockConfigService },
       ],
     }).compile();
 

--- a/backend/src/email/cron/application-validation-cron.service.ts
+++ b/backend/src/email/cron/application-validation-cron.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, OnApplicationBootstrap } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import { Cron } from "@nestjs/schedule";
 import { Status } from "@prisma/client";
 import { LoggerService } from "src/logger/logger.service";
@@ -18,13 +19,27 @@ function subtractMonths(baseDate: Date, monthsAmount: number): Date {
 export class ApplicationValidationCronService
   implements OnApplicationBootstrap
 {
+  private readonly cronEnabled: boolean;
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly emailService: EmailService,
     private readonly logger: LoggerService,
-  ) {}
+    private readonly configService: ConfigService,
+  ) {
+    this.cronEnabled = this.configService.get<boolean>(
+      "email.cronEnabled",
+      false,
+    );
+  }
 
   async onApplicationBootstrap() {
+    if (!this.cronEnabled) {
+      this.logger.log(
+        "Relances de validation désactivées (EMAIL_CRON_ENABLED) : vérification au démarrage ignorée.",
+      );
+      return;
+    }
     this.logger.log(
       "Bootstrap : Vérification initiale des applications à relancer...",
     );
@@ -33,6 +48,12 @@ export class ApplicationValidationCronService
 
   @Cron("30 9 1 * *", { timeZone: "Europe/Paris" })
   async handleMonthlyCron() {
+    if (!this.cronEnabled) {
+      this.logger.log(
+        "Relances de validation désactivées (EMAIL_CRON_ENABLED) : exécution mensuelle ignorée.",
+      );
+      return;
+    }
     this.logger.log("Exécution mensuelle programmée du rappel de validation.");
     await this.sendValidationReminders();
   }

--- a/backend/src/email/cron/email-cron.service.ts
+++ b/backend/src/email/cron/email-cron.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import { Cron } from "@nestjs/schedule";
 import { PrismaService } from "src/prisma/prisma.service";
 import { EmailService } from "../email.service";
@@ -22,12 +23,31 @@ interface UserDigestMap {
 
 @Injectable()
 export class EmailDigestCronService {
+  private readonly cronEnabled: boolean;
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly emailService: EmailService,
-  ) {}
+    private readonly configService: ConfigService,
+  ) {
+    this.cronEnabled = this.configService.get<boolean>(
+      "email.cronEnabled",
+      false,
+    );
+  }
 
   @Cron("0 0 * * *", { timeZone: "Europe/Paris" })
+  async handleDailyCron() {
+    if (!this.cronEnabled) {
+      Logger.log(
+        "Digest quotidien désactivé (EMAIL_CRON_ENABLED) : exécution nocturne ignorée.",
+      );
+      return;
+    }
+    await this.sendDailyDigest();
+  }
+
+  // Envoi effectif, aussi déclenchable manuellement via POST /email/digest (admin).
   async sendDailyDigest(targetDate?: Date) {
     Logger.log("Starting daily email digest job at midnight");
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       - SMTP_SECURE=false
       - SMTP_FROM=noreply@example.local
       - SMTP_ENABLED=true
+      # Crons d'envoi automatique (digest quotidien + relances de validation) — off par défaut
+      - EMAIL_CRON_ENABLED=false
       - ENV_LABEL=developpement
       - MAINTENANCE_MODE=${MAINTENANCE_MODE:-false}
       - MAINTENANCE_CACHE_TTL_MS=${MAINTENANCE_CACHE_TTL_MS:-30000}

--- a/docs/03-demarrage.md
+++ b/docs/03-demarrage.md
@@ -65,7 +65,7 @@ En développement, les variables nécessaires au backend sont **déjà fournies*
 - **Base de données** : `DATABASE_URL` (chaîne de connexion PostgreSQL).
 - **Authentification OIDC** : `OIDC_CONFIG_URL`, `OIDC_JWKS_URL`, `OIDC_CLIENT_ID`.
 - **CORS / réseau** : `ALLOWED_ORIGINS`, `PORT`, `HOST`.
-- **Messagerie (SMTP)** : `SMTP_HOST`, `SMTP_PORT`, `SMTP_SECURE`, `SMTP_FROM`, `SMTP_ENABLED` (pointés vers Mailpit en local).
+- **Messagerie (SMTP)** : `SMTP_HOST`, `SMTP_PORT`, `SMTP_SECURE`, `SMTP_FROM`, `SMTP_ENABLED` (pointés vers Mailpit en local) ; `EMAIL_CRON_ENABLED` active les envois automatiques (digest quotidien, relances de validation), désactivés par défaut.
 - **Maintenance** : `MAINTENANCE_MODE` force le mode lecture seule ; `MAINTENANCE_CACHE_TTL_MS` règle la durée de cache de la détection PostgreSQL.
 - **Divers** : `LOG_LEVEL`, `ENV_LABEL`, `FOOTER_LINKS`, `MOCK_MAIA_SERVICE`, `MOCK_MAIA_ORGANIZATION`, `NON_ACTOR_PERMISSIONS`.
 

--- a/docs/12-exploitation-deploiement.md
+++ b/docs/12-exploitation-deploiement.md
@@ -107,6 +107,7 @@ Les variables ci-dessous sont consommées par le code (`backend/src/config/confi
 | `SMTP_HOST` / `SMTP_PORT` / `SMTP_SECURE`      | Paramètres du serveur d'envoi de courriels.                                                                  |
 | `SMTP_FROM`                                    | Adresse expéditrice des courriels.                                                                           |
 | `SMTP_ENABLED`                                 | Activation de l'envoi de courriels.                                                                          |
+| `EMAIL_CRON_ENABLED`                           | Activation des envois automatiques (digest quotidien, relances de validation). Désactivé par défaut.         |
 | `PORT` / `HOST`                                | Port et interface d'écoute du backend (par défaut `3500` / `0.0.0.0`).                                       |
 | `NODE_ENV`                                     | Environnement d'exécution Node.                                                                              |
 | `ENV_LABEL`                                    | Libellé d'environnement affiché dans l'interface.                                                            |


### PR DESCRIPTION
Closes #2215

## Quoi

Introduit la variable d'environnement `EMAIL_CRON_ENABLED` (**désactivée par défaut**) qui neutralise les deux envois automatiques de mails :

- **Relances de validation** (`ApplicationValidationCronService`) : le cron mensuel (1er du mois à 9h30) et l'envoi au démarrage de l'app (`onApplicationBootstrap`) sont court-circuités.
- **Digest quotidien** (`EmailDigestCronService`) : le déclencheur cron de minuit est extrait dans `handleDailyCron()`, gardé par le flag.

## Ce qui ne change pas

- Le déclenchement manuel du digest via `POST /email/digest` (admin, utilisé par les ops et les e2e) reste fonctionnel quel que soit le flag.
- Les mails transactionnels (`EmailService`) et le flag `SMTP_ENABLED` existant ne sont pas touchés.

## Divers

- `docker-compose.yml` : `EMAIL_CRON_ENABLED=false` explicite pour documenter la variable en local.
- Docs `03-demarrage.md` et `12-exploitation-deploiement.md` mises à jour.
- Spec du cron de validation adapté (injection de `ConfigService`).

## Tests

- `jest src/email/cron/application-validation-cron.service.spec.ts` : 11/11 ✅ (dans le conteneur backend)
- `tsc --noEmit` dans le conteneur : 0 erreur ✅
- ESLint + Prettier : ✅

> **Note** : décision produit — les envois automatiques doivent rester **désactivés en production**. Aucune variable à ajouter côté infra : le défaut (`EMAIL_CRON_ENABLED` absent = off) est le comportement voulu.