### PR TITLE
feat: middleware de traçabilité centralisé (ActionLog) + audit des actions sous impersonification

### DIFF
--- a/backend/prisma/docs/schema.md
+++ b/backend/prisma/docs/schema.md
@@ -1138,6 +1138,16 @@ Properties as follows:
 
 ```mermaid
 erDiagram
+"ActionLog" {
+  String id PK
+  DateTime createdAt
+  String method
+  String path
+  Int statusCode
+  String userId FK
+  String impersonatorId FK "nullable"
+  String impersonationLogId FK "nullable"
+}
 "EmailLog" {
   String id PK
   String to
@@ -1167,7 +1177,27 @@ erDiagram
   DateTime startedAt
   DateTime endedAt "nullable"
 }
+"ActionLog" }o--o| "ImpersonationLog" : impersonationLog
 ```
+
+### `ActionLog`
+
+Journal centralisé des actions (#2224) : une entrée par requête HTTP
+mutante (POST/PATCH/PUT/DELETE), écrite automatiquement par
+l'ActionLogMiddleware, sans intervention des services métier.
+Trace l'identité effective ET l'administrateur réel lorsque l'action est
+faite sous impersonation, avec rattachement à la session.
+
+Properties as follows:
+
+- `id`:
+- `createdAt`:
+- `method`: Méthode HTTP de la requête
+- `path`: Chemin de la requête (sans query string)
+- `statusCode`: Code de statut HTTP renvoyé (y compris les refus 4xx)
+- `userId`: Identité effective de la requête (la cible en cas d'impersonation)
+- `impersonatorId`: Administrateur réel lorsque l'action a été faite sous impersonation
+- `impersonationLogId`: Session d'impersonation à laquelle l'action se rattache
 
 ### `EmailLog`
 

--- a/backend/prisma/migrations/20260807131841_add_action_log/migration.sql
+++ b/backend/prisma/migrations/20260807131841_add_action_log/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE "ActionLog" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "method" TEXT NOT NULL,
+    "path" TEXT NOT NULL,
+    "statusCode" INTEGER NOT NULL,
+    "userId" TEXT NOT NULL,
+    "impersonatorId" TEXT,
+    "impersonationLogId" TEXT,
+
+    CONSTRAINT "ActionLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ActionLog_userId_createdAt_idx" ON "ActionLog"("userId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ActionLog_impersonatorId_createdAt_idx" ON "ActionLog"("impersonatorId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "ActionLog" ADD CONSTRAINT "ActionLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ActionLog" ADD CONSTRAINT "ActionLog_impersonatorId_fkey" FOREIGN KEY ("impersonatorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ActionLog" ADD CONSTRAINT "ActionLog_impersonationLogId_fkey" FOREIGN KEY ("impersonationLogId") REFERENCES "ImpersonationLog"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/backend/prisma/schema/action-log.prisma
+++ b/backend/prisma/schema/action-log.prisma
@@ -1,0 +1,31 @@
+/// Journal centralisé des actions (#2224) : une entrée par requête HTTP
+/// mutante (POST/PATCH/PUT/DELETE), écrite automatiquement par
+/// l'ActionLogMiddleware, sans intervention des services métier.
+/// Trace l'identité effective ET l'administrateur réel lorsque l'action est
+/// faite sous impersonation, avec rattachement à la session.
+model ActionLog {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+
+  /// Méthode HTTP de la requête
+  method     String
+  /// Chemin de la requête (sans query string)
+  path       String
+  /// Code de statut HTTP renvoyé (y compris les refus 4xx)
+  statusCode Int
+
+  /// Identité effective de la requête (la cible en cas d'impersonation)
+  userId String
+  user   User   @relation("ActionLogUser", fields: [userId], references: [id], onDelete: Restrict)
+
+  /// Administrateur réel lorsque l'action a été faite sous impersonation
+  impersonatorId String?
+  impersonator   User?   @relation("ActionLogImpersonator", fields: [impersonatorId], references: [id], onDelete: Restrict)
+
+  /// Session d'impersonation à laquelle l'action se rattache
+  impersonationLogId String?
+  impersonationLog   ImpersonationLog? @relation(fields: [impersonationLogId], references: [id], onDelete: SetNull)
+
+  @@index([userId, createdAt])
+  @@index([impersonatorId, createdAt])
+}

--- a/backend/prisma/schema/user-log.prisma
+++ b/backend/prisma/schema/user-log.prisma
@@ -35,5 +35,8 @@ model ImpersonationLog {
   /// Fin de la session d'impersonation (null tant qu'elle est active)
   endedAt   DateTime?
 
+  /// Actions journalisées pendant cette session (#2224)
+  actions   ActionLog[]
+
   @@index([adminId, startedAt])
 }

--- a/backend/prisma/schema/users.prisma
+++ b/backend/prisma/schema/users.prisma
@@ -60,6 +60,11 @@ model User {
   /// Administrateur ayant bloqué cet utilisateur. Pas de jointure explicite
   /// (mêmes raisons que UserPermissionLog.changedById : éviter les soucis de cascade).
   blockedById                String?
+
+  /// Actions journalisées sous cette identité (effective)
+  actionLogs                ActionLog[]         @relation("ActionLogUser")
+  /// Actions réellement effectuées par cet utilisateur sous une identité empruntée
+  actionLogsAsImpersonator  ActionLog[]         @relation("ActionLogImpersonator")
 }
 
 /// @namespace Roles

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { LabelsModule } from "./labels/labels.module";
 import { LinksModule } from "./links/links.module";
 import { LoggerModule } from "./logger/logger.module";
 import { MetadatasModule } from "./metadatas/metadatas.module";
+import { ActionLogMiddleware } from "./middlewares/action-log.middleware";
 import { AuthMiddleware } from "./middlewares/auth.middleware";
 import { ReportModule } from "./report/report.module";
 import { OrganizationsModule } from "./organizations/organizations.module";
@@ -85,7 +86,7 @@ import { MaintenanceMiddleware } from "./maintenance/maintenance.middleware";
     HealthCheckModule,
   ],
   controllers: [AppController],
-  providers: [AppService, LoggingService, AuthMiddleware],
+  providers: [AppService, LoggingService, AuthMiddleware, ActionLogMiddleware],
   exports: [LoggingService],
 })
 export class AppModule implements NestModule {
@@ -107,6 +108,13 @@ export class AppModule implements NestModule {
 
     consumer
       .apply(AuthMiddleware)
+      .exclude(...unauthenticatedRoutes)
+      .forRoutes("{*splat}");
+
+    // Après AuthMiddleware : journalise les requêtes mutantes avec l'identité
+    // effective et l'éventuel impersonator posés par celui-ci (#2224).
+    consumer
+      .apply(ActionLogMiddleware)
       .exclude(...unauthenticatedRoutes)
       .forRoutes("{*splat}");
   }

--- a/backend/src/middlewares/action-log.middleware.ts
+++ b/backend/src/middlewares/action-log.middleware.ts
@@ -1,0 +1,82 @@
+import { Injectable, NestMiddleware } from "@nestjs/common";
+import { NextFunction, Request, Response } from "express";
+import { LoggerService } from "src/logger/logger.service";
+import { PrismaService } from "src/prisma/prisma.service";
+import { Requestor } from "src/user/entities/user.entity";
+
+const MUTATING_METHODS = new Set(["POST", "PATCH", "PUT", "DELETE"]);
+
+/**
+ * Journal centralisé des actions (#2224) : enregistre chaque requête mutante
+ * dans `ActionLog`, avec l'identité effective et, le cas échéant,
+ * l'administrateur réel derrière une impersonation (rattachée à sa session).
+ *
+ * Branché APRÈS AuthMiddleware (qui pose `req.user` / `req.impersonator`).
+ * L'écriture se fait sur l'évènement `finish` de la réponse : le code de
+ * statut final est connu (y compris les refus 4xx des guards) et la requête
+ * n'est jamais ralentie ni mise en échec par la journalisation.
+ */
+@Injectable()
+export class ActionLogMiddleware implements NestMiddleware {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly logger: LoggerService,
+  ) {}
+
+  use(req: Request, res: Response, next: NextFunction) {
+    if (!MUTATING_METHODS.has(req.method)) {
+      return next();
+    }
+
+    res.on("finish", () => {
+      const user = req.user;
+      // Pas d'utilisateur résolu (401 d'authentification) : rien à attribuer.
+      if (!user) {
+        return;
+      }
+      void this.record(req, res, user, req.impersonator ?? null);
+    });
+
+    next();
+  }
+
+  private async record(
+    req: Request,
+    res: Response,
+    user: Requestor,
+    impersonator: Requestor | null,
+  ): Promise<void> {
+    try {
+      let impersonationLogId: string | null = null;
+      if (impersonator) {
+        const openSession = await this.prisma.impersonationLog.findFirst({
+          where: {
+            adminId: impersonator.id,
+            targetId: user.id,
+            endedAt: null,
+          },
+          orderBy: { startedAt: "desc" },
+          select: { id: true },
+        });
+        impersonationLogId = openSession?.id ?? null;
+      }
+
+      await this.prisma.actionLog.create({
+        data: {
+          method: req.method,
+          path: (req.originalUrl ?? req.url).split("?")[0],
+          statusCode: res.statusCode,
+          userId: user.id,
+          impersonatorId: impersonator?.id ?? null,
+          impersonationLogId,
+        },
+      });
+    } catch (error) {
+      // La journalisation ne doit jamais faire échouer la requête.
+      this.logger.error(
+        "[ActionLog] Échec de journalisation d'une action",
+        error,
+      );
+    }
+  }
+}

--- a/backend/tests/action-log.e2e-spec.ts
+++ b/backend/tests/action-log.e2e-spec.ts
@@ -1,0 +1,129 @@
+import type { ActionLog } from "@prisma/client";
+import type { UserFakerReturnType } from "./fakers/user.faker";
+import { Roles } from "@prisma/client";
+import request from "supertest";
+import { getPrismaClient } from "./fakers/prisma";
+import { UserFaker } from "./fakers/user.faker";
+import { getToken } from "./getToken";
+import { setupTestSuite } from "./setup";
+
+const IMPERSONATE_HEADER = "x-impersonate-user-id";
+
+/** L'écriture du log est asynchrone (fire-and-forget) : on poll jusqu'à 2 s. */
+async function waitForActionLog(
+  where: Record<string, unknown>,
+): Promise<ActionLog | null> {
+  const prisma = getPrismaClient();
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const log = await prisma.actionLog.findFirst({
+      where,
+      orderBy: { createdAt: "desc" },
+    });
+    if (log) return log;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return null;
+}
+
+describe("ActionLog — middleware de traçabilité (#2224)", () => {
+  const app = setupTestSuite();
+
+  let contributor: UserFakerReturnType;
+  let admin: UserFakerReturnType;
+  let target: UserFakerReturnType;
+  let visitor: UserFakerReturnType;
+  let CONTRIBUTOR_TOKEN: string;
+  let ADMIN_TOKEN: string;
+  let VISITOR_TOKEN: string;
+
+  beforeAll(async () => {
+    contributor = await UserFaker.create({ role: Roles.CONTRIBUTOR });
+    admin = await UserFaker.create({ role: Roles.ADMIN });
+    target = await UserFaker.create({ role: Roles.VISITOR });
+    visitor = await UserFaker.create({ role: Roles.VISITOR });
+    CONTRIBUTOR_TOKEN = await getToken(contributor);
+    ADMIN_TOKEN = await getToken(admin);
+    VISITOR_TOKEN = await getToken(visitor);
+  });
+
+  it("journalise une requête mutante avec l'identité effective", async () => {
+    await request(app().getHttpServer())
+      .post("/organizations")
+      .set("Authorization", `Bearer ${CONTRIBUTOR_TOKEN}`)
+      .send({ path: `E2E/ACTIONLOG/${Date.now()}` })
+      .expect(201);
+
+    const log = await waitForActionLog({
+      userId: contributor.id,
+      method: "POST",
+      path: "/organizations",
+    });
+    expect(log).not.toBeNull();
+    expect(log!.statusCode).toBe(201);
+    expect(log!.impersonatorId).toBeNull();
+    expect(log!.impersonationLogId).toBeNull();
+  });
+
+  it("ne journalise pas les lectures (GET)", async () => {
+    await request(app().getHttpServer())
+      .get("/organizations")
+      .set("Authorization", `Bearer ${CONTRIBUTOR_TOKEN}`)
+      .expect(200);
+
+    // Laisse le temps à un éventuel log fautif d'être écrit.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const prisma = getPrismaClient();
+    const getLogs = await prisma.actionLog.count({
+      where: { userId: contributor.id, method: "GET" },
+    });
+    expect(getLogs).toBe(0);
+  });
+
+  it("journalise les refus avec leur code de statut", async () => {
+    await request(app().getHttpServer())
+      .post("/organizations")
+      .set("Authorization", `Bearer ${VISITOR_TOKEN}`)
+      .send({ path: "E2E/ACTIONLOG/REFUSE" })
+      .expect(403);
+
+    const log = await waitForActionLog({
+      userId: visitor.id,
+      method: "POST",
+      path: "/organizations",
+    });
+    expect(log).not.toBeNull();
+    expect(log!.statusCode).toBe(403);
+  });
+
+  it("attribue les actions sous impersonation à l'admin réel et les rattache à la session", async () => {
+    // Ouvre une session d'impersonation (crée l'ImpersonationLog).
+    await request(app().getHttpServer())
+      .post(`/users/${target.id}/impersonate`)
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .expect(200);
+
+    const prisma = getPrismaClient();
+    const session = await prisma.impersonationLog.findFirst({
+      where: { adminId: admin.id, targetId: target.id, endedAt: null },
+      orderBy: { startedAt: "desc" },
+    });
+    expect(session).not.toBeNull();
+
+    // Action mutante effectuée SOUS l'identité de la cible (header posé).
+    await request(app().getHttpServer())
+      .patch("/users/me")
+      .set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      .set(IMPERSONATE_HEADER, target.id)
+      .send({ emailNotificationsEnabled: false })
+      .expect(200);
+
+    const log = await waitForActionLog({
+      userId: target.id,
+      impersonatorId: admin.id,
+      method: "PATCH",
+    });
+    expect(log).not.toBeNull();
+    expect(log!.path).toBe("/users/me");
+    expect(log!.impersonationLogId).toBe(session!.id);
+  });
+});

--- a/docs/04-modele-de-donnees.md
+++ b/docs/04-modele-de-donnees.md
@@ -41,7 +41,7 @@ Les domaines sont les suivants :
 - **Catalogue de données** : familles, descriptions génériques, usages applicatifs, expositions et niveaux de sensibilité (`data.prisma`).
 - **Utilisateurs et acteurs** : comptes utilisateurs, acteurs métier/techniques et leurs types (`users.prisma`).
 - **Organisations** : arborescence des structures et table d'override MAIA (`organization.prisma`), directions métier MOA (`business-division.prisma`).
-- **Audit** : journal transverse des modifications (`metadata.prisma`).
+- **Audit** : journal transverse des modifications (`metadata.prisma`) et journal centralisé des actions HTTP mutantes (`action-log.prisma`, écrit par l'`ActionLogMiddleware` avec l'identité effective, l'éventuel impersonator réel et la session `ImpersonationLog` associée).
 - **Labels et tags** : étiquetage et catégorisation (`labels.prisma`, `tag.prisma`).
 - **Ressources externes** (`externals.prisma`), **dette technique** (`technical-debt-info.prisma`), **signalements** (`report.prisma`), **journaux de notification** (`notification-log.prisma`), **permissions** (`permissions.prisma`), **tokens** (`token.prisma`), **journaux utilisateur** (`user-log.prisma`) et **statistiques** (`stats.prisma`).
 

--- a/docs/06-permissions-et-securite.md
+++ b/docs/06-permissions-et-securite.md
@@ -283,7 +283,7 @@ Les composants passent en second argument les permissions applicatives obtenues 
 - **Contexte HTTPS obligatoire.** Le flux OIDC navigateur exige TLS ; en HTTP, attendre des boucles 302 et des 401 intermittents.
 - **Validation du jeton dans le backend.** La validation du JWT (signature via JWKS du fournisseur) est faite par l'`AuthMiddleware` du backend, seul garant de la vérification.
 - **Validation stricte des entrées.** Les DTO NestJS (class-validator) et le typage Prisma encadrent les données ; conserver une validation stricte sur tout nouvel endpoint.
-- **Audit.** Les changements de permissions (`UserPermissionLog`) et les connexions (`UserConnexionLog`) sont journalisés ; préserver ces traces.
+- **Audit.** Les changements de permissions (`UserPermissionLog`) et les connexions (`UserConnexionLog`) sont journalisés ; préserver ces traces. Depuis #2224, toute requête **mutante** est en outre journalisée dans `ActionLog` par l'`ActionLogMiddleware` (méthode, chemin, code de statut, identité effective) ; sous impersonation, l'**administrateur réel** est enregistré (`impersonatorId`) et l'action rattachée à sa session `ImpersonationLog` — on peut ainsi reconstituer tout ce qu'un admin a fait sous une identité empruntée.
 - **Respect du périmètre.** Toujours nommer `applicationId` le paramètre de route contextuel pour activer le contrôle par application, et respecter le scope organisationnel pour l'administration des utilisateurs.
 
 ---

--- a/docs/08-architecture-backend.md
+++ b/docs/08-architecture-backend.md
@@ -46,6 +46,8 @@ consumer
 
 `MaintenanceMiddleware` s'appuie sur `pg_is_in_recovery()` avec un cache configurable. Pendant la maintenance, les méthodes `GET`, `HEAD` et `OPTIONS` restent autorisées ; les autres reçoivent `503 Service Unavailable`.
 
+Un troisième middleware, `ActionLogMiddleware` (`backend/src/middlewares/action-log.middleware.ts`, #2224), est appliqué **après** `AuthMiddleware` : il journalise chaque requête **mutante** (POST/PATCH/PUT/DELETE) dans le modèle `ActionLog` — méthode, chemin, code de statut final (y compris les refus 4xx), identité effective, et, si la requête est faite sous impersonation, l'administrateur réel avec rattachement à la session `ImpersonationLog` ouverte. L'écriture se fait sur l'évènement `finish` de la réponse, en fire-and-forget : elle ne ralentit ni ne fait jamais échouer la requête.
+
 `AuthMiddleware` (`backend/src/middlewares/auth.middleware.ts`) accepte deux modes d'authentification : un en-tête de clé d'API résolu via `TokenService`, ou un jeton JWT OIDC porté par l'en-tête `Authorization`. Le JWT est vérifié contre le JWKS distant (`jose`) — sauf si `DISABLE_JWT_VALIDATION` est positionné, auquel cas le jeton est seulement décodé. En maintenance, seuls les utilisateurs existants sont chargés et le journal de connexion n'est pas écrit. En cas de succès, le middleware enrichit `req.user` avec les permissions calculées depuis le rôle (`roleToPermissions`). En cas d'échec, une `UnauthorizedException` est levée. Le détail de l'authentification et du modèle de permissions est traité dans [Permissions et sécurité](./06-permissions-et-securite.md).
 
 ## Anatomie d'un module


### PR DESCRIPTION
Closes #2224

## Quoi

Un **journal centralisé des actions**, écrit automatiquement par un middleware — sans toucher aux services métier — et qui ferme le trou d'audit de l'impersonification : jusqu'ici, une action faite sous identité empruntée était attribuée à la cible (`Metadata.createdById` = identité effective) sans aucune trace de l'admin réel.

## Comment

- **Modèle `ActionLog`** (`action-log.prisma` + migration `add_action_log`) : `method`, `path`, `statusCode`, `userId` (identité effective), `impersonatorId?` (admin réel), `impersonationLogId?` (rattachement à la session ouverte). Index sur `(userId, createdAt)` et `(impersonatorId, createdAt)`.
- **`ActionLogMiddleware`** branché **après** `AuthMiddleware` dans `AppModule.configure()` :
  - ne journalise que les requêtes **mutantes** (POST/PATCH/PUT/DELETE) ;
  - écrit sur l'évènement `finish` de la réponse → capture le **statut final, y compris les refus 4xx des guards** (un intercepteur Nest ne les verrait pas) ;
  - **fire-and-forget** : la journalisation ne ralentit jamais la requête et ses erreurs sont avalées (loggées) ;
  - sous impersonification (`req.impersonator`), enregistre l'admin réel et retrouve la session `ImpersonationLog` ouverte → on peut reconstituer **tout ce qu'un admin a fait sous une identité empruntée** (complète #2217 côté audit).

## Tests

Nouveau `backend/tests/action-log.e2e-spec.ts` (4 cas) : mutation journalisée avec identité effective ; GET non journalisé ; refus 403 journalisé avec son statut ; mutation sous header d'impersonification → `impersonatorId` + rattachement à la session. Suite backend complète **331 ✅**, `tsc` hôte + conteneur 0 erreur, ESLint/Prettier ✅. Aucun changement d'API (swagger inchangé), aucun changement front.

## Docs

- `docs/08-architecture-backend.md` (chaîne des middlewares), `docs/04-modele-de-donnees.md` (section Audit), `docs/06-permissions-et-securite.md` (bonnes pratiques — audit).

## Suites possibles (volontairement hors PR, cf. issue)

- Politique de rétention/purge des logs.
- Exposition dans le panel admin (consultation des actions d'une session d'impersonification).
- Enrichissement `resourceType`/`resourceId` extraits des routes.