### PR TITLE
refactor: unifier les libellés statuts/relations entre backend et frontend (#2246)

### DIFF
--- a/backend/src/applications/constants/enum-label.spec.ts
+++ b/backend/src/applications/constants/enum-label.spec.ts
@@ -1,0 +1,30 @@
+import { RelationType, Status } from "@prisma/client";
+import {
+  ALL_ENUM_LABELS,
+  ApplicationStatusLabels,
+  RelationTypeLabels,
+} from "./enum-label";
+import { RelationTypeLabelsBidirectional } from "./relation-type-labels";
+
+describe("enum-label (#2246)", () => {
+  it("couvre tous les types de relation, y compris use_sso_of", () => {
+    for (const type of Object.values(RelationType)) {
+      expect(RelationTypeLabels[type]).toBeTruthy();
+      expect(ALL_ENUM_LABELS[type]).toBe(RelationTypeLabels[type]);
+    }
+  });
+
+  it("dérive les libellés « source » de la map bidirectionnelle unique", () => {
+    for (const [type, labels] of Object.entries(
+      RelationTypeLabelsBidirectional,
+    )) {
+      expect(RelationTypeLabels[type as RelationType]).toBe(labels.source);
+    }
+  });
+
+  it("couvre tous les statuts d'application", () => {
+    for (const status of Object.values(Status)) {
+      expect(ApplicationStatusLabels[status]).toBeTruthy();
+    }
+  });
+});

--- a/backend/src/applications/constants/enum-label.ts
+++ b/backend/src/applications/constants/enum-label.ts
@@ -1,15 +1,21 @@
+import { RelationType, Status } from "@prisma/client";
+import { RelationTypeLabelsBidirectional } from "./relation-type-labels";
+
 export const ReportStatusLabels: Record<string, string> = {
   in_pending: "En attente",
   in_progress: "En cours",
   done: "Terminée",
 };
 
-export const RelationTypeLabels: Record<string, string> = {
-  is_part_of: "Fait partie de",
-  in_replacement_of: "En remplacement de",
-  is_service_user_of: "Utilise le service de",
-  is_data_user_of: "Utilise des données de",
-};
+/// Libellés « direction source », dérivés de la source unique bidirectionnelle
+/// (#2246) — plus de deuxième map à maintenir à la main.
+export const RelationTypeLabels: Record<RelationType, string> =
+  Object.fromEntries(
+    Object.entries(RelationTypeLabelsBidirectional).map(([type, labels]) => [
+      type,
+      labels.source,
+    ]),
+  ) as Record<RelationType, string>;
 
 export const PriorityRestartLabels: Record<string, string> = {
   R0: "R0 - Immédiat (H24)",
@@ -17,14 +23,6 @@ export const PriorityRestartLabels: Record<string, string> = {
   R1_STAR: "R1* - Selon période d'activité",
   R2: "R2 - Dès que possible (H24)",
   R3: "R3 - Quand le plus urgent est réalisé (H0)",
-};
-
-export const EventTypeLabels: Record<string, string> = {
-  under_construction: "En construction",
-  in_production: "En production",
-  decommissioned: "Décommissionnée",
-  decommissioning: "En décommissionnement",
-  highlight: "Événement",
 };
 
 export const ExternalRessourceTypeLabels: Record<string, string> = {
@@ -43,22 +41,23 @@ export const NatureLabels: Record<string, string> = {
   BARRE_METAL: "Bare metal",
 };
 
-export const ApplicationStatusLabels: Record<string, string> = {
+/// Wording aligné sur l'écran (frontend statusApplicationDictionary, #2246) :
+/// exports et UI doivent afficher le même libellé pour un même statut.
+export const ApplicationStatusLabels = {
   under_construction: "En construction",
   to_validate: "A valider",
-  poc: "POC",
-  in_production_mvp: "En production (MVP)",
+  poc: "POC (Preuve de concept)",
+  in_production_mvp: "MVP en production",
   in_production: "En production",
-  in_production_decommissioning: "En décommissionnement",
+  in_production_decommissioning: "À décommissionner",
   decommissioned: "Décommissionnée",
   deleted: "Supprimée",
-};
+} satisfies Record<Status, string>;
 
 export const ALL_ENUM_LABELS: Record<string, string> = {
   ...ReportStatusLabels,
   ...RelationTypeLabels,
   ...PriorityRestartLabels,
-  ...EventTypeLabels,
   ...ExternalRessourceTypeLabels,
   ...NatureLabels,
   ...ApplicationStatusLabels,

--- a/backend/src/applications/constants/relation-type-labels.ts
+++ b/backend/src/applications/constants/relation-type-labels.ts
@@ -1,7 +1,10 @@
-export const RelationTypeLabelsBidirectional: Record<
-  string,
-  { source: string; target: string }
-> = {
+import { RelationType } from "@prisma/client";
+
+/// Source unique des libellés de type de relation (#2246). La variante
+/// « direction source » (RelationTypeLabels, enum-label.ts) en est dérivée ;
+/// le wording frontend (dictionary.ts, relationTypeLabels) doit rester aligné
+/// sur les libellés `source` (casse de phrase à part).
+export const RelationTypeLabelsBidirectional = {
   is_part_of: {
     source: "Fait partie de",
     target: "A comme sous‑élément",
@@ -15,11 +18,11 @@ export const RelationTypeLabelsBidirectional: Record<
     target: "Fournit le service à",
   },
   is_data_user_of: {
-    source: "Utilise la donnée de",
-    target: "Fournit la donnée à",
+    source: "Utilise les données de",
+    target: "Fournit les données à",
   },
   use_sso_of: {
     source: "Utilise le SSO de",
     target: "Fournit le SSO à",
   },
-};
+} satisfies Record<RelationType, { source: string; target: string }>;

--- a/frontend/src/composables/use-application-search.ts
+++ b/frontend/src/composables/use-application-search.ts
@@ -7,6 +7,7 @@ import type {
 import { computed, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import api from "@/api/index.js";
+import { APPLICATION_STATUSES } from "@/constants/dictionary";
 import { RELATION_TYPE_FILTERS } from "@/types/relation-type-filter";
 import { useStatisticsStore } from "@/stores/statisticsStore";
 
@@ -19,15 +20,9 @@ const DEFAULT_FILTERS: Filters = {
   tag: [],
   link: undefined,
   priorityRestart: undefined,
-  currentStatus__in: [
-    "under_construction",
-    "to_validate",
-    "poc",
-    "in_production_mvp",
-    "in_production",
-    "in_production_decommissioning",
-    "decommissioned",
-  ],
+  // Tous les statuts sauf « supprimée » — dérivé de l'enum généré pour qu'un
+  // nouveau statut apparaisse automatiquement dans la recherche par défaut (#2246).
+  currentStatus__in: APPLICATION_STATUSES.filter((status) => status !== "deleted"),
   currentStatus__isNull: true,
   subscribersEmail: false,
   myApplications: false,

--- a/frontend/src/constants/dictionary.ts
+++ b/frontend/src/constants/dictionary.ts
@@ -86,16 +86,6 @@ export const linkTypesDict = {
   main_service: "Service principal",
 };
 
-export const eventTypesArray = [
-  { value: "under_construction", text: "En construction" },
-  { value: "in_production", text: "En production" },
-  { value: "decommissioned", text: "Décommissionnée" },
-  { value: "decommissioning", text: "En décommissionnement" },
-  { value: "highlight", text: "Événement" },
-];
-
-export const eventTypesDict = Object.fromEntries(eventTypesArray.map(({ value, text }) => [value, text]));
-
 export const restartPrioritiesConfig = {
   R0: {
     type: "error",
@@ -130,6 +120,8 @@ export const restartPrioritiesConfig = {
   },
 } as const satisfies Record<ApplicationPriorityRestart, { type: string; label: string; shortLabel: string; tooltip: string }>;
 
+// Wording aligné sur les exports backend (ApplicationStatusLabels, #2246) :
+// un même statut doit s'afficher pareil à l'écran et dans les exports CSV/XLSX.
 export const statusApplicationDictionary: Record<ApplicationStatus, string> = {
   under_construction: "En construction",
   to_validate: "A valider",
@@ -137,9 +129,14 @@ export const statusApplicationDictionary: Record<ApplicationStatus, string> = {
   in_production_mvp: "MVP en production",
   in_production: "En production",
   in_production_decommissioning: "À décommissionner",
-  decommissioned: "Décommissionné",
-  deleted: "Supprimé",
+  decommissioned: "Décommissionnée",
+  deleted: "Supprimée",
 };
+
+// Liste exhaustive des statuts, dérivée du dictionnaire ci-dessus (lui-même
+// contraint par l'enum généré) : un nouveau statut backend casse la compilation
+// ici au lieu de disparaître silencieusement des filtres (#2246).
+export const APPLICATION_STATUSES = Object.keys(statusApplicationDictionary) as ApplicationStatus[];
 
 export const priorityRestartLabelsOptions = Object.entries(restartPrioritiesConfig).map(([key, value]) => ({
   value: key as ApplicationPriorityRestart,


### PR DESCRIPTION
## Contexte

Deuxième lot du chantier dédup (audit du 12/08). Les libellés de statut et de type de relation étaient maintenus à la main à 3 endroits et avaient déjà divergé : « POC » vs « POC (Preuve de concept) », « En production (MVP) » vs « MVP en production », accords masculin/féminin différents, clé `use_sso_of` absente de la map backend historique (affichage de la valeur brute de l'enum dans l'historique des métadonnées).

## Changements

### Backend
- **`RelationTypeLabelsBidirectional` devient la source unique** des libellés de relation, typée `satisfies Record<RelationType, {source, target}>` (exhaustivité garantie à la compilation — c'est ce typage qui aurait attrapé l'oubli de `use_sso_of`). `RelationTypeLabels` (historique des métadonnées) en est **dérivée** au lieu d'être maintenue à part ; wording harmonisé (« les données » au pluriel).
- **`ApplicationStatusLabels` aligné sur le wording de l'écran** et typé `satisfies Record<Status, string>` : exports CSV/XLSX et UI affichent désormais le même libellé pour un même statut.
- **`EventTypeLabels` supprimé** : aucun enum Prisma `EventType`, aucun usage de `highlight` nulle part — code mort confirmé (les clés communes étaient déjà écrasées par `ApplicationStatusLabels` dans `ALL_ENUM_LABELS`).
- Spec de non-régression : tous les types de relation (dont `use_sso_of`) et tous les statuts ont un libellé ; la dérivation source/bidirectionnelle est verrouillée.

### Frontend
- `statusApplicationDictionary` : accords alignés (« Décommissionnée », « Supprimée » — une application).
- **`APPLICATION_STATUSES` dérivé du dictionnaire** (lui-même contraint par l'enum généré) et `DEFAULT_FILTERS.currentStatus__in` calculé dessus (`filter ≠ "deleted"`) : un nouveau statut backend casse la compilation au lieu de disparaître silencieusement de la recherche par défaut.
- `eventTypesArray`/`eventTypesDict` supprimés (jamais importés).

### Non couvert (assumé)
La génération des maps front depuis l'OpenAPI (source croisée unique) est volontairement écartée : les libellés ne transitent pas par le swagger et un endpoint dédié imposerait un fetch au bootstrap. Le garde-fou retenu est l'exhaustivité compilée des deux côtés + wording aligné et commenté en miroir.

## Tests
- Backend : 48 suites / 357 tests ✅ (dont le nouveau `enum-label.spec.ts`) — `tsc --noEmit` ✅.
- Frontend : type-check ✅, 33 tests unitaires ✅, lint 0 erreur ✅.
- Aucune assertion e2e/QA sur les anciens libellés (vérifié par grep).

Closes #2246
