### PR TITLE
fix(e2e): aligner les libellés de statut du POM sur #2246 (débloque la release #2203)

### DIFF
--- a/e2e/pom/search.page.ts
+++ b/e2e/pom/search.page.ts
@@ -3,6 +3,8 @@ import { BasePage } from "./base.page";
 import { parseFirstNumber, waitForSearchParams } from "../support/helpers";
 
 const SEARCH_PATH = "/recherche-application";
+// Miroir de `frontend/src/constants/dictionary.ts` (statusApplicationDictionary,
+// #2246) : toute évolution des libellés côté front doit être répercutée ici.
 const STATUS_LABELS: Record<string, string> = {
   under_construction: "En construction",
   to_validate: "A valider",
@@ -10,8 +12,8 @@ const STATUS_LABELS: Record<string, string> = {
   in_production_mvp: "MVP en production",
   in_production: "En production",
   in_production_decommissioning: "À décommissionner",
-  decommissioned: "Décommissionné",
-  deleted: "Supprimé",
+  decommissioned: "Décommissionnée",
+  deleted: "Supprimée",
 };
 
 /** Page Object — Catalogue & recherche (`/recherche-application`). */


### PR DESCRIPTION
## Contexte

La PR de release **#2203** (release-please 1.87.0) est bloquée : la campagne de non-régression échoue sur 3 tests catalogue (CAT-04 « filtre par statut reflété dans l'URL », CAT-06 « combinaison de plusieurs filtres », CAT-12 « persistance des filtres après rechargement ») avec `element(s) not found`.

## Cause

La PR #2252 (unification des libellés, #2246) a aligné les accords des statuts à l'écran (« Décommissionnée », « Supprimée »), mais le POM des e2e (`e2e/pom/search.page.ts`) portait **sa propre copie** de la map des libellés — ironiquement, une duplication de plus que l'audit n'avait pas recensée (mon grep de vérification couvrait `e2e/tests`, pas `e2e/pom`). Les tests cliquaient donc sur une checkbox « Décommissionné » qui n'existe plus.

## Changements

- Alignement des deux libellés dans `STATUS_LABELS` du POM + commentaire de miroir explicite vers `statusApplicationDictionary` (source front).

## Vérifications

- Les 3 tests rejoués en local (seed QA + stack docker) : **CAT-04 ✅ CAT-06 ✅ CAT-12 ✅**.
- Après merge, la prochaine exécution de la campagne sur la branche release-please devrait débloquer #2203.

Réf. #2246
