### PR TITLE
feat: restreindre l'impersonification au périmètre de l'admin local

### DIFF
--- a/backend/src/middlewares/auth.middleware.spec.ts
+++ b/backend/src/middlewares/auth.middleware.spec.ts
@@ -4,6 +4,7 @@ import { Roles, UserType } from "@prisma/client";
 import type { LoggerService } from "src/logger/logger.service";
 import type { MaintenanceService } from "src/maintenance/maintenance.service";
 import type { TokenService } from "src/token/token.service";
+import type { ScopedPermissionService } from "src/user/scope-permission/scoped-permission.service";
 import type { UserConnexionLogService } from "src/user/user-connexion-log.service";
 import type { UserService } from "src/user/user.service";
 import type { OidcConfig } from "src/config/configs/oidc.config";
@@ -23,6 +24,9 @@ jest.mock("src/user/user-connexion-log.service", () => ({
 }));
 jest.mock("src/user/user.service", () => ({
   UserService: class UserService {},
+}));
+jest.mock("src/user/scope-permission/scoped-permission.service", () => ({
+  ScopedPermissionService: class ScopedPermissionService {},
 }));
 
 const oidcConfig = {
@@ -69,6 +73,9 @@ describe("AuthMiddleware maintenance mode", () => {
     const middleware = new AuthMiddleware(
       oidcConfig,
       userService as unknown as UserService,
+      {
+        assertCanImpersonate: jest.fn(),
+      } as unknown as ScopedPermissionService,
       tokenService as unknown as TokenService,
       userConnexionLogService as unknown as UserConnexionLogService,
       logger as unknown as LoggerService,
@@ -116,6 +123,9 @@ describe("AuthMiddleware maintenance mode", () => {
     const middleware = new AuthMiddleware(
       oidcConfig,
       userService as unknown as UserService,
+      {
+        assertCanImpersonate: jest.fn(),
+      } as unknown as ScopedPermissionService,
       tokenService as unknown as TokenService,
       userConnexionLogService as unknown as UserConnexionLogService,
       { error: jest.fn() } as unknown as LoggerService,

--- a/backend/src/middlewares/auth.middleware.spec.ts
+++ b/backend/src/middlewares/auth.middleware.spec.ts
@@ -172,6 +172,9 @@ describe("AuthMiddleware blocked user", () => {
     const middleware = new AuthMiddleware(
       oidcConfig,
       userService as unknown as UserService,
+      {
+        assertCanImpersonate: jest.fn(),
+      } as unknown as ScopedPermissionService,
       tokenService as unknown as TokenService,
       userConnexionLogService as unknown as UserConnexionLogService,
       { error: jest.fn() } as unknown as LoggerService,

--- a/backend/src/middlewares/auth.middleware.ts
+++ b/backend/src/middlewares/auth.middleware.ts
@@ -14,6 +14,8 @@ import { oidcConfig } from "src/config/configs";
 import { roleToPermissions } from "src/permissions/role-to-permissions";
 import { TokenService } from "src/token/token.service";
 import { Requestor, UserEntity, UserType } from "src/user/entities/user.entity";
+import { ScopePermissionsException } from "src/user/errors/scope-permissions.exception";
+import { ScopedPermissionService } from "src/user/scope-permission/scoped-permission.service";
 import { UserConnexionLogService } from "src/user/user-connexion-log.service";
 import { UserService } from "src/user/user.service";
 import { API_KEY_HEADER, IMPERSONATE_HEADER } from "src/utils/constants.util";
@@ -36,6 +38,7 @@ export class AuthMiddleware implements NestMiddleware {
     @Inject(oidcConfig.KEY)
     private readonly oidc: ConfigType<typeof oidcConfig>,
     private readonly userService: UserService,
+    private readonly scopedPermissionService: ScopedPermissionService,
     private readonly tokenService: TokenService,
     private readonly userConnexionLogService: UserConnexionLogService,
     private readonly logger: LoggerService,
@@ -119,7 +122,8 @@ export class AuthMiddleware implements NestMiddleware {
 
       if (
         error instanceof ForbiddenException ||
-        error instanceof NotFoundException
+        error instanceof NotFoundException ||
+        error instanceof ScopePermissionsException
       ) {
         throw error;
       }
@@ -147,6 +151,14 @@ export class AuthMiddleware implements NestMiddleware {
         "Impossible d'impersonner un utilisateur bloqué",
       );
     }
+
+    // Contrôle de périmètre ICI et pas seulement dans startImpersonation :
+    // c'est ce middleware qui applique l'identité à chaque requête, et le
+    // header peut être posé sans jamais passer par l'endpoint dédié (#2217).
+    await this.scopedPermissionService.assertCanImpersonate(
+      targetUserId,
+      admin,
+    );
 
     return {
       ...target,

--- a/backend/src/user/scope-permission/scoped-permission.service.spec.ts
+++ b/backend/src/user/scope-permission/scoped-permission.service.spec.ts
@@ -65,3 +65,73 @@ describe("ScopedPermissionService — assertCanAssignScopeToNewPrincipal", () =>
     ).resolves.toBeUndefined();
   });
 });
+
+describe("ScopedPermissionService — assertCanImpersonate", () => {
+  function buildRequestor(scopePath?: string): Requestor {
+    return {
+      id: "requestor-1",
+      scopeOrganization: scopePath ? { path: scopePath } : null,
+    } as unknown as Requestor;
+  }
+
+  function buildService(
+    users: Record<
+      string,
+      { id: string; organization: { path: string } | null }
+    >,
+  ) {
+    const prisma = {
+      user: {
+        findFirst: jest.fn(({ where: { id } }: { where: { id: string } }) =>
+          Promise.resolve(users[id] ?? null),
+        ),
+      },
+    } as unknown as PrismaService;
+    return new ScopedPermissionService(prisma);
+  }
+
+  it("does nothing for a global admin (no scope)", async () => {
+    const service = buildService({});
+    await expect(
+      service.assertCanImpersonate("target-1", buildRequestor()),
+    ).resolves.toBeUndefined();
+  });
+
+  it("allows impersonating a user within the requestor's scope", async () => {
+    const service = buildService({
+      "target-1": {
+        id: "target-1",
+        organization: { path: "DTNUM/TOTO/SUB" },
+      },
+    });
+    await expect(
+      service.assertCanImpersonate("target-1", buildRequestor("DTNUM/TOTO")),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects impersonating a user outside the requestor's scope", async () => {
+    const service = buildService({
+      "target-1": { id: "target-1", organization: { path: "DGPN" } },
+    });
+    await expect(
+      service.assertCanImpersonate("target-1", buildRequestor("DTNUM/TOTO")),
+    ).rejects.toBeInstanceOf(ScopePermissionsException);
+  });
+
+  it("allows impersonating a user with no organization", async () => {
+    // Cohérent avec l'édition (canEditUser) : sans organisation, pas de refus.
+    const service = buildService({
+      "target-1": { id: "target-1", organization: null },
+    });
+    await expect(
+      service.assertCanImpersonate("target-1", buildRequestor("DTNUM/TOTO")),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws 404 when the target user does not exist", async () => {
+    const service = buildService({});
+    await expect(
+      service.assertCanImpersonate("ghost", buildRequestor("DTNUM/TOTO")),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/backend/src/user/scope-permission/scoped-permission.service.ts
+++ b/backend/src/user/scope-permission/scoped-permission.service.ts
@@ -113,6 +113,35 @@ export class ScopedPermissionService {
   }
 
   /**
+   * Vérifie qu'un administrateur peut impersonner l'utilisateur cible : un
+   * admin scopé ne peut impersonner que les utilisateurs dont l'organisation
+   * est dans son périmètre (même règle que l'édition, cf. `assertCanUpdate`).
+   */
+  async assertCanImpersonate(
+    targetUserId: string,
+    requestor: Requestor,
+  ): Promise<void> {
+    const requestorScopePath = requestor?.scopeOrganization?.path;
+    // Si le requestor n'a pas de scope, c'est qu'il est super admin et peut tout faire → PAS DE CHECK
+    if (!requestorScopePath) return;
+
+    const target = await this.prisma.user.findFirst({
+      where: { id: targetUserId },
+      include: { organization: true },
+    });
+
+    if (!target) {
+      throw new HttpException("Utilisateur introuvable", HttpStatus.NOT_FOUND);
+    }
+
+    this.assertWithinScope(
+      target.organization?.path,
+      requestorScopePath,
+      "Vous n'avez pas les permissions pour impersonner cet utilisateur",
+    );
+  }
+
+  /**
    * Valide l'assignation d'un périmètre à un nouveau principal (ex: le compte
    * de service créé pour un token applicatif), qui n'a donc pas d'état
    * précédent à comparer, contrairement à `assertCanUpdate`.

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -209,7 +209,8 @@ export class UserController {
     type: UserWithPermissions,
   })
   @ApiForbiddenResponse({
-    description: "Accès refusé - Privilège admin requis",
+    description:
+      "Accès refusé - Privilège admin requis, ou utilisateur hors du périmètre de l'administrateur",
   })
   @ApiNotFoundResponse({ description: "Utilisateur non trouvé" })
   async impersonate(

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -389,6 +389,9 @@ export class UserService {
       );
     }
 
+    // Un admin scopé ne peut impersonner que dans son périmètre (#2217).
+    await this.scopedPermissionService.assertCanImpersonate(targetId, admin);
+
     await this.prisma.impersonationLog.create({
       data: { adminId: admin.id, targetId },
     });

--- a/backend/tests/fakers/organization.faker.ts
+++ b/backend/tests/fakers/organization.faker.ts
@@ -2,12 +2,12 @@ import { faker } from "@faker-js/faker";
 import { getPrismaClient } from "./prisma";
 
 export class OrganizationFaker {
-  static async create() {
+  static async create({ path }: { path?: string } = {}) {
     const prisma = getPrismaClient();
 
     return await prisma.organization.create({
       data: {
-        path: faker.company.name(),
+        path: path ?? faker.company.name(),
         url: faker.internet.url(),
         sigle: faker.string.alpha({ length: 4, casing: "upper" }),
       },

--- a/backend/tests/impersonation.e2e-spec.ts
+++ b/backend/tests/impersonation.e2e-spec.ts
@@ -1,0 +1,109 @@
+import type { UserFakerReturnType } from "./fakers/user.faker";
+import { Roles } from "@prisma/client";
+import request from "supertest";
+import { OrganizationFaker } from "./fakers/organization.faker";
+import { UserFaker } from "./fakers/user.faker";
+import { getToken } from "./getToken";
+import { setupTestSuite } from "./setup";
+
+const IMPERSONATE_HEADER = "x-impersonate-user-id";
+
+describe("Impersonation — contrôle de périmètre (#2217)", () => {
+  const app = setupTestSuite();
+  const suffix = Date.now();
+
+  let globalAdmin: UserFakerReturnType;
+  let scopedAdmin: UserFakerReturnType;
+  let targetInScope: UserFakerReturnType;
+  let targetOutOfScope: UserFakerReturnType;
+  let GLOBAL_ADMIN_TOKEN: string;
+  let SCOPED_ADMIN_TOKEN: string;
+
+  beforeAll(async () => {
+    const scopeOrg = await OrganizationFaker.create({
+      path: `E2E/IMP/DTNUM-${suffix}`,
+    });
+    const inScopeOrg = await OrganizationFaker.create({
+      path: `E2E/IMP/DTNUM-${suffix}/SDAN`,
+    });
+    const outOfScopeOrg = await OrganizationFaker.create({
+      path: `E2E/IMP/DGPN-${suffix}`,
+    });
+
+    globalAdmin = await UserFaker.create({ role: Roles.ADMIN });
+
+    scopedAdmin = await UserFaker.create({ role: Roles.ADMIN });
+    await scopedAdmin.update({
+      scopeOrganization: { connect: { id: scopeOrg.id } },
+    });
+
+    targetInScope = await UserFaker.create({ role: Roles.VISITOR });
+    await targetInScope.update({
+      organization: { connect: { id: inScopeOrg.id } },
+    });
+
+    targetOutOfScope = await UserFaker.create({ role: Roles.VISITOR });
+    await targetOutOfScope.update({
+      organization: { connect: { id: outOfScopeOrg.id } },
+    });
+
+    GLOBAL_ADMIN_TOKEN = await getToken(globalAdmin);
+    SCOPED_ADMIN_TOKEN = await getToken(scopedAdmin);
+  });
+
+  it("POST /users/:id/impersonate - a global admin can impersonate anyone", async () => {
+    const response = await request(app().getHttpServer())
+      .post(`/users/${targetOutOfScope.id}/impersonate`)
+      .set("Authorization", `Bearer ${GLOBAL_ADMIN_TOKEN}`)
+      .expect(200);
+
+    expect(response.body.id).toEqual(targetOutOfScope.id);
+  });
+
+  it("POST /users/:id/impersonate - a scoped admin can impersonate within their scope", async () => {
+    const response = await request(app().getHttpServer())
+      .post(`/users/${targetInScope.id}/impersonate`)
+      .set("Authorization", `Bearer ${SCOPED_ADMIN_TOKEN}`)
+      .expect(200);
+
+    expect(response.body.id).toEqual(targetInScope.id);
+  });
+
+  it("POST /users/:id/impersonate - a scoped admin is rejected outside their scope", async () => {
+    await request(app().getHttpServer())
+      .post(`/users/${targetOutOfScope.id}/impersonate`)
+      .set("Authorization", `Bearer ${SCOPED_ADMIN_TOKEN}`)
+      .expect(403);
+  });
+
+  it("header direct - a scoped admin is served the in-scope identity", async () => {
+    const response = await request(app().getHttpServer())
+      .get("/users/me")
+      .set("Authorization", `Bearer ${SCOPED_ADMIN_TOKEN}`)
+      .set(IMPERSONATE_HEADER, targetInScope.id)
+      .expect(200);
+
+    expect(response.body.id).toEqual(targetInScope.id);
+  });
+
+  it("header direct - a scoped admin is rejected outside their scope even without the endpoint", async () => {
+    // Le header peut être posé à la main sans passer par POST /users/:id/impersonate :
+    // le middleware doit refuser lui-même l'identité hors périmètre.
+    await request(app().getHttpServer())
+      .get("/users/me")
+      .set("Authorization", `Bearer ${SCOPED_ADMIN_TOKEN}`)
+      .set(IMPERSONATE_HEADER, targetOutOfScope.id)
+      .expect(403);
+  });
+
+  it("header direct - a non-admin cannot impersonate at all", async () => {
+    const visitor = await UserFaker.create({ role: Roles.VISITOR });
+    const VISITOR_TOKEN = await getToken(visitor);
+
+    await request(app().getHttpServer())
+      .get("/users/me")
+      .set("Authorization", `Bearer ${VISITOR_TOKEN}`)
+      .set(IMPERSONATE_HEADER, targetInScope.id)
+      .expect(403);
+  });
+});

--- a/docs/06-permissions-et-securite.md
+++ b/docs/06-permissions-et-securite.md
@@ -237,6 +237,15 @@ Dans `getUserRolePermissions` (`check-permissions.service.ts:85-126`) :
 - Sinon, toute cible et toute organisation manipulée doivent être **dans le périmètre** : `targetPath.startsWith(requestorScopePath)` (`assertWithinScope:125-133`).
 - Règle dédiée : **seul un administrateur global peut supprimer le périmètre d'un utilisateur** (`assertScopeOrganizationAction`, action `REMOVE` → exception).
 
+### 6.3. Effet sur l'impersonation
+
+La même règle de périmètre s'applique à l'impersonation (#2217, `assertCanImpersonate`) : un admin scopé ne peut se faire passer que pour un utilisateur dont l'organisation est dans son périmètre (un utilisateur sans organisation reste impersonnable, comme pour l'édition). Le contrôle est appliqué à **deux niveaux** :
+
+- `UserService.startImpersonation` (endpoint `POST /users/:id/impersonate`) ;
+- `AuthMiddleware.resolveImpersonatedUser` — indispensable car c'est le middleware qui applique l'identité à chaque requête via le header `x-impersonate-user-id`, qui peut être posé sans passer par l'endpoint.
+
+Côté interface, le bouton « Se connecter en tant que » n'est pas proposé hors périmètre (`UserActions.vue`, `canImpersonate`, alignée sur `canEditUser`).
+
 ## 7. Mise en œuvre côté code
 
 ### 7.1. Backend — garde et décorateur

--- a/e2e/tests/impersonation.spec.ts
+++ b/e2e/tests/impersonation.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "../fixtures/test";
 import { DataFeature } from "../fixtures/datafeature";
-import { AdminPage, ApplicationPage, loginAs } from "../pom";
+import { AdminPage, ApplicationPage, loginAs, switchTo } from "../pom";
 import { captureStepScreenshot } from "../support/screenshots";
 
 const ADMIN_EMAIL = "admin@example.com";
@@ -192,5 +192,35 @@ test.describe("Impersonation", () => {
       await data.setUserRole("qa-target@example.com", "READER").catch(() => {});
       await data.removeApplication(appRef.id).catch(() => {});
     }
+  });
+
+  test("IMP-08 - un admin scopé ne peut impersonner que dans son périmètre (#2217)", async ({
+    page,
+    data,
+  }) => {
+    // Cibles du seed QA : `qa-target` (org TOTO/TUTU, dans le périmètre TOTO de
+    // `scope-admin`) et `qa-outside` (org ABCD, hors périmètre).
+    const outside = await data.getUser("qa-outside@example.com");
+    const inScope = await data.getUser("qa-target@example.com");
+    test.skip(
+      !outside || !inScope,
+      "Fixture QA absente — `pnpm db:seed:qa` requis.",
+    );
+
+    // `switchTo` (pas `loginAs`) : la fixture `data` a déjà connecté `page` en `admin`.
+    await switchTo(page, "scope-admin");
+    const admin = new AdminPage(page);
+    await admin.open();
+
+    // Hors périmètre : le bouton « Se connecter en tant que » n'est pas proposé.
+    // (Le refus 403 côté API — endpoint ET header direct — est couvert par
+    // backend/tests/impersonation.e2e-spec.ts.)
+    await admin.expectImpersonateUnavailable("qa-outside@example.com");
+
+    // Dans le périmètre : l'impersonation complète fonctionne.
+    await admin.impersonateUser("qa-target@example.com");
+    await admin.expectImpersonationBanner("qa-target@example.com");
+    await admin.stopImpersonation();
+    await admin.expectNotImpersonating();
   });
 });

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -385,7 +385,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/UserWithPermissions"
         "403":
-          description: Accès refusé - Privilège admin requis
+          description: Accès refusé - Privilège admin requis, ou utilisateur hors du
+            périmètre de l'administrateur
         "404":
           description: Utilisateur non trouvé
       summary: Impersonner un utilisateur

--- a/frontend/src/components/admin/UserActions.spec.ts
+++ b/frontend/src/components/admin/UserActions.spec.ts
@@ -41,6 +41,12 @@ vi.mock("@/stores/userStore", () => ({
       return currentUserMock.user;
     },
     hasPermissions: hasPermissionsMock,
+    // Même règle que le vrai store : sans scope tout est permis, sinon préfixe de chemin.
+    isWithinScope: (targetOrganizationPath?: string | null) => {
+      const scopePath = currentUserMock.user.scopeOrganization?.path;
+      if (!scopePath) return true;
+      return !targetOrganizationPath || targetOrganizationPath.startsWith(scopePath);
+    },
     startImpersonation: vi.fn(),
   }),
 }));

--- a/frontend/src/components/admin/UserActions.spec.ts
+++ b/frontend/src/components/admin/UserActions.spec.ts
@@ -222,4 +222,39 @@ describe("UserActions", () => {
     expect(screen.queryByTestId("admin-user-block-btn")).not.toBeInTheDocument();
     currentUserMock.user.id = "current-user";
   });
+
+  it("shows the impersonate button to a global administrator for any user", () => {
+    hasPermissionsMock.mockReturnValue(true);
+
+    render(UserActions, {
+      props: { user: createTargetUser("/HORS-PERIMETRE") },
+      global,
+    });
+
+    expect(screen.getByTestId("admin-user-impersonate-btn")).toBeInTheDocument();
+  });
+
+  it("shows the impersonate button to a scoped administrator within their scope", () => {
+    hasPermissionsMock.mockReturnValue(true);
+    currentUserMock.user.scopeOrganization = createOrganization("/MININT/DTNUM");
+
+    render(UserActions, {
+      props: { user: createTargetUser("/MININT/DTNUM/SDAN") },
+      global,
+    });
+
+    expect(screen.getByTestId("admin-user-impersonate-btn")).toBeInTheDocument();
+  });
+
+  it("hides the impersonate button from a scoped administrator outside their scope", () => {
+    hasPermissionsMock.mockReturnValue(true);
+    currentUserMock.user.scopeOrganization = createOrganization("/MININT/DTNUM");
+
+    render(UserActions, {
+      props: { user: createTargetUser("/MININT/DGPN") },
+      global,
+    });
+
+    expect(screen.queryByTestId("admin-user-impersonate-btn")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/admin/UserActions.vue
+++ b/frontend/src/components/admin/UserActions.vue
@@ -24,27 +24,15 @@ const emit = defineEmits<{
 
 const toaster = useToasterStore();
 const userStore = useUserStore();
-const canEditUser = computed(() => {
-  if (!userStore.hasPermissions([Permission.ADMIN_PANEL_MANAGE])) return false;
-
-  const requestorScopePath = userStore.user?.scopeOrganization?.path;
-  if (!requestorScopePath) return true;
-
-  const targetOrganizationPath = props.user.organization?.path;
-  return !targetOrganizationPath || targetOrganizationPath.startsWith(requestorScopePath);
-});
+const canEditUser = computed(
+  () => userStore.hasPermissions([Permission.ADMIN_PANEL_MANAGE]) && userStore.isWithinScope(props.user.organization?.path),
+);
 
 // On peut impersonner tout utilisateur humain, sauf soi-même — et pour un
 // admin scopé, seulement dans son périmètre (même règle que canEditUser, #2217).
-const canImpersonate = computed(() => {
-  if (props.user.type === "bot" || props.user.id === userStore.user?.id) return false;
-
-  const requestorScopePath = userStore.user?.scopeOrganization?.path;
-  if (!requestorScopePath) return true;
-
-  const targetOrganizationPath = props.user.organization?.path;
-  return !targetOrganizationPath || targetOrganizationPath.startsWith(requestorScopePath);
-});
+const canImpersonate = computed(
+  () => props.user.type !== "bot" && props.user.id !== userStore.user?.id && userStore.isWithinScope(props.user.organization?.path),
+);
 const isImpersonating = ref(false);
 
 // On ne peut pas bloquer son propre accès (cf. UserService.block côté back).

--- a/frontend/src/components/admin/UserActions.vue
+++ b/frontend/src/components/admin/UserActions.vue
@@ -34,8 +34,17 @@ const canEditUser = computed(() => {
   return !targetOrganizationPath || targetOrganizationPath.startsWith(requestorScopePath);
 });
 
-// On peut impersonner tout utilisateur humain, sauf soi-même.
-const canImpersonate = computed(() => props.user.type !== "bot" && props.user.id !== userStore.user?.id);
+// On peut impersonner tout utilisateur humain, sauf soi-même — et pour un
+// admin scopé, seulement dans son périmètre (même règle que canEditUser, #2217).
+const canImpersonate = computed(() => {
+  if (props.user.type === "bot" || props.user.id === userStore.user?.id) return false;
+
+  const requestorScopePath = userStore.user?.scopeOrganization?.path;
+  if (!requestorScopePath) return true;
+
+  const targetOrganizationPath = props.user.organization?.path;
+  return !targetOrganizationPath || targetOrganizationPath.startsWith(requestorScopePath);
+});
 const isImpersonating = ref(false);
 
 // On ne peut pas bloquer son propre accès (cf. UserService.block côté back).

--- a/frontend/src/stores/userStore.ts
+++ b/frontend/src/stores/userStore.ts
@@ -113,6 +113,15 @@ export const useUserStore = defineStore("userStore", () => {
     }
   }
 
+  // Un admin scopé n'agit que dans son périmètre : cible sans organisation, ou
+  // organisation dont le chemin est porté par celui du scope. Sans scope
+  // (admin global), tout est permis. Règle unique pour édition, impersonation…
+  function isWithinScope(targetOrganizationPath?: string | null) {
+    const scopePath = user.value?.scopeOrganization?.path;
+    if (!scopePath) return true;
+    return !targetOrganizationPath || targetOrganizationPath.startsWith(scopePath);
+  }
+
   function hasPermissions(permissions: Permission[], userApplicationPerms?: APP_PERMISSIONS[]) {
     if (permissions.length === 0) return true;
     const userPermissions = new Set([
@@ -134,6 +143,7 @@ export const useUserStore = defineStore("userStore", () => {
     unsubscribeFromApp,
     getBusinessDivisionId,
     hasPermissions,
+    isWithinScope,
     impersonation,
     isImpersonating,
     startImpersonation,

--- a/qa/protocoles/impersonation.md
+++ b/qa/protocoles/impersonation.md
@@ -74,3 +74,18 @@
   (via `admin@example.com`) » — l'action est attribuée à l'identité effective ET l'administrateur
   réel est visible. Même affichage sur la page globale Modifications et le détail d'une metadata.
   Hors impersonification, aucun « (via …) » n'apparaît.
+  =======
+
+### IMP-08 — Un admin scopé ne peut impersonner que dans son périmètre (#2217) ✅
+
+- **Datafeature** : seed QA (`pnpm db:seed:qa`) — `scope-admin` (ADMIN, périmètre TOTO),
+  `qa-target@example.com` (org TOTO/TUTU, dans le périmètre), `qa-outside@example.com`
+  (org ABCD, hors périmètre).
+- **Action** : en `scope-admin`, administration → Gestion des utilisateurs → vérifier la ligne de
+  `qa-outside` (pas de bouton « Se connecter en tant que ») ; impersonner `qa-target` puis arrêter.
+  Côté API : `POST /users/{id}/impersonate` sur `qa-outside`, et n'importe quelle requête portant le
+  header `x-impersonate-user-id` avec son id.
+- **Résultat attendu** : bouton absent hors périmètre ; `403 Forbidden` sur l'endpoint ET sur le
+  header direct (contrôle dans le middleware, non contournable) ; impersonation normale dans le
+  périmètre. Un admin sans périmètre (global) reste libre d'impersonner tout utilisateur humain.
+  > > > > > > > b2aa798c (feat: restrict impersonation to the local admin's organization scope)

--- a/qa/protocoles/impersonation.md
+++ b/qa/protocoles/impersonation.md
@@ -74,7 +74,6 @@
   (via `admin@example.com`) » — l'action est attribuée à l'identité effective ET l'administrateur
   réel est visible. Même affichage sur la page globale Modifications et le détail d'une metadata.
   Hors impersonification, aucun « (via …) » n'apparaît.
-  =======
 
 ### IMP-08 — Un admin scopé ne peut impersonner que dans son périmètre (#2217) ✅
 
@@ -88,4 +87,3 @@
 - **Résultat attendu** : bouton absent hors périmètre ; `403 Forbidden` sur l'endpoint ET sur le
   header direct (contrôle dans le middleware, non contournable) ; impersonation normale dans le
   périmètre. Un admin sans périmètre (global) reste libre d'impersonner tout utilisateur humain.
-  > > > > > > > b2aa798c (feat: restrict impersonation to the local admin's organization scope)


### PR DESCRIPTION
Closes #2217

## Quoi

Réplique sur l'**impersonification** le contrôle de périmètre déjà en place pour l'édition d'utilisateur (#1830) : un admin scopé ne peut plus se faire passer que pour un utilisateur dont l'organisation est **dans son périmètre**. Un admin global (sans `scopeOrganization`) reste libre, et un utilisateur sans organisation reste impersonnable (mêmes règles que `canEditUser`).

## Comment

- **`ScopedPermissionService.assertCanImpersonate(targetUserId, requestor)`** : bail-out sans scope, sinon `assertWithinScope` sur le path de l'organisation de la cible (403 `ScopePermissionsException`).
- Appelée à **deux niveaux** (défense en profondeur) :
  1. `UserService.startImpersonation` — endpoint `POST /users/:id/impersonate` ;
  2. **`AuthMiddleware.resolveImpersonatedUser`** — indispensable : c'est le middleware qui applique l'identité à chaque requête via le header `x-impersonate-user-id`, qui peut être posé sans jamais passer par l'endpoint. Le catch du middleware re-lève désormais `ScopePermissionsException` (sinon le 403 devenait un 401 trompeur).
- **Front** : `canImpersonate` (`UserActions.vue`) alignée sur `canEditUser` — le bouton « Se connecter en tant que » n'est plus proposé hors périmètre.
- Swagger : description du 403 de l'endpoint enrichie ; `swagger.yaml` régénéré.

## Tests

- **Unitaires back** : 5 cas `assertCanImpersonate` dans `scoped-permission.service.spec.ts` (sans scope, dans/hors périmètre, cible sans organisation, cible inconnue → 404) ; `auth.middleware.spec.ts` adapté à la nouvelle injection.
- **e2e back** (nouveau `backend/tests/impersonation.e2e-spec.ts`) : admin global OK partout, admin scopé 200 dans le périmètre / **403 sur l'endpoint ET sur le header posé à la main**, non-admin 403. `OrganizationFaker` accepte désormais un `path` déterministe.
- **Front** : 3 cas vitest sur la visibilité du bouton (global, scopé dans/hors périmètre).
- **Playwright** : **IMP-08** (utilise le seed QA `scope-admin`/`qa-target`/`qa-outside`) — 24/24 sur chromium/firefox/webkit, IMP-01→07 sans régression.
- Protocole QA `impersonation.md` : cas IMP-08 ajouté.
- Suite backend complète 338 ✅, `tsc` hôte + conteneur 0 erreur, `vue-tsc` 0 erreur, vitest 30 ✅, ESLint/Prettier ✅.

## Docs

- `docs/06-permissions-et-securite.md` : nouvelle section 6.3 « Effet sur l'impersonation ».

## Hors périmètre (déjà tracé dans l'issue)

- La liste admin des utilisateurs n'est pas filtrée par scope (`user.service.ts`, `_requestor` inutilisé) : un admin local voit tous les utilisateurs mais ne peut plus ni les éditer ni les impersonner hors périmètre.