### PR TITLE
feat: panel admin directions métier + rattachement aux organisations

### DIFF
--- a/backend/src/business-division/business-division.controller.ts
+++ b/backend/src/business-division/business-division.controller.ts
@@ -1,5 +1,20 @@
-import { Controller, Get, Param, Query, UseGuards } from "@nestjs/common";
 import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import {
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNoContentResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -14,6 +29,8 @@ import { BusinessDivisionService } from "./business-division.service";
 import {
   BusinessDivisionDTO,
   BusinessDivisionFiltersDto,
+  CreateBusinessDivisionDto,
+  UpdateBusinessDivisionDto,
 } from "./dto/business-division.dto";
 
 @ApiTags("Business Division")
@@ -44,6 +61,78 @@ export class BusinessDivisionController {
   })
   async findAll(@Query() filters: BusinessDivisionFiltersDto) {
     return await this.businessDivisionService.search(filters);
+  }
+
+  @Post()
+  @RequiredPermissions([Permission.AdminPanelManage])
+  @ApiOperation({
+    summary: "Créer une direction métier.",
+    description: `
+Ce endpoint permet de créer une nouvelle direction métier (business division).
+
+Information requise :
+- **label** : nom unique de la direction métier
+    `,
+  })
+  @HttpCode(201)
+  @ApiCreatedResponse({
+    description: "Direction métier créée avec succès",
+    type: BusinessDivisionDTO,
+  })
+  @ApiForbiddenResponse({
+    description: "Accès refusé - Privilège admin requis",
+  })
+  @ApiConflictResponse({
+    description: "Une direction métier existe déjà avec ce nom",
+  })
+  async create(@Body() createBusinessDivisionDto: CreateBusinessDivisionDto) {
+    return await this.businessDivisionService.createDivision(
+      createBusinessDivisionDto,
+    );
+  }
+
+  @Patch(":id")
+  @RequiredPermissions([Permission.AdminPanelManage])
+  @ApiOperation({ summary: "Modifier une direction métier" })
+  @ApiOkResponse({
+    description: "Direction métier mise à jour avec succès",
+    type: BusinessDivisionDTO,
+  })
+  @ApiForbiddenResponse({
+    description: "Accès refusé - Privilège admin requis",
+  })
+  @ApiNotFoundResponse({ description: "Direction métier non trouvée" })
+  @ApiConflictResponse({
+    description: "Une direction métier existe déjà avec ce nom",
+  })
+  @ApiParam({ name: "id", description: "ID de la direction métier à modifier" })
+  async update(
+    @Param("id") id: string,
+    @Body() updateBusinessDivisionDto: UpdateBusinessDivisionDto,
+  ) {
+    return await this.businessDivisionService.updateDivision(
+      id,
+      updateBusinessDivisionDto,
+    );
+  }
+
+  @Delete(":id")
+  @RequiredPermissions([Permission.AdminPanelManage])
+  @ApiOperation({ summary: "Supprimer une direction métier" })
+  @HttpCode(204)
+  @ApiNoContentResponse({
+    description: "Direction métier supprimée avec succès",
+  })
+  @ApiForbiddenResponse({
+    description: "Accès refusé - Privilège admin requis",
+  })
+  @ApiNotFoundResponse({ description: "Direction métier non trouvée" })
+  @ApiParam({
+    name: "id",
+    description: "ID de la direction métier à supprimer",
+  })
+  async remove(@Param("id") id: string) {
+    return await this.businessDivisionService.delete(id);
   }
 
   @Get(":id")

--- a/backend/src/business-division/business-division.service.ts
+++ b/backend/src/business-division/business-division.service.ts
@@ -1,9 +1,11 @@
-import { Injectable } from "@nestjs/common";
+import { ConflictException, Injectable } from "@nestjs/common";
 import { BaseService } from "src/common/base.service";
 import { PrismaService } from "src/prisma/prisma.service";
 import {
   BusinessDivisionDTO,
   BusinessDivisionFiltersDto,
+  CreateBusinessDivisionDto,
+  UpdateBusinessDivisionDto,
 } from "./dto/business-division.dto";
 import { PrismaQueryBuilder } from "./prisma-query-builder.service";
 import { Prisma } from "@prisma/client";
@@ -22,6 +24,29 @@ export class BusinessDivisionService extends BaseService<
 
   public findById(id: string) {
     return this.findOne(id);
+  }
+
+  public async createDivision(dto: CreateBusinessDivisionDto) {
+    await this.assertLabelAvailable(dto.label);
+    return this.create(dto);
+  }
+
+  public async updateDivision(id: string, dto: UpdateBusinessDivisionDto) {
+    if (dto.label != null) {
+      await this.assertLabelAvailable(dto.label, id);
+    }
+    return this.update(id, dto);
+  }
+
+  private async assertLabelAvailable(label: string, excludedId?: string) {
+    const existing = await this.prisma.businessDivision.findUnique({
+      where: { label },
+    });
+    if (existing && existing.id !== excludedId) {
+      throw new ConflictException(
+        `Une direction métier existe déjà avec le nom « ${label} »`,
+      );
+    }
   }
 
   public async search(searchParams: BusinessDivisionFiltersDto) {

--- a/backend/src/business-division/business-division.service.ts
+++ b/backend/src/business-division/business-division.service.ts
@@ -57,6 +57,9 @@ export class BusinessDivisionService extends BaseService<
       orderBy,
       page: searchParams.page,
       pageSize: searchParams.pageSize,
+      include: {
+        _count: { select: { organizations: true, applications: true } },
+      },
     });
   }
 }

--- a/backend/src/business-division/dto/business-division.dto.ts
+++ b/backend/src/business-division/dto/business-division.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import { IsOptional, IsString } from "class-validator";
+import { ApiProperty, ApiPropertyOptional, PartialType } from "@nestjs/swagger";
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from "class-validator";
 import { PaginationDto } from "src/common/dto";
 
 export class BusinessDivisionFiltersDto extends PaginationDto {
@@ -13,16 +13,24 @@ export class BusinessDivisionFiltersDto extends PaginationDto {
   label?: string;
 }
 
-export class BusinessDivisionDTO {
-  @ApiProperty({ description: "Identifiant unique de la division DTO" })
-  @IsString()
-  id: string;
-
+export class CreateBusinessDivisionDto {
   @ApiProperty({
     description: "Nom unique du business division",
     example: "farm",
     required: true,
   })
   @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
   label: string;
+}
+
+export class UpdateBusinessDivisionDto extends PartialType(
+  CreateBusinessDivisionDto,
+) {}
+
+export class BusinessDivisionDTO extends CreateBusinessDivisionDto {
+  @ApiProperty({ description: "Identifiant unique de la division DTO" })
+  @IsString()
+  id: string;
 }

--- a/backend/src/business-division/prisma-query-builder.service.ts
+++ b/backend/src/business-division/prisma-query-builder.service.ts
@@ -22,7 +22,8 @@ export class PrismaQueryBuilder {
     let orderBy: Prisma.BusinessDivisionOrderByWithRelationInput = {};
 
     if (filters.sortBy) {
-      const sortField = filters.sortBy === "createdAt" ? "createdAt" : "label";
+      // BusinessDivision n'a pas de createdAt : label est le seul champ triable.
+      const sortField = "label";
       const sortOrder: Prisma.SortOrder =
         filters.order === "desc" ? "desc" : "asc";
 

--- a/backend/src/organizations/dto/organizations.dto.ts
+++ b/backend/src/organizations/dto/organizations.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional, PartialType } from "@nestjs/swagger";
-import { IsOptional, IsString } from "class-validator";
+import { IsOptional, IsString, ValidateIf } from "class-validator";
+import { BusinessDivisionDTO } from "src/business-division/dto/business-division.dto";
 import { OrganizationMaiaReferenceDto } from "src/organization-maia-references/dto/organization-maia-references.dto";
 
 export class CreateOrganizationDto {
@@ -37,6 +38,17 @@ export class CreateOrganizationDto {
   @IsString()
   @IsOptional()
   parentId: string;
+
+  @ApiPropertyOptional({
+    example: "f09ed26a-8415-476a-be3b-ada479291c34",
+    description:
+      "L'identifiant de la direction métier associée (null pour détacher)",
+    nullable: true,
+  })
+  @IsOptional()
+  @ValidateIf((_object, value) => value !== null)
+  @IsString()
+  businessDivisionId?: string | null;
 }
 
 export class PatchOrganizationDto extends PartialType(CreateOrganizationDto) {}
@@ -84,6 +96,13 @@ export class OrganizationDto {
   @IsString()
   @IsOptional()
   businessDivisionId: string | null;
+
+  @ApiPropertyOptional({
+    description: "Direction métier associée à l'organisation",
+    type: BusinessDivisionDTO,
+    nullable: true,
+  })
+  businessDivision?: BusinessDivisionDTO | null;
 
   @ApiPropertyOptional({
     description: "Références MAIA associées à l'organisation",

--- a/backend/src/organizations/organizations.service.ts
+++ b/backend/src/organizations/organizations.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, NotFoundException } from "@nestjs/common";
 import { Organization, Prisma } from "@prisma/client";
 import { BaseService } from "src/common/base.service";
 import { PaginatedResponseDto } from "src/common/dto";
@@ -23,6 +23,7 @@ export class OrganizationsService extends BaseService<
   }
 
   async create(data: CreateOrganizationDto): Promise<Organization> {
+    await this.assertBusinessDivisionExists(data.businessDivisionId);
     const newOrg = await super.create(data);
     return newOrg;
   }
@@ -38,6 +39,7 @@ export class OrganizationsService extends BaseService<
       pageSize,
       include: {
         maiaReferences: true,
+        businessDivision: true,
       },
     });
   }
@@ -45,6 +47,7 @@ export class OrganizationsService extends BaseService<
   async findOneWithReferences(id: string) {
     return this.findOne(id, {
       maiaReferences: true,
+      businessDivision: true,
     });
   }
 
@@ -52,8 +55,23 @@ export class OrganizationsService extends BaseService<
     id: string,
     data: Partial<CreateOrganizationDto>,
   ): Promise<Organization> {
+    await this.assertBusinessDivisionExists(data.businessDivisionId);
     const patchedOrg = await super.update(id, data);
     return patchedOrg;
+  }
+
+  private async assertBusinessDivisionExists(
+    businessDivisionId?: string | null,
+  ) {
+    if (!businessDivisionId) {
+      return;
+    }
+    const division = await this.prisma.businessDivision.findUnique({
+      where: { id: businessDivisionId },
+    });
+    if (!division) {
+      throw new NotFoundException("Direction métier non trouvée");
+    }
   }
 
   async deleteSafe(id: string, force = false): Promise<void> {

--- a/backend/tests/business-division.e2e-spec.ts
+++ b/backend/tests/business-division.e2e-spec.ts
@@ -1,0 +1,123 @@
+import type { UserFakerReturnType } from "./fakers/user.faker";
+import { Roles } from "@prisma/client";
+import request from "supertest";
+import { UserFaker } from "./fakers/user.faker";
+import { getToken } from "./getToken";
+import { setupTestSuite } from "./setup";
+
+describe("BusinessDivision", () => {
+  const app = setupTestSuite();
+  let admin: UserFakerReturnType;
+  let contributor: UserFakerReturnType;
+  let ADMIN_TOKEN: string;
+  let CONTRIBUTOR_TOKEN: string;
+  // Libellés dédiés au test (hors divisions seedées), supprimés en fin de suite.
+  const LABEL_A = "e2e-direction-alpha";
+  const LABEL_B = "e2e-direction-beta";
+  const createdIds: string[] = [];
+
+  beforeAll(async () => {
+    admin = await UserFaker.create({ role: Roles.ADMIN });
+    contributor = await UserFaker.create({ role: Roles.CONTRIBUTOR });
+    ADMIN_TOKEN = await getToken(admin);
+    CONTRIBUTOR_TOKEN = await getToken(contributor);
+  });
+
+  afterAll(async () => {
+    for (const id of createdIds) {
+      await request(app().getHttpServer())
+        .delete(`/business-division/${id}`)
+        .set("Authorization", `Bearer ${ADMIN_TOKEN}`);
+    }
+  });
+
+  it("/POST business-division - should reject a non-admin user", async () => {
+    await request(app().getHttpServer())
+      .post("/business-division")
+      .send({ label: LABEL_A })
+      .set("Authorization", `Bearer ${CONTRIBUTOR_TOKEN}`)
+      .expect(403);
+  });
+
+  it("/POST business-division - should create a division as admin", async () => {
+    const response = await request(app().getHttpServer())
+      .post("/business-division")
+      .send({ label: LABEL_A })
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .expect(201);
+
+    expect(response.body.id).toBeDefined();
+    expect(response.body.label).toEqual(LABEL_A);
+    createdIds.push(response.body.id);
+  });
+
+  it("/POST business-division - should reject a duplicate label", async () => {
+    await request(app().getHttpServer())
+      .post("/business-division")
+      .send({ label: LABEL_A })
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .expect(409);
+  });
+
+  it("/POST business-division - should reject an empty label", async () => {
+    await request(app().getHttpServer())
+      .post("/business-division")
+      .send({ label: "" })
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .expect(400);
+  });
+
+  it("/GET business-division - should list divisions filtered by label", async () => {
+    const list = await request(app().getHttpServer())
+      .get("/business-division")
+      .query({ label: LABEL_A, pageSize: 100 })
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .expect(200);
+
+    const labels: string[] = list.body.results.map(
+      (d: { label: string }) => d.label,
+    );
+    expect(labels).toContain(LABEL_A);
+  });
+
+  it("/PATCH business-division/:id - should update a division as admin", async () => {
+    const response = await request(app().getHttpServer())
+      .patch(`/business-division/${createdIds[0]}`)
+      .send({ label: LABEL_B })
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .expect(200);
+
+    expect(response.body.label).toEqual(LABEL_B);
+  });
+
+  it("/PATCH business-division/:id - should allow keeping its own label", async () => {
+    await request(app().getHttpServer())
+      .patch(`/business-division/${createdIds[0]}`)
+      .send({ label: LABEL_B })
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .expect(200);
+  });
+
+  it("/PATCH business-division/:id - should reject a non-admin user", async () => {
+    await request(app().getHttpServer())
+      .patch(`/business-division/${createdIds[0]}`)
+      .send({ label: "x" })
+      .set("Authorization", `Bearer ${CONTRIBUTOR_TOKEN}`)
+      .expect(403);
+  });
+
+  it("/DELETE business-division/:id - should reject a non-admin user", async () => {
+    await request(app().getHttpServer())
+      .delete(`/business-division/${createdIds[0]}`)
+      .set("Authorization", `Bearer ${CONTRIBUTOR_TOKEN}`)
+      .expect(403);
+  });
+
+  it("/DELETE business-division/:id - should delete a division as admin", async () => {
+    const id = createdIds.pop()!;
+    await request(app().getHttpServer())
+      .delete(`/business-division/${id}`)
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .expect(204);
+  });
+});

--- a/backend/tests/business-division.e2e-spec.ts
+++ b/backend/tests/business-division.e2e-spec.ts
@@ -78,6 +78,12 @@ describe("BusinessDivision", () => {
       (d: { label: string }) => d.label,
     );
     expect(labels).toContain(LABEL_A);
+
+    // Le décompte des liaisons est exposé pour l'onglet admin (0 pour une division neuve).
+    const created = list.body.results.find(
+      (d: { label: string }) => d.label === LABEL_A,
+    );
+    expect(created._count).toEqual({ organizations: 0, applications: 0 });
   });
 
   it("/PATCH business-division/:id - should update a division as admin", async () => {

--- a/backend/tests/organization.e2e-spec.ts
+++ b/backend/tests/organization.e2e-spec.ts
@@ -1,6 +1,7 @@
 import type { UserFakerReturnType } from "./fakers/user.faker";
 import { Roles } from "@prisma/client";
 import request from "supertest";
+import { BusinessDivisionFaker } from "./fakers/business-division.faker";
 import { OrganizationFaker } from "./fakers/organization.faker";
 import { UserFaker } from "./fakers/user.faker";
 import { getToken } from "./getToken";
@@ -59,6 +60,40 @@ describe("Organizations", () => {
       .delete(`/organizations/${organization.id}`)
       .set("Authorization", `Bearer ${TOKEN}`)
       .expect(204);
+  });
+
+  it("/PATCH organizations/:id - attaches then detaches a business division", async () => {
+    const organization = await OrganizationFaker.create();
+    const division = await BusinessDivisionFaker.create();
+
+    const attached = await request(app().getHttpServer())
+      .patch(`/organizations/${organization.id}`)
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ businessDivisionId: division.id })
+      .expect(200);
+    expect(attached.body.businessDivisionId).toEqual(division.id);
+
+    const fetched = await request(app().getHttpServer())
+      .get(`/organizations/${organization.id}`)
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .expect(200);
+    expect(fetched.body.businessDivision?.label).toEqual(division.label);
+
+    const detached = await request(app().getHttpServer())
+      .patch(`/organizations/${organization.id}`)
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ businessDivisionId: null })
+      .expect(200);
+    expect(detached.body.businessDivisionId).toBeNull();
+  });
+
+  it("/PATCH organizations/:id - rejects an unknown business division", async () => {
+    const organization = await OrganizationFaker.create();
+    await request(app().getHttpServer())
+      .patch(`/organizations/${organization.id}`)
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ businessDivisionId: "00000000-0000-0000-0000-000000000000" })
+      .expect(404);
   });
 });
 

--- a/docs/05-api.md
+++ b/docs/05-api.md
@@ -166,7 +166,7 @@ Inventaire **par module / ressource** (résumé : verbes et chemins principaux, 
 | `POST /tags` · `GET /tags` · `GET /tags/:id` · `PATCH /tags/:id` · `DELETE /tags/:id` | Tags                                 |
 | `POST /label-sources` · `GET` · `PATCH :id` · `DELETE :id`                            | Sources de labels                    |
 | `GET /metadatas` · `GET /metadatas/:id`                                               | Métadonnées (lecture globale)        |
-| `GET /business-division` · `GET /business-division/:id`                               | Divisions métier                     |
+| `GET /business-division` · `GET :id` · `POST` · `PATCH :id` · `DELETE :id`            | Divisions métier (écritures admin)   |
 | `GET /data-catalog/descriptions` (+ `POST`, `PATCH :id`, `DELETE :id`)                | Descriptions du catalogue de données |
 | `GET /data-catalog/applications/:applicationId` · `.../:dataApplicationId`            | Données rattachées aux applications  |
 

--- a/docs/07-fonctionnalites.md
+++ b/docs/07-fonctionnalites.md
@@ -242,7 +242,8 @@ Les contributeurs et administrateurs consultent l'ensemble des signalements, les
 Le panneau d'administration (`frontend/src/views/AdminPage.vue`) est organisé en onglets, réservés aux administrateurs (`AdminPanelManage`).
 
 - **Gestion des utilisateurs** (`admin/AdminUsersTab.vue`) : liste des utilisateurs (humains et comptes techniques), modification du rôle (Visiteur, Lecteur, Contributeur, Administrateur), rattachement à une organisation, et attribution de **permissions individuelles** complémentaires (couche 2). Module back `backend/src/user/`.
-- **Gestion des organisations** (`admin/AdminOrganizationsTab.vue`) : création/modification/suppression. Permission `OrganizationManage`. Modules `backend/src/organizations/`, `backend/src/organization-maia-references/`.
+- **Gestion des organisations** (`admin/AdminOrganizationsTab.vue`) : création/modification/suppression, rattachement d'une **direction métier** à l'organisation. Permission `OrganizationManage`. Modules `backend/src/organizations/`, `backend/src/organization-maia-references/`.
+- **Directions métier** (`admin/AdminBusinessDivisionsTab.vue`) : création/modification/suppression des directions métier (nom unique) rattachables aux organisations et aux applications. Écritures sous `AdminPanelManage`. Module `backend/src/business-division/`.
 - **Gestion des tags** (`admin/AdminTagsTab.vue`) : tags libres attachables aux applications. Module `backend/src/tag/`.
 - **Gestion des sources** (`admin/AdminLabelSourcesTab.vue`) : sources contextualisant les noms alternatifs (labels). Modules `backend/src/labels/`, `backend/src/label-source/`.
 - **Indice de qualité** (`admin/AdminQualityTab.vue`) : recalcul global de l'IQ (voir [section 3](#3-indice-de-qualité-iq)).

--- a/e2e/fixtures/api-client.ts
+++ b/e2e/fixtures/api-client.ts
@@ -156,6 +156,15 @@ export class ApiClient {
     if (found) await this.del(`/mdit-campaigns/${found.id}`);
   }
 
+  /** Supprime la direction métier du libellé donné si elle existe (idempotence des tests). */
+  async deleteBusinessDivisionByLabel(label: string): Promise<void> {
+    const list = await this.get<Paginated<{ id: string; label: string }>>(
+      `/business-division?label=${encodeURIComponent(label)}&pageSize=100&page=0`,
+    );
+    const found = list?.results?.find((d) => d.label === label);
+    if (found) await this.del(`/business-division/${found.id}`);
+  }
+
   /** Évaluations de dette technique d'une application (plus récente d'abord), paginées. */
   applicationTechnicalDebtInfo(
     appId: string,

--- a/e2e/fixtures/datafeature.ts
+++ b/e2e/fixtures/datafeature.ts
@@ -362,6 +362,11 @@ export class DataFeature {
     return this.api.deleteMditCampaignByYear(year);
   }
 
+  /** Supprime la direction métier d'un libellé si elle existe (idempotence des tests admin). */
+  removeBusinessDivisionLabel(label: string): Promise<void> {
+    return this.api.deleteBusinessDivisionByLabel(label);
+  }
+
   // --- Provisioning pour les tests de permissions (effectué avec le token admin) ---
 
   /** Récupère un utilisateur (admin) par email. */

--- a/e2e/pom/admin.page.ts
+++ b/e2e/pom/admin.page.ts
@@ -545,6 +545,99 @@ export class AdminPage extends BasePage {
     await this.expectToaster(/Campagne supprimée avec succès/i);
   }
 
+  // --- Onglet « Directions métier » (ADM-22, ADM-23) ---
+
+  private businessDivisionsTable = () =>
+    this.byTestId("admin-business-divisions-table");
+
+  async openBusinessDivisionsTab(): Promise<void> {
+    await this.adminTabs()
+      .getByRole("tab", { name: /directions métier/i })
+      .click();
+    await expect(this.businessDivisionsTable()).toBeVisible();
+  }
+
+  async searchBusinessDivision(value: string): Promise<void> {
+    const refetch = this.page
+      .waitForResponse(
+        (r) =>
+          /\/business-division\?/.test(r.url()) &&
+          r.request().method() === "GET",
+        { timeout: 10_000 },
+      )
+      .catch(() => null);
+    await this.byTestId("admin-business-division-search")
+      .locator("input")
+      .fill(value);
+    await refetch;
+  }
+
+  async createBusinessDivision(label: string): Promise<void> {
+    await this.byTestId("admin-create-business-division-btn").click();
+    const dialog = this.visibleDialog();
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel(/Nom de la direction métier/i).fill(label);
+    await dialog.getByRole("button", { name: /Enregistrer/i }).click();
+    await this.expectToaster(/Direction métier créée avec succès/i);
+  }
+
+  async expectBusinessDivisionRow(label: string): Promise<void> {
+    await this.searchBusinessDivision(label);
+    await expect(this.businessDivisionsTable()).toContainText(label);
+  }
+
+  async editBusinessDivision(label: string, newLabel: string): Promise<void> {
+    await this.searchBusinessDivision(label);
+    const row = this.businessDivisionsTable().locator("tr", {
+      hasText: label,
+    });
+    await row.getByTestId("admin-business-division-edit-btn").click();
+    const dialog = this.visibleDialog();
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel(/Nom de la direction métier/i).fill(newLabel);
+    await dialog.getByRole("button", { name: /Enregistrer/i }).click();
+    await this.expectToaster(/Direction métier mise à jour avec succès/i);
+  }
+
+  async deleteBusinessDivision(label: string): Promise<void> {
+    await this.searchBusinessDivision(label);
+    const row = this.businessDivisionsTable().locator("tr", {
+      hasText: label,
+    });
+    await row.getByTestId("admin-business-division-delete-btn").click();
+    await expect(
+      this.byTestId("admin-business-division-delete-confirm-btn"),
+    ).toBeVisible();
+    await this.byTestId("admin-business-division-delete-confirm-btn").click();
+    await this.expectToaster(/Direction métier supprimée avec succès/i);
+  }
+
+  /** Rattache (ou détache avec un libellé vide) une direction métier via la modale d'édition d'organisation. */
+  async attachBusinessDivisionToOrganization(
+    orgPath: string,
+    divisionLabel: string,
+  ): Promise<void> {
+    await this.searchOrganization(orgPath);
+    const row = this.orgsTable().locator("tr", { hasText: orgPath });
+    await row.getByTestId("admin-organization-edit-btn").click();
+    const dialog = this.visibleDialog();
+    await expect(dialog).toBeVisible();
+    await dialog
+      .getByTestId("organization-business-division-select")
+      .selectOption({ label: divisionLabel || "Aucune direction métier" });
+    await dialog.getByRole("button", { name: /Enregistrer/i }).click();
+    await this.expectToaster(/mise à jour avec succès/i);
+  }
+
+  async expectOrganizationBusinessDivision(
+    orgPath: string,
+    divisionLabel: string,
+  ): Promise<void> {
+    await this.searchOrganization(orgPath);
+    const row = this.orgsTable().locator("tr", { hasText: orgPath });
+    await expect(row).toContainText(divisionLabel);
+  }
+
   // --- Onglet « Batch de données » : synchronisation MAIA (#1825, MAI-04) ---
   async openBatchDataTab(): Promise<void> {
     await this.adminTabs()

--- a/e2e/tests/administration-referentiels.spec.ts
+++ b/e2e/tests/administration-referentiels.spec.ts
@@ -773,4 +773,55 @@ test.describe("Administration des référentiels", () => {
     );
     expect(rows[0]?.label).toBe(originalLabel);
   });
+
+  test("ADM-22 - cycle de vie d'une direction métier", async ({
+    page,
+    data,
+  }) => {
+    const ts = Date.now();
+    const label = `e2e-adm22-${ts}`;
+    const renamedLabel = `e2e-adm22-renamed-${ts}`;
+    // Idempotence : repartir d'un état propre si un run précédent a laissé la division.
+    await data.removeBusinessDivisionLabel(label);
+    await data.removeBusinessDivisionLabel(renamedLabel);
+
+    const admin = new AdminPage(page);
+    await admin.open();
+    await admin.openBusinessDivisionsTab();
+    await admin.createBusinessDivision(label);
+    await admin.expectBusinessDivisionRow(label);
+    await admin.editBusinessDivision(label, renamedLabel);
+    await admin.expectBusinessDivisionRow(renamedLabel);
+    await admin.deleteBusinessDivision(renamedLabel);
+  });
+
+  test("ADM-23 - rattacher une direction métier à une organisation", async ({
+    page,
+    data,
+  }) => {
+    const ts = Date.now();
+    const orgPath = `E2E/ADM23/${ts}`;
+    const divisionLabel = `e2e-adm23-${ts}`;
+    await data.removeBusinessDivisionLabel(divisionLabel);
+    const org = await data.createOrganization(orgPath);
+    test.skip(!org, "Impossible de créer l'organisation de test");
+
+    const admin = new AdminPage(page);
+    await admin.open();
+    try {
+      await admin.openBusinessDivisionsTab();
+      await admin.createBusinessDivision(divisionLabel);
+
+      await admin.openOrganizationsTab();
+      await admin.attachBusinessDivisionToOrganization(orgPath, divisionLabel);
+      await admin.expectOrganizationBusinessDivision(orgPath, divisionLabel);
+
+      // Détachement : la colonne repasse à « - ».
+      await admin.attachBusinessDivisionToOrganization(orgPath, "");
+      await admin.expectOrganizationBusinessDivision(orgPath, "-");
+    } finally {
+      if (org) await data.deleteOrganization(org.id).catch(() => {});
+      await data.removeBusinessDivisionLabel(divisionLabel).catch(() => {});
+    }
+  });
 });

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -2230,7 +2230,88 @@ paths:
       summary: Rechercher des Business division.
       tags: &a9
         - Business Division
+    post:
+      description: "
+
+        Ce endpoint permet de créer une nouvelle direction métier (business
+        division).
+
+
+        Information requise :
+
+        - **label** : nom unique de la direction métier
+
+        \    "
+      operationId: BusinessDivisionController_create
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateBusinessDivisionDto"
+      responses:
+        "201":
+          description: Direction métier créée avec succès
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BusinessDivisionDTO"
+        "403":
+          description: Accès refusé - Privilège admin requis
+        "409":
+          description: Une direction métier existe déjà avec ce nom
+      summary: Créer une direction métier.
+      tags: *a9
   /api/v2/business-division/{id}:
+    patch:
+      operationId: BusinessDivisionController_update
+      parameters:
+        - name: id
+          required: true
+          in: path
+          description: ID de la direction métier à modifier
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateBusinessDivisionDto"
+      responses:
+        "200":
+          description: Direction métier mise à jour avec succès
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BusinessDivisionDTO"
+        "403":
+          description: Accès refusé - Privilège admin requis
+        "404":
+          description: Direction métier non trouvée
+        "409":
+          description: Une direction métier existe déjà avec ce nom
+      summary: Modifier une direction métier
+      tags: *a9
+    delete:
+      operationId: BusinessDivisionController_remove
+      parameters:
+        - name: id
+          required: true
+          in: path
+          description: ID de la direction métier à supprimer
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Direction métier supprimée avec succès
+        "403":
+          description: Accès refusé - Privilège admin requis
+        "404":
+          description: Direction métier non trouvée
+      summary: Supprimer une direction métier
+      tags: *a9
     get:
       operationId: BusinessDivisionController_findById
       parameters:
@@ -5867,6 +5948,20 @@ components:
       required:
         - id
         - email
+    BusinessDivisionDTO:
+      type: object
+      properties:
+        label:
+          type: string
+          maxLength: 255
+          description: Nom unique du business division
+          example: farm
+        id:
+          type: string
+          description: Identifiant unique de la division DTO
+      required:
+        - label
+        - id
     OrganizationMaiaReferenceDto:
       type: object
       properties:
@@ -5927,6 +6022,12 @@ components:
           nullable: true
           example: f09ed26a-8415-476a-be3b-ada479291c34
           description: L'identifiant de la direction métier associée
+        businessDivision:
+          nullable: true
+          description: Direction métier associée à l'organisation
+          type: object
+          allOf:
+            - $ref: "#/components/schemas/BusinessDivisionDTO"
         maiaReferences:
           description: Références MAIA associées à l'organisation
           type: array
@@ -6802,19 +6903,6 @@ components:
       required:
         - id
         - applicationId
-    BusinessDivisionDTO:
-      type: object
-      properties:
-        id:
-          type: string
-          description: Identifiant unique de la division DTO
-        label:
-          type: string
-          description: Nom unique du business division
-          example: farm
-      required:
-        - id
-        - label
     ApplicationDto:
       type: object
       properties:
@@ -7133,6 +7221,24 @@ components:
       required:
         - results
         - total
+    CreateBusinessDivisionDto:
+      type: object
+      properties:
+        label:
+          type: string
+          maxLength: 255
+          description: Nom unique du business division
+          example: farm
+      required:
+        - label
+    UpdateBusinessDivisionDto:
+      type: object
+      properties:
+        label:
+          type: string
+          maxLength: 255
+          description: Nom unique du business division
+          example: farm
     CreateDataDescriptionDto:
       type: object
       properties:
@@ -7636,6 +7742,11 @@ components:
           type: string
           example: f09ed26a-8415-476a-be3b-ada479291c34
           description: L'identifiant de l'organisation parente
+        businessDivisionId:
+          type: string
+          nullable: true
+          example: f09ed26a-8415-476a-be3b-ada479291c34
+          description: L'identifiant de la direction métier associée (null pour détacher)
       required:
         - path
     PaginatedOrganizationDto:
@@ -7672,6 +7783,11 @@ components:
           type: string
           example: f09ed26a-8415-476a-be3b-ada479291c34
           description: L'identifiant de l'organisation parente
+        businessDivisionId:
+          type: string
+          nullable: true
+          example: f09ed26a-8415-476a-be3b-ada479291c34
+          description: L'identifiant de la direction métier associée (null pour détacher)
     CreateActorDto:
       type: object
       properties:

--- a/frontend/src/components/admin/AdminBusinessDivisionsTab.vue
+++ b/frontend/src/components/admin/AdminBusinessDivisionsTab.vue
@@ -1,0 +1,160 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from "vue";
+import { watchDebounced } from "@vueuse/core";
+import type { BusinessDivisionDto } from "@/client/types.gen";
+import type { DsfrDataTableHeaderCellObject } from "@gouvminint/vue-dsfr";
+import BusinessDivisionActions from "./BusinessDivisionActions.vue";
+import api from "@/api";
+import RefAppTable from "@/components/RefAppTable.vue";
+import type { TableColumn, TableSortEvent } from "@/types/table";
+
+const data = ref<{ results: BusinessDivisionDto[]; total: number }>({ results: [], total: 0 });
+
+const headers: (DsfrDataTableHeaderCellObject & { isSortable?: boolean })[] = [
+  {
+    key: "label",
+    label: "Nom",
+    isSortable: true,
+  },
+  {
+    key: "actions",
+    label: "Actions",
+  },
+] as const;
+
+const tableColumns: TableColumn[] = headers.map((h) => ({
+  field: h.key,
+  header: h.label,
+  sortable: h.isSortable || false,
+}));
+
+const isLoading = ref(false);
+const searchQuery = ref("");
+
+const sortColumn = ref<(typeof headers)[number]["key"]>();
+const isSortDescending = ref(false);
+
+const itemsPerPage = ref(15);
+const currentPage = ref(0);
+const firstIndex = computed(() => currentPage.value * itemsPerPage.value);
+
+// RGAA-084 (7.5) : message de statut sur le nombre de résultats, restitué aux TA.
+const statusMessage = computed(() => {
+  if (isLoading.value) return "Chargement des directions métier…";
+  const total = data.value.total;
+  if (total === 0) return "Aucune donnée ne correspond à votre recherche : Résultat 0 à 0";
+  const from = firstIndex.value + 1;
+  const to = Math.min(firstIndex.value + data.value.results.length, total);
+  return `Résultat ${from} à ${to} sur ${total}`;
+});
+
+async function fetchBusinessDivisions() {
+  isLoading.value = true;
+
+  const query = {
+    label: searchQuery.value || undefined,
+    page: currentPage.value,
+    pageSize: itemsPerPage.value,
+    sortBy: sortColumn.value,
+    order: isSortDescending.value ? ("desc" as const) : ("asc" as const),
+  };
+
+  const response = await api.businessDivisionControllerFindAll({ query });
+  if (!response.data?.results) {
+    isLoading.value = false;
+    return;
+  }
+  data.value = response.data;
+  isLoading.value = false;
+}
+
+watchDebounced(
+  searchQuery,
+  async () => {
+    currentPage.value = 0;
+    await fetchBusinessDivisions();
+  },
+  { debounce: 300 },
+);
+
+watch([sortColumn, isSortDescending], () => {
+  currentPage.value = 0;
+  fetchBusinessDivisions();
+});
+
+const tableRows = computed(() =>
+  data.value.results.map((businessDivision) => ({
+    label: businessDivision.label,
+    actions: businessDivision,
+  })),
+);
+
+function onSort(event: TableSortEvent) {
+  sortColumn.value = event.sortField as (typeof headers)[number]["key"];
+  isSortDescending.value = event.sortOrder === -1;
+}
+
+function onPage(event: { page: number; rows: number }) {
+  currentPage.value = event.page;
+  itemsPerPage.value = event.rows;
+  fetchBusinessDivisions();
+}
+
+onMounted(fetchBusinessDivisions);
+</script>
+
+<template>
+  <div class="header-row">
+    <h1 class="fr-h1" data-testid="admin-business-divisions-title">Gestion des directions métier</h1>
+
+    <BusinessDivisionActions @fetch-business-divisions="fetchBusinessDivisions" />
+  </div>
+
+  <div class="fr-mb-4w">
+    <DsfrSearchBar
+      v-model.trim="searchQuery"
+      label="Rechercher une direction métier"
+      placeholder="Rechercher par nom..."
+      button-text="Rechercher"
+      class="fr-col-12"
+      data-testid="admin-business-division-search"
+    />
+  </div>
+
+  <div aria-live="polite" aria-atomic="true" class="fr-sr-only" data-testid="admin-business-divisions-status">
+    <p>{{ statusMessage }}</p>
+  </div>
+
+  <div v-if="isLoading" class="fr-alert fr-alert--info" data-testid="admin-business-divisions-loading">
+    <p>Chargement des directions métier...</p>
+  </div>
+
+  <div v-else>
+    <RefAppTable
+      :items="tableRows"
+      :columns="tableColumns"
+      :paginator="true"
+      :lazy="true"
+      :rows="itemsPerPage"
+      :first="firstIndex"
+      :total-records="data.total"
+      :sort-field="sortColumn"
+      :sort-order="isSortDescending ? -1 : 1"
+      data-testid="admin-business-divisions-table"
+      @sort="onSort"
+      @page="onPage"
+    >
+      <template #body-actions="{ data: row }">
+        <BusinessDivisionActions :business-division="row.actions" @fetch-business-divisions="fetchBusinessDivisions" />
+      </template>
+    </RefAppTable>
+  </div>
+</template>
+
+<style scoped>
+.header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+</style>

--- a/frontend/src/components/admin/AdminBusinessDivisionsTab.vue
+++ b/frontend/src/components/admin/AdminBusinessDivisionsTab.vue
@@ -8,13 +8,23 @@ import api from "@/api";
 import RefAppTable from "@/components/RefAppTable.vue";
 import type { TableColumn, TableSortEvent } from "@/types/table";
 
-const data = ref<{ results: BusinessDivisionDto[]; total: number }>({ results: [], total: 0 });
+// L'API renvoie le décompte des liaisons, non déclaré dans BusinessDivisionDto.
+type BusinessDivisionRow = BusinessDivisionDto & { _count?: { organizations: number; applications: number } };
+const data = ref<{ results: BusinessDivisionRow[]; total: number }>({ results: [], total: 0 });
 
 const headers: (DsfrDataTableHeaderCellObject & { isSortable?: boolean })[] = [
   {
     key: "label",
     label: "Nom",
     isSortable: true,
+  },
+  {
+    key: "organizationsCount",
+    label: "Organisations liées",
+  },
+  {
+    key: "applicationsCount",
+    label: "Applications liées",
   },
   {
     key: "actions",
@@ -85,6 +95,8 @@ watch([sortColumn, isSortDescending], () => {
 const tableRows = computed(() =>
   data.value.results.map((businessDivision) => ({
     label: businessDivision.label,
+    organizationsCount: businessDivision._count?.organizations ?? 0,
+    applicationsCount: businessDivision._count?.applications ?? 0,
     actions: businessDivision,
   })),
 );

--- a/frontend/src/components/admin/AdminOrganizationsTab.vue
+++ b/frontend/src/components/admin/AdminOrganizationsTab.vue
@@ -31,6 +31,11 @@ const headers: (DsfrDataTableHeaderCellObject & { isSortable?: boolean })[] = [
     isSortable: true,
   },
   {
+    key: "businessDivision",
+    label: "Direction métier",
+    isSortable: false,
+  },
+  {
     key: "url",
     label: "URL",
     isSortable: false,
@@ -109,6 +114,7 @@ const tableRows = computed(() =>
       path: organization.path,
       maiaReferences,
       sigle: organization.sigle || "-",
+      businessDivision: organization.businessDivision?.label || "-",
       url: organization.url || "-",
       actions: organization,
     };

--- a/frontend/src/components/admin/BusinessDivisionActions.vue
+++ b/frontend/src/components/admin/BusinessDivisionActions.vue
@@ -1,0 +1,223 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import type { BusinessDivisionDto } from "@/client/types.gen";
+import { useToasterStore } from "@/stores/toasterStore";
+import api from "@/api";
+
+const props = defineProps<{
+  businessDivision?: BusinessDivisionDto;
+}>();
+
+const emit = defineEmits<{
+  fetchBusinessDivisions: [];
+}>();
+
+const toaster = useToasterStore();
+
+const isEditModalOpen = ref(false);
+const isDeleteModalOpen = ref(false);
+const isSaving = ref(false);
+const isDeleting = ref(false);
+const editingLabel = ref<string>("");
+const errorMessage = ref<string>("");
+
+function openEditModal() {
+  editingLabel.value = props.businessDivision?.label || "";
+  errorMessage.value = "";
+  isEditModalOpen.value = true;
+}
+
+function openDeleteModal() {
+  isDeleteModalOpen.value = true;
+}
+
+function closeEditModal() {
+  isEditModalOpen.value = false;
+  errorMessage.value = "";
+}
+
+function closeDeleteModal() {
+  isDeleteModalOpen.value = false;
+}
+
+async function saveBusinessDivision() {
+  const label = editingLabel.value.trim();
+  if (!label) {
+    errorMessage.value = "Le nom de la direction métier est obligatoire.";
+    return;
+  }
+
+  isSaving.value = true;
+  errorMessage.value = "";
+
+  const body = { label };
+
+  const response = props.businessDivision?.id
+    ? await api.businessDivisionControllerUpdate({ path: { id: props.businessDivision.id }, body })
+    : await api.businessDivisionControllerCreate({ body });
+
+  if (response.response.ok) {
+    toaster.addSuccessMessage(
+      props.businessDivision?.id ? "Direction métier mise à jour avec succès" : "Direction métier créée avec succès",
+    );
+    closeEditModal();
+    emit("fetchBusinessDivisions");
+  } else if (response.response.status === 409) {
+    errorMessage.value = "Une direction métier existe déjà avec ce nom.";
+  } else if (response.response.status === 400) {
+    errorMessage.value = "Les informations saisies sont incorrectes.";
+  } else {
+    errorMessage.value = "Erreur lors de la sauvegarde de la direction métier.";
+  }
+  isSaving.value = false;
+}
+
+async function deleteBusinessDivision() {
+  if (!props.businessDivision?.id) return;
+
+  isDeleting.value = true;
+
+  const response = await api.businessDivisionControllerRemove({ path: { id: props.businessDivision.id } });
+  if (response.response.ok) {
+    toaster.addSuccessMessage("Direction métier supprimée avec succès");
+    closeDeleteModal();
+    emit("fetchBusinessDivisions");
+  } else {
+    toaster.addErrorMessage("Erreur lors de la suppression de la direction métier");
+  }
+  isDeleting.value = false;
+}
+</script>
+
+<template>
+  <DsfrButton
+    v-if="!businessDivision?.id"
+    class="fr-btn--icon-left fr-icon-add-line"
+    label="Créer une direction métier"
+    data-testid="admin-create-business-division-btn"
+    title="Créer une nouvelle direction métier"
+    aria-label="Créer une nouvelle direction métier"
+    @click="openEditModal"
+  />
+
+  <div v-else class="button-row">
+    <DsfrButton
+      label="Modifier"
+      size="sm"
+      secondary
+      data-testid="admin-business-division-edit-btn"
+      title="Modifier la direction métier"
+      aria-label="Modifier la direction métier"
+      @click="openEditModal"
+    />
+    <DsfrButton
+      label="Supprimer"
+      size="sm"
+      secondary
+      data-testid="admin-business-division-delete-btn"
+      title="Supprimer la direction métier"
+      aria-label="Supprimer la direction métier"
+      @click="openDeleteModal"
+    />
+  </div>
+
+  <DsfrModal
+    :opened="isEditModalOpen"
+    :title="!businessDivision?.id ? 'Créer une direction métier' : `Modifier la direction métier ${businessDivision?.label}`"
+    :data-testid="!businessDivision?.id ? 'admin-create-business-division-modal' : 'admin-edit-business-division-modal'"
+    @close="closeEditModal"
+  >
+    <p class="fr-text--sm fr-hint-text fr-mb-3w" style="white-space: normal">
+      Une direction métier regroupe des organisations et des applications sous une même entité métier. Son nom doit être unique.
+    </p>
+
+    <DsfrAlert
+      v-if="errorMessage"
+      type="error"
+      :description="errorMessage"
+      small
+      class="fr-mb-3w"
+      data-testid="business-division-form-error"
+    />
+
+    <DsfrInputGroup
+      v-model="editingLabel"
+      class="fr-mb-3w"
+      label="Nom de la direction métier"
+      hint="Nom unique de la direction métier (ex. dgpn)"
+      label-visible
+      required
+      data-testid="business-division-label"
+    />
+
+    <template #footer>
+      <DsfrButtonGroup :inline-layout-when="true" :reverse="true">
+        <DsfrButton
+          label="Annuler"
+          secondary
+          data-testid="admin-business-division-cancel-btn"
+          title="Annuler"
+          aria-label="Annuler"
+          @click="closeEditModal"
+        />
+        <DsfrButton
+          :label="isSaving ? 'Enregistrement…' : 'Enregistrer'"
+          title="Enregistrer"
+          aria-label="Enregistrer"
+          :disabled="isSaving"
+          data-testid="admin-business-division-save-btn"
+          @click="saveBusinessDivision"
+        />
+      </DsfrButtonGroup>
+    </template>
+  </DsfrModal>
+
+  <DsfrModal
+    :opened="isDeleteModalOpen"
+    title="Supprimer la direction métier"
+    data-testid="admin-delete-business-division-modal"
+    @close="closeDeleteModal"
+  >
+    <DsfrAlert
+      id="business-division-delete-alert"
+      title="Cette action est irréversible"
+      :description="`Êtes-vous sûr de vouloir supprimer la direction métier : ${businessDivision?.label} ? Les organisations et applications liées ne seront pas supprimées, seulement détachées.`"
+      type="warning"
+      class="fr-mb-3w alert-multiline"
+      data-testid="business-division-delete-alert"
+    />
+
+    <template #footer>
+      <DsfrButtonGroup :inline-layout-when="true" :reverse="true">
+        <DsfrButton
+          label="Annuler"
+          secondary
+          data-testid="admin-business-division-delete-cancel-btn"
+          title="Annuler la suppression"
+          aria-label="Annuler la suppression"
+          @click="closeDeleteModal"
+        />
+        <DsfrButton
+          label="Supprimer"
+          data-testid="admin-business-division-delete-confirm-btn"
+          title="Confirmer la suppression"
+          aria-label="Confirmer la suppression"
+          danger
+          :disabled="isDeleting"
+          @click="deleteBusinessDivision"
+        />
+      </DsfrButtonGroup>
+    </template>
+  </DsfrModal>
+</template>
+
+<style scoped>
+.button-row {
+  display: flex;
+  gap: 1rem;
+}
+.alert-multiline {
+  white-space: normal;
+  word-wrap: break-word;
+}
+</style>

--- a/frontend/src/components/admin/OrganizationActions.vue
+++ b/frontend/src/components/admin/OrganizationActions.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import api from "@/api";
 import type {
+  BusinessDivisionDto,
   CreateOrganizationDto,
   CreateOrganizationMaiaReferenceDto,
   OrganizationDto,
@@ -39,6 +40,28 @@ const referencesErrorMessage = ref("");
 const maiaReferences = ref<OrganizationMaiaReferenceDto[]>([]);
 const newMaiaReference = ref("");
 
+// "" = aucune direction métier (détachement à l'enregistrement).
+const selectedBusinessDivisionId = ref("");
+const businessDivisions = ref<BusinessDivisionDto[]>([]);
+
+const businessDivisionOptions = computed(() => [
+  { value: "", text: "Aucune direction métier" },
+  ...businessDivisions.value.map((division) => ({
+    value: division.id,
+    text: division.label,
+  })),
+]);
+
+async function loadBusinessDivisions() {
+  const response = await api.businessDivisionControllerFindAll({
+    query: { pageSize: 0, sortBy: "label", order: "asc" },
+  });
+
+  if (response.response.ok && response.data) {
+    businessDivisions.value = response.data.results;
+  }
+}
+
 function getInitialForm(): CreateOrganizationDto {
   return {
     path: props.organization?.path || "",
@@ -72,8 +95,9 @@ function resetForm() {
 }
 
 async function openEditModal() {
-  await loadMaiaReferences();
+  await Promise.all([loadMaiaReferences(), loadBusinessDivisions()]);
   form.value = getInitialForm();
+  selectedBusinessDivisionId.value = props.organization?.businessDivisionId || "";
   errorMessage.value = "";
   isEditModalOpen.value = true;
 }
@@ -96,6 +120,7 @@ function toPayload(): CreateOrganizationDto | PatchOrganizationDto {
     path: form.value.path,
     sigle: form.value.sigle || undefined,
     url: form.value.url || undefined,
+    businessDivisionId: selectedBusinessDivisionId.value || null,
   };
 }
 
@@ -250,6 +275,16 @@ async function deleteOrganization() {
     <DsfrInputGroup v-model="form.sigle" class="fr-mb-2w" label="Sigle" hint="Optionnel" label-visible data-testid="organization-sigle" />
 
     <DsfrInputGroup v-model="form.url" class="fr-mb-2w" label="URL" hint="Optionnel" label-visible data-testid="organization-url" />
+
+    <DsfrSelect
+      v-model="selectedBusinessDivisionId"
+      class="fr-mb-2w"
+      :options="businessDivisionOptions"
+      label="Direction métier"
+      hint="Optionnel — direction métier rattachée à l'organisation"
+      label-visible
+      data-testid="organization-business-division-select"
+    />
 
     <div v-if="!isCreateMode" class="fr-mt-3w">
       <h5 class="fr-h6 fr-mb-2w">Références MAIA</h5>

--- a/frontend/src/components/admin/UserActions.spec.ts
+++ b/frontend/src/components/admin/UserActions.spec.ts
@@ -50,6 +50,8 @@ const targetUser = {
   email: "target@example.gouv.fr",
   organizationId: null,
   scopeOrganizationId: null,
+  lastPermissionChangeAt: null,
+  lastPermissionChangedByEmail: null,
 } satisfies Required<UserEntity>;
 
 function createOrganization(path: string): OrganizationDto {

--- a/frontend/src/views/AdminPage.vue
+++ b/frontend/src/views/AdminPage.vue
@@ -9,6 +9,7 @@ import AdminPermsMatrixTab from "@/components/admin/AdminPermsMatrixTab.vue";
 import AdminLabelSourcesTab from "@/components/admin/AdminLabelSourcesTab.vue";
 import AdminMditCampaignsTab from "@/components/admin/AdminMditCampaignsTab.vue";
 import AdminTokensTab from "@/components/admin/AdminTokensTab.vue";
+import AdminBusinessDivisionsTab from "@/components/admin/AdminBusinessDivisionsTab.vue";
 
 interface DsfrTab {
   title: string;
@@ -40,6 +41,13 @@ const tabs = ref<DsfrTab[]>([
     tabId: "tab-actors",
     panelId: "panel-actors",
     component: markRaw(AdminActorsTab),
+  },
+  {
+    title: "Directions métier",
+    icon: "ri-organization-chart",
+    tabId: "tab-business-divisions",
+    panelId: "panel-business-divisions",
+    component: markRaw(AdminBusinessDivisionsTab),
   },
   {
     title: "Gestions des tags",

--- a/qa/protocoles/administration-referentiels.md
+++ b/qa/protocoles/administration-referentiels.md
@@ -181,4 +181,24 @@
   `admin-actor-delete-all-btn` → confirmer dans le modal de suppression bulk.
 - **Résultat attendu** : toast « N acteur(s) supprimé(s) avec succès » ; l'email disparaît de
   `admin-actors-table`.
-  > > > > > > > origin/main
+
+### ADM-22 — Cycle de vie d'une direction métier ✅
+
+- **Datafeature** : nettoyage préalable des libellés de test via l'API (idempotence).
+- **Action** : administration → onglet Directions métier → `admin-create-business-division-btn`
+  → saisir le nom → enregistrer → rechercher (`admin-business-division-search`) → modifier via
+  `admin-business-division-edit-btn` → supprimer via `admin-business-division-delete-btn` + confirmation.
+- **Résultat attendu** : toasts « Direction métier créée / mise à jour / supprimée avec succès » ;
+  la ligne apparaît puis disparaît de `admin-business-divisions-table`. Un doublon de nom est refusé
+  avec le message « Une direction métier existe déjà avec ce nom. ».
+
+### ADM-23 — Rattacher une direction métier à une organisation ✅
+
+- **Datafeature** : une organisation de test créée via l'API et une direction métier créée via l'onglet
+  (nettoyées en fin de test).
+- **Action** : administration → onglet Gestion des organisations → rechercher l'organisation →
+  `admin-organization-edit-btn` → choisir la direction métier dans
+  `organization-business-division-select` → enregistrer ; puis rouvrir et sélectionner
+  « Aucune direction métier » pour détacher.
+- **Résultat attendu** : toast « Organisation mise à jour avec succès » ; la colonne « Direction métier »
+  de `admin-organizations-table` affiche le nom de la direction, puis « - » après détachement.


### PR DESCRIPTION
Closes #2213

## Quoi

### Onglet admin « Directions métier »
- Nouveau CRUD sur le module `business-division` existant (jusqu'ici en lecture seule) : `POST` / `PATCH :id` / `DELETE :id` protégés par `AdminPanelManage`, unicité du `label` → 409 (pattern `mdit-campaign`), lectures inchangées (`AppRead`, utilisées par `BusinessDivisionSearch`).
- Nouvel onglet `AdminBusinessDivisionsTab.vue` (calque `AdminLabelSourcesTab` : recherche debouncée, tri, pagination lazy, message de statut aria-live RGAA) + `BusinessDivisionActions.vue` (modales création/édition/suppression, gestion 409/400).

### Rattachement organisation ↔ direction métier
- La relation `Organization.businessDivisionId` existait déjà en base (aucune migration) ; elle est maintenant exposée : `businessDivisionId` (nullable, `null` = détachement) accepté dans `CreateOrganizationDto`/`PatchOrganizationDto`, avec 404 propre si l'id est inconnu ; `businessDivision` inclus dans les réponses.
- Modale d'édition d'organisation : sélecteur « Direction métier » (option « Aucune » pour détacher) ; colonne « Direction métier » dans le tableau admin.

### Corrections au passage
- Fix du tri `sortBy=createdAt` du query builder business-division (champ inexistant → erreur Prisma latente).
- Mocks de `UserActions.spec.ts` complétés (`lastPermissionChangeAt`/`lastPermissionChangedByEmail`) : le swagger committé était en retard sur le backend, la régénération a révélé l'écart.
- Marqueur de conflit git résiduel supprimé en fin de `qa/protocoles/administration-referentiels.md`.

## Tests
- Backend e2e : `business-division.e2e-spec.ts` (403/201/409/400/200/204) + cas rattachement/détachement/id inconnu dans `organization.e2e-spec.ts` — suite complète : **339 ✅** (conteneur).
- Playwright : **ADM-22** (cycle de vie direction métier) et **ADM-23** (rattachement + détachement à une organisation) — **6/6 ✅** sur chromium/firefox/webkit ; helpers POM + fixtures d'idempotence.
- Protocole QA : cas ADM-22/ADM-23 ajoutés.
- `tsc --noEmit` back (hôte + conteneur) et `vue-tsc` front : 0 erreur ; ESLint/Prettier ✅ ; vitest front 27 ✅.

## Docs
- `docs/05-api.md` (routes d'écriture), `docs/07-fonctionnalites.md` (nouvel onglet + rattachement).
- `frontend/openapi/swagger.yaml` régénéré et committé.