### PR TITLE
feat(technology): vérification de fin de vie complète via endoflife.date (#1789)

### DIFF
--- a/backend/prisma/docs/schema.md
+++ b/backend/prisma/docs/schema.md
@@ -1107,6 +1107,9 @@ erDiagram
   String(2048) docUrl "nullable"
   DateTime eolDate "nullable"
   DateTime eolCheckedAt "nullable"
+  String(100) eolProduct "nullable"
+  DateTime eoasDate "nullable"
+  String(50) latestVersion "nullable"
 }
 ```
 
@@ -1127,6 +1130,9 @@ Properties as follows:
 - `docUrl`: Lien documentaire (URL) associé au produit
 - `eolDate`: Date de fin de support/vie de la version (renseignée via endoflife.date)
 - `eolCheckedAt`: Date de dernière vérification du statut de fin de vie
+- `eolProduct`: Slug produit endoflife.date résolu (null + eolCheckedAt renseigné = produit non suivi)
+- `eoasDate`: Date de fin de support actif de la version (renseignée via endoflife.date)
+- `latestVersion`: Dernière version publiée du cycle correspondant (renseignée via endoflife.date)
 
 ## default
 

--- a/backend/prisma/migrations/20260810070000_add_technology_eol_details/migration.sql
+++ b/backend/prisma/migrations/20260810070000_add_technology_eol_details/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "TechnologyStack" ADD COLUMN     "eoasDate" TIMESTAMP(3),
+ADD COLUMN     "eolProduct" VARCHAR(100),
+ADD COLUMN     "latestVersion" VARCHAR(50);

--- a/backend/prisma/schema/technology.prisma
+++ b/backend/prisma/schema/technology.prisma
@@ -25,6 +25,12 @@ model TechnologyStack {
   eolDate       DateTime?
   /// Date de dernière vérification du statut de fin de vie
   eolCheckedAt  DateTime?
+  /// Slug produit endoflife.date résolu (null + eolCheckedAt renseigné = produit non suivi)
+  eolProduct    String?   @db.VarChar(100)
+  /// Date de fin de support actif de la version (renseignée via endoflife.date)
+  eoasDate      DateTime?
+  /// Dernière version publiée du cycle correspondant (renseignée via endoflife.date)
+  latestVersion String?   @db.VarChar(50)
 
   metadatas Metadata[] @relation()
 

--- a/backend/src/technology/dto/technology.dto.ts
+++ b/backend/src/technology/dto/technology.dto.ts
@@ -84,6 +84,77 @@ export class TechnologyDto extends CreateTechnologyDto {
   @IsOptional()
   @IsDateString()
   eolCheckedAt?: string | null;
+
+  @ApiProperty({
+    example: "postgresql",
+    description:
+      "Slug produit endoflife.date résolu (null + eolCheckedAt renseigné = produit non suivi par endoflife.date)",
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  eolProduct?: string | null;
+
+  @ApiProperty({
+    type: String,
+    format: "date-time",
+    example: "2026-10-20",
+    description:
+      "Date de fin de support actif de la version (source endoflife.date)",
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsDateString()
+  eoasDate?: string | null;
+
+  @ApiProperty({
+    example: "20.19.5",
+    description:
+      "Dernière version publiée du cycle correspondant (source endoflife.date)",
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  latestVersion?: string | null;
+}
+
+export class EolProductDto {
+  @ApiProperty({
+    example: "nodejs",
+    description: "Slug produit endoflife.date",
+  })
+  @IsString()
+  name: string;
+
+  @ApiProperty({
+    example: "Node.js",
+    description: "Libellé d'affichage du produit",
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  label?: string | null;
+
+  @ApiProperty({
+    example: "database",
+    description: "Catégorie du produit",
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  category?: string | null;
+
+  @ApiProperty({
+    example: ["node"],
+    description: "Alias reconnus pour ce produit",
+    type: [String],
+  })
+  aliases: string[];
 }
 
 export class TechnologyErrorResponseDto {

--- a/backend/src/technology/entities/technology.entity.ts
+++ b/backend/src/technology/entities/technology.entity.ts
@@ -7,4 +7,7 @@ export class TechnologyStack {
   docUrl?: string;
   eolDate?: Date;
   eolCheckedAt?: Date;
+  eolProduct?: string;
+  eoasDate?: Date;
+  latestVersion?: string;
 }

--- a/backend/src/technology/technology.controller.ts
+++ b/backend/src/technology/technology.controller.ts
@@ -25,6 +25,7 @@ import { PermissionGuard } from "src/common/guards/permission.guard";
 import { UserId } from "src/common/decorators/user-id.decorator";
 import {
   CreateTechnologyDto,
+  EolProductDto,
   TechnologyDto,
   TechnologyErrorResponseDto,
 } from "./dto/technology.dto";
@@ -56,6 +57,22 @@ export class TechnologyController {
   @ApiParam({ name: "applicationId", description: "ID de l'application" })
   async findAll(@Param("applicationId") applicationId: string) {
     return this.technologyService.findAllByApplicationId(applicationId);
+  }
+
+  @Get("eol-products")
+  @RequiredPermissions([Permission.TechnologyRead])
+  @ApiOperation({
+    summary:
+      "Lister les produits suivis par endoflife.date (autocomplétion de la saisie produit)",
+  })
+  @ApiOkResponse({
+    description:
+      "Catalogue des produits endoflife.date (vide si le catalogue est indisponible)",
+    type: [EolProductDto],
+  })
+  @ApiParam({ name: "applicationId", description: "ID de l'application" })
+  async listEolProducts() {
+    return this.technologyService.listEolProducts();
   }
 
   @Post()

--- a/backend/src/technology/technology.service.ts
+++ b/backend/src/technology/technology.service.ts
@@ -11,10 +11,12 @@ import { TechnologyStack } from "./entities/technology.entity";
 import { ServiceOptions } from "src/common/utils/types";
 import { ApplicationService } from "src/applications/application.service";
 import {
-  fetchProductReleases,
-  parseEolDate,
-  toEndoflifeProduct,
-  type EndoflifeRelease,
+  fetchProductCatalog,
+  normalizeProductKey,
+  parseEolInfo,
+  resolveProductReleases,
+  type EndoflifeProduct,
+  type EolResolution,
 } from "./utils/endoflife.utils";
 
 // Au-delà de ce délai, on rafraîchit paresseusement la fin de vie au GET.
@@ -39,20 +41,56 @@ export class TechnologyService extends BaseService<TechnologyStack> {
     );
   }
 
-  // Résout la fin de vie à partir du PRODUIT (et de la version). En cas d'ÉCHEC réseau/HTTP
-  // (releases === null, distinct d'un produit connu sans EOL qui renvoie []), on ne renvoie
-  // RIEN : la valeur existante n'est ni écrasée ni son TTL réarmé (retentée au prochain GET).
+  // Traduit une résolution endoflife en champs à persister. Trois cas :
+  // - « unavailable » (réseau/API en échec) → AUCUN champ : la valeur existante n'est
+  //   ni écrasée ni son TTL réarmé (retentée au prochain GET) ;
+  // - « unknown-product » → eolProduct null + eolCheckedAt : le front peut signaler
+  //   « produit non suivi par endoflife.date » (distinct d'un produit sans EOL publiée) ;
+  // - « resolved » → slug + dates EOL/fin de support actif + dernière version du cycle.
+  private eolFieldsFrom(
+    resolution: EolResolution,
+    version?: string | null,
+  ): {
+    eolProduct?: string | null;
+    eolDate?: Date | null;
+    eoasDate?: Date | null;
+    latestVersion?: string | null;
+    eolCheckedAt?: Date | null;
+  } {
+    if (resolution.status === "unavailable") return {};
+    const eolCheckedAt = new Date();
+    if (resolution.status === "unknown-product") {
+      return {
+        eolProduct: null,
+        eolDate: null,
+        eoasDate: null,
+        latestVersion: null,
+        eolCheckedAt,
+      };
+    }
+    return {
+      eolProduct: resolution.slug,
+      ...parseEolInfo(resolution.releases, version ?? ""),
+      eolCheckedAt,
+    };
+  }
+
+  // Résout la fin de vie à partir du PRODUIT (et de la version, optionnelle : sans
+  // version on résout quand même le produit pour détecter les produits non suivis).
   private async resolveEol(
     product: string,
     version?: string | null,
-  ): Promise<{ eolDate?: Date | null; eolCheckedAt?: Date | null }> {
-    if (this.eolDisabled() || !product?.trim() || !version?.trim()) return {};
-    const releases = await fetchProductReleases(product);
-    if (releases === null) return {};
-    return {
-      eolDate: parseEolDate(releases, version),
-      eolCheckedAt: new Date(),
-    };
+  ): Promise<ReturnType<TechnologyService["eolFieldsFrom"]>> {
+    if (this.eolDisabled() || !product?.trim()) return {};
+    return this.eolFieldsFrom(await resolveProductReleases(product), version);
+  }
+
+  // Catalogue des produits suivis par endoflife.date (autocomplétion côté front).
+  // Best-effort : liste vide si le catalogue n'a jamais pu être récupéré (le front
+  // retombe alors sur la saisie libre).
+  async listEolProducts(): Promise<EndoflifeProduct[]> {
+    if (this.eolDisabled()) return [];
+    return (await fetchProductCatalog()) ?? [];
   }
 
   async findAllByApplicationId(
@@ -66,19 +104,16 @@ export class TechnologyService extends BaseService<TechnologyStack> {
     if (this.eolDisabled()) return rows;
 
     // Rafraîchissement paresseux best-effort des lignes dont la fin de vie n'a jamais
-    // été calculée ou dépasse le TTL. Les cycles d'un produit ne sont récupérés qu'UNE
-    // fois par requête (mémoïsation par slug produit) puis appliqués à chaque version.
+    // été calculée ou dépasse le TTL. La résolution d'un produit n'est faite qu'UNE
+    // fois par requête (mémoïsation par clé produit) puis appliquée à chaque version.
     const now = Date.now();
-    const releasesBySlug = new Map<
-      string,
-      Promise<EndoflifeRelease[] | null>
-    >();
-    const getReleases = (product: string) => {
-      const slug = toEndoflifeProduct(product);
-      let pending = releasesBySlug.get(slug);
+    const resolutionsByKey = new Map<string, Promise<EolResolution>>();
+    const getResolution = (product: string) => {
+      const key = normalizeProductKey(product);
+      let pending = resolutionsByKey.get(key);
       if (!pending) {
-        pending = fetchProductReleases(product);
-        releasesBySlug.set(slug, pending);
+        pending = resolveProductReleases(product);
+        resolutionsByKey.set(key, pending);
       }
       return pending;
     };
@@ -88,20 +123,21 @@ export class TechnologyService extends BaseService<TechnologyStack> {
         const stale =
           !row.eolCheckedAt ||
           now - new Date(row.eolCheckedAt).getTime() > EOL_REFRESH_TTL_MS;
-        if (!stale || !row.version) return row;
+        if (!stale) return row;
 
-        const releases = await getReleases(row.product);
+        const fields = this.eolFieldsFrom(
+          await getResolution(row.product),
+          row.version,
+        );
         // Échec réseau/HTTP : on NE réécrit PAS — sinon on écraserait une date valide par
         // null et on figerait la ligne pour tout le TTL. On la laisse « périmée » : elle
         // sera retentée au prochain GET dès qu'endoflife.date répond de nouveau.
-        if (releases === null) return row;
-        const eolDate = parseEolDate(releases, row.version);
-        const eolCheckedAt = new Date();
+        if (!fields.eolCheckedAt) return row;
         // Persistance best-effort : un échec d'écriture ne doit pas casser la lecture.
         await this.prisma.technologyStack
-          .update({ where: { id: row.id }, data: { eolDate, eolCheckedAt } })
+          .update({ where: { id: row.id }, data: fields })
           .catch(() => undefined);
-        return { ...row, eolDate, eolCheckedAt };
+        return { ...row, ...fields };
       }),
     );
   }

--- a/backend/src/technology/utils/endoflife.utils.spec.ts
+++ b/backend/src/technology/utils/endoflife.utils.spec.ts
@@ -1,19 +1,68 @@
 import {
+  type EndoflifeProduct,
   type EndoflifeRelease,
+  buildProductIndex,
+  lookupProductSlug,
   matchRelease,
+  normalizeProductKey,
   parseEolDate,
+  parseEolInfo,
   toEndoflifeProduct,
 } from "./endoflife.utils";
 
 const RELEASES: EndoflifeRelease[] = [
-  { name: "26", isEol: false, eolFrom: "2029-04-30" },
-  { name: "24", isEol: false, eolFrom: "2028-04-30" },
+  {
+    name: "26",
+    isEol: false,
+    eolFrom: "2029-04-30",
+    isEoas: false,
+    eoasFrom: "2027-10-27",
+    latest: { name: "26.7.0" },
+  },
+  {
+    name: "24",
+    isEol: false,
+    eolFrom: "2028-04-30",
+    isEoas: false,
+    eoasFrom: "2026-10-20",
+    latest: { name: "24.5.0" },
+  },
   { name: "20", isEol: false, eolFrom: "2026-04-30" },
   { name: "18", isEol: true, eolFrom: "2025-04-30" },
 ];
 
+const CATALOG: EndoflifeProduct[] = [
+  {
+    name: "nodejs",
+    label: "Node.js",
+    category: "framework",
+    aliases: ["node"],
+  },
+  {
+    name: "postgresql",
+    label: "PostgreSQL",
+    category: "db",
+    aliases: ["postgres"],
+  },
+  {
+    name: "mssqlserver",
+    label: "Microsoft SQL Server",
+    category: "db",
+    aliases: ["mssql", "sql-server"],
+  },
+  { name: "dotnet", label: ".NET", category: "framework", aliases: [] },
+];
+
 describe("endoflife.utils", () => {
-  describe("toEndoflifeProduct", () => {
+  describe("normalizeProductKey", () => {
+    it("normalise un nom libre en clé de comparaison", () => {
+      expect(normalizeProductKey("Node.js")).toBe("nodejs");
+      expect(normalizeProductKey("  SQL Server  ")).toBe("sqlserver");
+      expect(normalizeProductKey(".NET")).toBe("net");
+    });
+  });
+
+  describe("toEndoflifeProduct (mode dégradé sans catalogue)", () => {
     it("normalise un nom de produit en identifiant endoflife.date", () => {
       expect(toEndoflifeProduct("Node.js")).toBe("nodejs");
       expect(toEndoflifeProduct("PostgreSQL")).toBe("postgresql");
@@ -25,6 +74,35 @@ describe("endoflife.utils", () => {
       expect(toEndoflifeProduct(".NET")).toBe("dotnet");
       expect(toEndoflifeProduct(".NET Core")).toBe("dotnet");
       expect(toEndoflifeProduct("Postgres")).toBe("postgresql");
+    });
+  });
+
+  describe("buildProductIndex / lookupProductSlug", () => {
+    const index = buildProductIndex(CATALOG);
+
+    it("résout un produit par son slug, son label ou un alias officiel", () => {
+      expect(lookupProductSlug(index, "nodejs")).toBe("nodejs");
+      expect(lookupProductSlug(index, "Node.js")).toBe("nodejs");
+      expect(lookupProductSlug(index, "node")).toBe("nodejs");
+      expect(lookupProductSlug(index, "Microsoft SQL Server")).toBe(
+        "mssqlserver",
+      );
+      expect(lookupProductSlug(index, "sql-server")).toBe("mssqlserver");
+    });
+
+    it("est insensible à la casse, aux espaces et à la ponctuation", () => {
+      expect(lookupProductSlug(index, "  POSTGRES  ")).toBe("postgresql");
+      expect(lookupProductSlug(index, "Postgre SQL")).toBe("postgresql");
+    });
+
+    it("conserve les alias internes en complément du catalogue", () => {
+      expect(lookupProductSlug(index, ".NET Core")).toBe("dotnet");
+      expect(lookupProductSlug(index, "SQL Server")).toBe("mssqlserver");
+    });
+
+    it("renvoie null pour un produit absent du catalogue", () => {
+      expect(lookupProductSlug(index, "Logiciel Interne Maison")).toBeNull();
+      expect(lookupProductSlug(index, "")).toBeNull();
     });
   });
 
@@ -42,6 +120,28 @@ describe("endoflife.utils", () => {
       expect(matchRelease(RELEASES, "12.0")).toBeNull();
       expect(matchRelease(RELEASES, "")).toBeNull();
     });
+
+    it("se replie sur le libellé commercial du cycle (ex. SQL Server)", () => {
+      const releases: EndoflifeRelease[] = [
+        { name: "16.0", label: "2022 'Dallas'" },
+        { name: "15.0", label: "2019 'Aris/Seattle'", eolFrom: "2030-01-08" },
+        { name: "13.0-sp3", label: "2016 SP3" },
+      ];
+      expect(matchRelease(releases, "2019")?.name).toBe("15.0");
+      expect(matchRelease(releases, "2016 SP3")?.name).toBe("13.0-sp3");
+      // Frontière : « 2019 » ne doit pas matcher un label « 20191 »
+      expect(matchRelease([{ name: "x", label: "20191" }], "2019")).toBeNull();
+      // Le nom de cycle reste prioritaire sur le label
+      expect(matchRelease(releases, "16.0")?.name).toBe("16.0");
+    });
+
+    it("se replie sur le nom de code du cycle (ex. Debian)", () => {
+      const releases: EndoflifeRelease[] = [
+        { name: "13", codename: "trixie" },
+        { name: "12", codename: "bookworm", eolFrom: "2028-06-30" },
+      ];
+      expect(matchRelease(releases, "Bookworm")?.name).toBe("12");
+    });
   });
 
   describe("parseEolDate", () => {
@@ -57,6 +157,37 @@ describe("endoflife.utils", () => {
     it("renvoie null si le cycle n'a pas de date de fin de vie", () => {
       const releases: EndoflifeRelease[] = [{ name: "1", eolFrom: null }];
       expect(parseEolDate(releases, "1.0")).toBeNull();
+    });
+  });
+
+  describe("parseEolInfo", () => {
+    it("extrait EOL, fin de support actif et dernière version du cycle", () => {
+      expect(parseEolInfo(RELEASES, "24.1")).toEqual({
+        eolDate: new Date("2028-04-30"),
+        eoasDate: new Date("2026-10-20"),
+        latestVersion: "24.5.0",
+      });
+    });
+
+    it("renvoie des valeurs nulles pour les champs absents du cycle", () => {
+      expect(parseEolInfo(RELEASES, "20.11")).toEqual({
+        eolDate: new Date("2026-04-30"),
+        eoasDate: null,
+        latestVersion: null,
+      });
+    });
+
+    it("renvoie tout à null si la version ne correspond à aucun cycle", () => {
+      expect(parseEolInfo(RELEASES, "12.0")).toEqual({
+        eolDate: null,
+        eoasDate: null,
+        latestVersion: null,
+      });
+      expect(parseEolInfo(RELEASES, "")).toEqual({
+        eolDate: null,
+        eoasDate: null,
+        latestVersion: null,
+      });
     });
   });
 });

--- a/backend/src/technology/utils/endoflife.utils.ts
+++ b/backend/src/technology/utils/endoflife.utils.ts
@@ -1,19 +1,61 @@
 /// Intégration https://endoflife.date (API v1) pour déterminer la date de fin de
 /// vie / fin de support d'une technologie donnée à partir de sa version.
 /// Modèle « valeurs calculées + date de dernier calcul » (cf. ecoindex.utils.ts).
+///
+/// La résolution du produit s'appuie sur le catalogue `GET /products` (noms, labels
+/// et alias officiels, mis en cache en mémoire) plutôt que sur une normalisation
+/// aveugle : cela permet de distinguer « produit non suivi par endoflife.date »
+/// (statut `unknown-product`, persisté) d'une simple indisponibilité réseau
+/// (statut `unavailable`, aucune écriture).
 
 const ENDOFLIFE_BASE_URL = "https://endoflife.date/api/v1/products";
 const FETCH_TIMEOUT_MS = 5000;
+const CATALOG_TTL_MS = 24 * 60 * 60 * 1000; // 24 h
 
 export interface EndoflifeRelease {
   /// Nom du cycle de release (généralement le major, ex. « 20 », ou « 3.11 »)
   name: string;
+  /// Libellé commercial du cycle (ex. « 2019 'Aris/Seattle' » pour SQL Server 15.0)
+  label?: string | null;
+  /// Nom de code du cycle (ex. « bookworm » pour Debian 12)
+  codename?: string | null;
+  isLts?: boolean | null;
+  /// Fin de support actif (End of Active Support)
+  isEoas?: boolean | null;
+  eoasFrom?: string | null;
   isEol?: boolean | null;
   eolFrom?: string | null;
+  isMaintained?: boolean | null;
+  /// Dernière version publiée du cycle
+  latest?: { name?: string | null } | null;
 }
 
-/// Alias produit libre (normalisé `[a-z0-9]`) → slug endoflife.date, pour les cas où
-/// la normalisation par suppression des caractères spéciaux ne donne pas le bon slug.
+export interface EndoflifeProduct {
+  /// Slug produit endoflife.date (ex. « nodejs »)
+  name: string;
+  /// Libellé d'affichage (ex. « Node.js »)
+  label: string | null;
+  category: string | null;
+  aliases: string[];
+}
+
+/// Valeurs de fin de vie extraites pour une version donnée.
+export interface EolInfo {
+  eolDate: Date | null;
+  eoasDate: Date | null;
+  latestVersion: string | null;
+}
+
+export type EolResolution =
+  /// Produit reconnu : cycles de release récupérés
+  | { status: "resolved"; slug: string; releases: EndoflifeRelease[] }
+  /// Produit absent du catalogue endoflife.date (ou 404 en mode dégradé)
+  | { status: "unknown-product" }
+  /// API/réseau indisponible : ne rien écraser, retenter plus tard
+  | { status: "unavailable" };
+
+/// Alias produit libre (normalisé `[a-z0-9]`) → slug endoflife.date, en complément
+/// des alias officiels du catalogue (saisies courantes côté SI non couvertes).
 const PRODUCT_ALIASES: Record<string, string> = {
   sqlserver: "mssqlserver",
   net: "dotnet",
@@ -21,32 +63,90 @@ const PRODUCT_ALIASES: Record<string, string> = {
   postgres: "postgresql",
 };
 
-/// Normalise un nom de produit libre en identifiant produit endoflife.date
-/// (ex. « Node.js » → « nodejs », « PostgreSQL » → « postgresql », « SQL Server » →
-/// « mssqlserver », « .NET » → « dotnet »).
-export function toEndoflifeProduct(product: string): string {
-  const slug = product
+/// Normalise un nom libre en clé de comparaison (ex. « Node.js » → « nodejs »).
+export function normalizeProductKey(product: string): string {
+  return product
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]/g, "");
+}
+
+/// Normalisation historique (mode dégradé, sans catalogue) : clé + table d'alias.
+export function toEndoflifeProduct(product: string): string {
+  const slug = normalizeProductKey(product);
   return PRODUCT_ALIASES[slug] ?? slug;
 }
 
+/// Construit l'index clé normalisée → slug à partir du catalogue (slug, label,
+/// alias officiels, puis alias internes). Fonction pure (testable sans réseau).
+export function buildProductIndex(
+  products: EndoflifeProduct[],
+): Map<string, string> {
+  const index = new Map<string, string>();
+  const add = (key: string, slug: string) => {
+    const normalized = normalizeProductKey(key);
+    if (normalized && !index.has(normalized)) index.set(normalized, slug);
+  };
+  for (const product of products) {
+    add(product.name, product.name);
+    if (product.label) add(product.label, product.name);
+    for (const alias of product.aliases) add(alias, product.name);
+  }
+  for (const [alias, slug] of Object.entries(PRODUCT_ALIASES)) {
+    add(alias, slug);
+  }
+  return index;
+}
+
+/// Résout un nom de produit libre en slug via l'index (null = produit inconnu).
+export function lookupProductSlug(
+  index: Map<string, string>,
+  product: string,
+): string | null {
+  return index.get(normalizeProductKey(product)) ?? null;
+}
+
 /// Sélectionne le cycle de release correspondant à une version : correspondance
-/// exacte sur le nom de cycle, ou version préfixée par le cycle (« 20.11 » → « 20 »).
+/// exacte sur le nom de cycle, version préfixée par le cycle (« 20.11 » → « 20 »),
+/// puis repli sur le libellé commercial (« 2019 » → SQL Server « 15.0 », dont le
+/// label est « 2019 'Aris/Seattle' ») ou le nom de code (« bookworm » → Debian 12).
 export function matchRelease(
   releases: EndoflifeRelease[],
   version: string,
 ): EndoflifeRelease | null {
   const v = version.trim();
   if (!v) return null;
-  return (
-    releases.find(
-      (release) =>
-        !!release.name &&
-        (v === release.name || v.startsWith(`${release.name}.`)),
-    ) ?? null
+
+  const byName = releases.find(
+    (release) =>
+      !!release.name &&
+      (v === release.name || v.startsWith(`${release.name}.`)),
   );
+  if (byName) return byName;
+
+  return (
+    releases.find((release) => {
+      const label = release.label?.trim();
+      // Préfixe à frontière non alphanumérique : « 2019 » matche « 2019 'Aris/Seattle' »
+      // mais pas « 20191 ».
+      if (
+        label &&
+        (label === v ||
+          (label.startsWith(v) && !/[a-z0-9]/i.test(label.charAt(v.length))))
+      ) {
+        return true;
+      }
+      return (
+        !!release.codename && release.codename.toLowerCase() === v.toLowerCase()
+      );
+    }) ?? null
+  );
+}
+
+function toDate(value?: string | null): Date | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
 }
 
 /// Extrait la date de fin de vie d'un ensemble de releases pour une version.
@@ -56,34 +156,144 @@ export function parseEolDate(
   version: string,
 ): Date | null {
   const release = matchRelease(releases, version);
-  if (!release?.eolFrom) return null;
-  const date = new Date(release.eolFrom);
-  return Number.isNaN(date.getTime()) ? null : date;
+  return toDate(release?.eolFrom);
 }
 
-/// Récupère les cycles de release d'un produit sur endoflife.date. Best-effort : toute
-/// erreur (produit inconnu, réseau, timeout) renvoie `null`. Isolé de la résolution de
-/// version pour pouvoir être mémoïsé par produit (dédup des appels réseau).
-export async function fetchProductReleases(
-  product: string,
-): Promise<EndoflifeRelease[] | null> {
-  const slug = toEndoflifeProduct(product);
-  // Garde stricte : le segment produit ne peut contenir que [a-z0-9] (pas de « / »,
-  // « . » ni caractère spécial) → pas d'injection de chemin ni de SSRF possible.
-  if (!/^[a-z0-9]+$/.test(slug)) return null;
+/// Extrait l'ensemble des valeurs de fin de vie (EOL, fin de support actif,
+/// dernière version du cycle) pour une version. Fonction pure.
+export function parseEolInfo(
+  releases: EndoflifeRelease[],
+  version: string,
+): EolInfo {
+  const release = matchRelease(releases, version);
+  return {
+    eolDate: toDate(release?.eolFrom),
+    eoasDate: toDate(release?.eoasFrom),
+    latestVersion: release?.latest?.name ?? null,
+  };
+}
 
+type FetchResult =
+  | { kind: "ok"; data: unknown }
+  | { kind: "not-found" }
+  | { kind: "error" };
+
+async function fetchJson(url: string): Promise<FetchResult> {
   try {
-    const response = await fetch(
-      `${ENDOFLIFE_BASE_URL}/${encodeURIComponent(slug)}`,
-      { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
-    );
-    if (!response.ok) return null;
-
-    const payload = (await response.json()) as {
-      result?: { releases?: EndoflifeRelease[] };
-    };
-    return payload?.result?.releases ?? [];
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (response.status === 404) return { kind: "not-found" };
+    if (!response.ok) return { kind: "error" };
+    return { kind: "ok", data: await response.json() };
   } catch {
-    return null;
+    return { kind: "error" };
   }
+}
+
+let catalogCache: { products: EndoflifeProduct[]; expiresAt: number } | null =
+  null;
+
+/// Réservé aux tests : réinitialise le cache du catalogue.
+export function clearProductCatalogCache(): void {
+  catalogCache = null;
+}
+
+/// Récupère le catalogue des produits suivis par endoflife.date (cache mémoire
+/// 24 h). En cas d'échec réseau, sert la dernière version connue même périmée ;
+/// `null` uniquement si aucun catalogue n'a jamais pu être récupéré.
+export async function fetchProductCatalog(): Promise<
+  EndoflifeProduct[] | null
+> {
+  const now = Date.now();
+  if (catalogCache && catalogCache.expiresAt > now) {
+    return catalogCache.products;
+  }
+
+  const payload = await fetchJson(ENDOFLIFE_BASE_URL);
+  const raw =
+    payload.kind === "ok"
+      ? (
+          payload.data as {
+            result?: {
+              name?: string;
+              label?: string | null;
+              category?: string | null;
+              aliases?: string[] | null;
+            }[];
+          }
+        )?.result
+      : null;
+
+  if (!raw) return catalogCache?.products ?? null;
+
+  const products: EndoflifeProduct[] = raw
+    .filter((product): product is { name: string } & typeof product =>
+      Boolean(product?.name),
+    )
+    .map((product) => ({
+      name: product.name,
+      label: product.label ?? null,
+      category: product.category ?? null,
+      aliases: product.aliases ?? [],
+    }));
+  catalogCache = { products, expiresAt: now + CATALOG_TTL_MS };
+  return products;
+}
+
+/// Récupère les cycles de release d'un produit (slug déjà résolu).
+/// `"not-found"` = produit inconnu de l'API, `null` = échec réseau/HTTP.
+export async function fetchProductReleases(
+  slug: string,
+): Promise<EndoflifeRelease[] | "not-found" | null> {
+  // Garde stricte : le segment produit ne peut contenir que [a-z0-9-] (pas de « / »,
+  // « . » ni caractère spécial) → pas d'injection de chemin ni de SSRF possible.
+  if (!/^[a-z0-9-]+$/.test(slug)) return "not-found";
+
+  const payload = await fetchJson(
+    `${ENDOFLIFE_BASE_URL}/${encodeURIComponent(slug)}`,
+  );
+  if (payload.kind === "not-found") return "not-found";
+  if (payload.kind === "error") return null;
+  return (
+    (payload.data as { result?: { releases?: EndoflifeRelease[] } })?.result
+      ?.releases ?? []
+  );
+}
+
+// Index mémoïsé par référence de catalogue (reconstruit uniquement à son
+// rafraîchissement, pas à chaque résolution).
+let indexMemo: {
+  products: EndoflifeProduct[];
+  index: Map<string, string>;
+} | null = null;
+
+function productIndexFor(products: EndoflifeProduct[]): Map<string, string> {
+  if (indexMemo?.products !== products) {
+    indexMemo = { products, index: buildProductIndex(products) };
+  }
+  return indexMemo.index;
+}
+
+/// Résout un produit saisi librement en cycles de release endoflife.date.
+/// Passe par le catalogue (noms + labels + alias) ; en mode dégradé (catalogue
+/// jamais récupéré), retombe sur la normalisation historique du slug.
+export async function resolveProductReleases(
+  product: string,
+): Promise<EolResolution> {
+  const catalog = await fetchProductCatalog();
+
+  let slug: string | null;
+  if (catalog) {
+    slug = lookupProductSlug(productIndexFor(catalog), product);
+    if (!slug) return { status: "unknown-product" };
+  } else {
+    slug = toEndoflifeProduct(product);
+    if (!slug) return { status: "unknown-product" };
+  }
+
+  const releases = await fetchProductReleases(slug);
+  if (releases === "not-found") return { status: "unknown-product" };
+  if (releases === null) return { status: "unavailable" };
+  return { status: "resolved", slug, releases };
 }

--- a/frontend/openapi/swagger.yaml
+++ b/frontend/openapi/swagger.yaml
@@ -5521,6 +5521,28 @@ paths:
                 $ref: "#/components/schemas/TechnologyErrorResponseDto"
       summary: Ajouter une technologie à la stack d'une application
       tags: *a32
+  /api/v2/applications/{applicationId}/technologies/eol-products:
+    get:
+      operationId: TechnologyController_listEolProducts
+      parameters:
+        - name: applicationId
+          required: true
+          in: path
+          description: ID de l'application
+          schema: {}
+      responses:
+        "200":
+          description: Catalogue des produits endoflife.date (vide si le catalogue est
+            indisponible)
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/EolProductDto"
+      summary: Lister les produits suivis par endoflife.date (autocomplétion de la
+        saisie produit)
+      tags: *a32
   /api/v2/applications/{applicationId}/technologies/{id}:
     patch:
       operationId: TechnologyController_update
@@ -9303,11 +9325,56 @@ components:
           format: date-time
           example: 2026-07-03T10:00:00.000Z
           description: Date de dernière vérification du statut de fin de vie
+        eolProduct:
+          type: string
+          nullable: true
+          example: postgresql
+          description: Slug produit endoflife.date résolu (null + eolCheckedAt renseigné =
+            produit non suivi par endoflife.date)
+        eoasDate:
+          type: string
+          nullable: true
+          format: date-time
+          example: 2026-10-20
+          description: Date de fin de support actif de la version (source endoflife.date)
+        latestVersion:
+          type: string
+          nullable: true
+          example: 20.19.5
+          description: Dernière version publiée du cycle correspondant (source
+            endoflife.date)
       required:
         - technology
         - product
         - id
         - applicationId
+    EolProductDto:
+      type: object
+      properties:
+        name:
+          type: string
+          example: nodejs
+          description: Slug produit endoflife.date
+        label:
+          type: string
+          nullable: true
+          example: Node.js
+          description: Libellé d'affichage du produit
+        category:
+          type: string
+          nullable: true
+          example: database
+          description: Catégorie du produit
+        aliases:
+          example:
+            - node
+          description: Alias reconnus pour ce produit
+          type: array
+          items:
+            type: string
+      required:
+        - name
+        - aliases
     CreateTechnologyDto:
       type: object
       properties:

--- a/frontend/src/components/technology/TechnologyForm.vue
+++ b/frontend/src/components/technology/TechnologyForm.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
-import type { TechnologyDto } from "@/client/types.gen";
+import type { EolProductDto, TechnologyDto } from "@/client/types.gen";
 import type { PropType } from "vue";
 import { computed, ref } from "vue";
 
 const props = defineProps({
   initialData: Object as PropType<TechnologyDto>,
   isSubmitting: Boolean,
+  eolProducts: {
+    type: Array as PropType<EolProductDto[]>,
+    default: () => [],
+  },
 });
 
 const emit = defineEmits(["submit", "cancel"]);
@@ -23,6 +27,36 @@ const form = ref<{
 });
 
 const isFormValid = computed(() => form.value.technology.trim() !== "" && form.value.product.trim() !== "");
+
+// Miroir de la normalisation backend (normalizeProductKey) : les alias avec
+// tirets/points du catalogue couvrent ainsi les saisies « SQL Server », etc.
+function normalizeProductKey(product: string): string {
+  return product
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+}
+
+const productOptions = computed(() =>
+  [...new Set(props.eolProducts.map((product) => product.label || product.name))].sort((a, b) => a.localeCompare(b, "fr")),
+);
+
+const knownProductKeys = computed(() => {
+  const keys = new Set<string>();
+  for (const product of props.eolProducts) {
+    keys.add(normalizeProductKey(product.name));
+    if (product.label) keys.add(normalizeProductKey(product.label));
+    for (const alias of product.aliases ?? []) keys.add(normalizeProductKey(alias));
+  }
+  return keys;
+});
+
+// Avertissement non bloquant : le catalogue peut être indisponible (liste vide,
+// on ne sait pas) et la saisie d'un produit hors catalogue reste autorisée.
+const productUnknown = computed(() => {
+  const key = normalizeProductKey(form.value.product);
+  return key !== "" && knownProductKeys.value.size > 0 && !knownProductKeys.value.has(key);
+});
 
 function handleSubmit() {
   emit("submit", {
@@ -53,9 +87,17 @@ function handleSubmit() {
       label-visible
       required
       placeholder="ex : PostgreSQL, Node.js"
+      hint="La fin de vie est vérifiée automatiquement via endoflife.date"
+      list="technology-product-options"
       data-testid="technology-product-input"
-      class="fr-mb-3w"
+      :class="productUnknown ? 'fr-mb-1w' : 'fr-mb-3w'"
     />
+    <datalist id="technology-product-options">
+      <option v-for="option in productOptions" :key="option" :value="option"></option>
+    </datalist>
+    <p v-if="productUnknown" class="fr-hint-text fr-mb-3w" data-testid="technology-product-unknown-hint">
+      Produit non suivi par endoflife.date : la fin de vie ne pourra pas être vérifiée automatiquement.
+    </p>
 
     <DsfrInput
       v-model="form.version"

--- a/frontend/src/components/technology/TechnologyTab.vue
+++ b/frontend/src/components/technology/TechnologyTab.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import api from "@/api/index";
-import { type TechnologyDto, Permission } from "@/client/types.gen";
+import { type EolProductDto, type TechnologyDto, Permission } from "@/client/types.gen";
 import useModal from "@/composables/use-modal";
 import type { APP_PERMISSIONS, Application } from "@/models/Application";
 import { useToasterStore } from "@/stores/toasterStore";
@@ -22,6 +22,7 @@ const toaster = useToasterStore();
 const technologyModal = useModal<TechnologyDto>();
 
 const technologies = ref<TechnologyDto[]>([]);
+const eolProducts = ref<EolProductDto[]>([]);
 const loading = ref(false);
 const showDeleteConfirmation = ref(false);
 const technologyToDelete = ref<TechnologyDto | null>(null);
@@ -44,9 +45,23 @@ function formatEol(value?: string | Date | null): string {
   return new Date(value).toLocaleDateString("fr-FR");
 }
 
+// Fin de vie « proche » : dans moins de 6 mois.
+const EOL_SOON_MS = 182 * 24 * 60 * 60 * 1000;
+
+type EolStatus = "eol" | "eol-soon" | "eoas-passed" | null;
+
+function computeEolStatus(techno: TechnologyDto): EolStatus {
+  const now = Date.now();
+  const eol = techno.eolDate ? new Date(techno.eolDate).getTime() : null;
+  const eoas = techno.eoasDate ? new Date(techno.eoasDate).getTime() : null;
+  if (eol !== null && eol < now) return "eol";
+  if (eol !== null && eol < now + EOL_SOON_MS) return "eol-soon";
+  if (eoas !== null && eoas < now) return "eoas-passed";
+  return null;
+}
+
 const tableRows = computed(() =>
   technologies.value.map((techno) => {
-    const eol = techno.eolDate ? new Date(techno.eolDate) : null;
     return {
       id: techno.id,
       Technologie: techno.technology,
@@ -54,7 +69,10 @@ const tableRows = computed(() =>
       Version: techno.version || "—",
       Documentation: techno.docUrl || "",
       FinDeVie: formatEol(techno.eolDate),
-      isEol: eol ? eol.getTime() < Date.now() : false,
+      eolStatus: computeEolStatus(techno),
+      // eolCheckedAt renseigné + eolProduct null = produit non suivi par endoflife.date
+      unknownProduct: Boolean(techno.eolCheckedAt) && !techno.eolProduct,
+      latestVersion: techno.version && techno.latestVersion && techno.latestVersion !== techno.version ? techno.latestVersion : null,
       Actions: {
         edit: () => technologyModal.openModal(techno),
         remove: () => askDelete(techno),
@@ -68,6 +86,17 @@ async function fetchTechnologies(applicationId: string) {
   technologies.value = response.data ?? [];
 }
 
+// Catalogue endoflife.date pour l'autocomplétion du produit (best-effort :
+// en cas d'échec, la saisie reste libre).
+async function fetchEolProducts(applicationId: string) {
+  try {
+    const response = await api.technologyControllerListEolProducts({ path: { applicationId } });
+    eolProducts.value = response.data ?? [];
+  } catch {
+    eolProducts.value = [];
+  }
+}
+
 function rememberTrigger(event: Event) {
   lastTrigger.value = (event.currentTarget as HTMLElement) ?? null;
 }
@@ -75,7 +104,7 @@ function rememberTrigger(event: Event) {
 onBeforeMount(async () => {
   loading.value = true;
   try {
-    await fetchTechnologies(props.application.id);
+    await Promise.all([fetchTechnologies(props.application.id), fetchEolProducts(props.application.id)]);
   } finally {
     loading.value = false;
   }
@@ -194,9 +223,52 @@ function cancelDelete() {
       <template v-else>—</template>
     </template>
 
+    <template #body-Version="{ data }">
+      <span>{{ data.Version }}</span>
+      <span v-if="data.latestVersion" class="fr-hint-text" :data-testid="`technology-latest-version-${data.id}`">
+        dernière du cycle : {{ data.latestVersion }}
+      </span>
+    </template>
+
     <template #body-FinDeVie="{ data }">
-      <DsfrBadge v-if="data.isEol" type="error" label="Fin de vie" small :data-testid="`technology-eol-badge-${data.id}`"></DsfrBadge>
+      <template v-if="data.eolStatus === 'eol'">
+        <DsfrBadge
+          type="error"
+          label="Fin de vie"
+          small
+          :title="data.FinDeVie ? `Fin de vie depuis le ${data.FinDeVie}` : undefined"
+          :data-testid="`technology-eol-badge-${data.id}`"
+        ></DsfrBadge>
+      </template>
+      <template v-else-if="data.eolStatus === 'eol-soon'">
+        <DsfrBadge
+          type="warning"
+          label="Fin de vie proche"
+          small
+          :title="`Fin de vie prévue le ${data.FinDeVie}`"
+          :data-testid="`technology-eol-soon-badge-${data.id}`"
+        ></DsfrBadge>
+        <span class="fr-hint-text">{{ data.FinDeVie }}</span>
+      </template>
+      <template v-else-if="data.eolStatus === 'eoas-passed'">
+        <DsfrBadge
+          type="info"
+          label="Support actif terminé"
+          small
+          :title="data.FinDeVie ? `Fin de vie prévue le ${data.FinDeVie}` : undefined"
+          :data-testid="`technology-eoas-badge-${data.id}`"
+        ></DsfrBadge>
+        <span v-if="data.FinDeVie" class="fr-hint-text">{{ data.FinDeVie }}</span>
+      </template>
       <span v-else-if="data.FinDeVie" :title="`Fin de support prévue le ${data.FinDeVie}`">{{ data.FinDeVie }}</span>
+      <span
+        v-else-if="data.unknownProduct"
+        class="fr-hint-text"
+        title="Produit non suivi par endoflife.date : la fin de vie ne peut pas être vérifiée automatiquement"
+        :data-testid="`technology-eol-unknown-${data.id}`"
+      >
+        Produit non suivi
+      </span>
       <template v-else>—</template>
     </template>
 
@@ -242,6 +314,7 @@ function cancelDelete() {
     <TechnologyForm
       :initial-data="technologyModal.selectedItem.value ?? undefined"
       :is-submitting="loading"
+      :eol-products="eolProducts"
       data-testid="technology-form-container"
       @submit="handleSave"
       @cancel="technologyModal.closeModal"


### PR DESCRIPTION
## Contexte

Suite au retour d'Hassan : l'intégration endoflife.date livrée avec la stack technique (#1099, refonte #2026) n'allait pas au bout de la démarche de vérification de fin de vie (#1789). La résolution du produit était devinée par normalisation (4 alias en dur), échouait en silence, et seul le champ `eolFrom` de l'API était exploité.

## Changements

### Backend
- **Résolution du produit via le catalogue officiel** `GET /api/v1/products` (462 produits, noms + labels + alias), mis en cache mémoire 24 h avec repli sur la dernière version connue en cas d'échec réseau. « SQL Server », « Postgre SQL », « node »… se résolvent désormais correctement.
- **Distinction des statuts** : `unknown-product` (produit non suivi → persisté `eolProduct = null` + `eolCheckedAt`, signalé au front) vs `unavailable` (échec réseau → aucune écriture, retenté au prochain GET).
- **Matching de version étendu** : nom de cycle (existant), puis repli sur le **label commercial** (« 2019 » → SQL Server 15.0) et le **nom de code** (« bookworm » → Debian 12).
- **Champs enrichis** (migration `add_technology_eol_details`) : `eolProduct` (slug résolu), `eoasDate` (fin de support actif), `latestVersion` (dernière version du cycle), en plus de `eolDate`/`eolCheckedAt`.
- **Nouvel endpoint** `GET /applications/:id/technologies/eol-products` (permission `TechnologyRead`) exposant le catalogue pour l'autocomplétion.
- La résolution se fait désormais aussi sans version renseignée (détection des produits non suivis) ; mémoïsation par produit conservée au rafraîchissement paresseux.

### Frontend
- **Autocomplétion du champ Produit** (datalist alimentée par le catalogue) + avertissement non bloquant « Produit non suivi par endoflife.date » à la saisie.
- **Badges d'état gradués** dans l'onglet Stack technique :
  - `error` « Fin de vie » (date passée, comportement existant conservé) ;
  - `warning` « Fin de vie proche » (< 6 mois) ;
  - `info` « Support actif terminé » (fin de support actif passée, EOL à venir) ;
  - « Produit non suivi » quand endoflife.date ne connaît pas le produit.
- Affichage de la **dernière version du cycle** quand elle diffère de la version saisie.

## Tests
- `endoflife.utils.spec.ts` : 18 tests (résolution par alias/label/codename, parsing enrichi, frontières).
- Suite backend complète : 45 suites / 337 tests ✅ — type-check backend + frontend ✅ — lint 0 erreur ✅ — tests unitaires front 27 ✅.
- Vérifié en conditions réelles contre l'API : `SQL Server 2019` → EOL 2030-01-08, `Debian bookworm` → 2026-07-11, `Postgre SQL 13` → 2025-11-13, produit inconnu → « non suivi ».
- Fix au passage : mock `UserActions.spec.ts` non aligné sur `lastPermissionChangeAt`/`lastPermissionChangedByEmail` (#2207), révélé par la régénération du client.

## Hors périmètre (suivi proposé)
- Vue transverse « applications avec technologie en fin de vie » + impact indicateur dette technique.
- Cron de recalcul global + notifications (à articuler avec `EMAIL_CRON_ENABLED`).

Closes #1789
